### PR TITLE
[+] Project: Add JSCS to format .js files during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 !/package.json
 !/README.md
 !/.editorconfig
+!/.jscsrc
 !/.gitignore
 !/.gitconfig
 !/.gitattributes

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,88 +1,90 @@
 {
-    "esnext": true,
-    "disallowSpacesInNamedFunctionExpression": {
-        "beforeOpeningRoundBrace": true
-    },
-    "disallowSpacesInFunctionExpression": {
-        "beforeOpeningRoundBrace": true
-    },
-    "disallowSpacesInAnonymousFunctionExpression": {
-        "beforeOpeningRoundBrace": true
-    },
-    "disallowSpacesInFunctionDeclaration": {
-        "beforeOpeningRoundBrace": true
-    },
-    "disallowSpacesInsideBrackets": true,
-    "disallowEmptyBlocks": true,
-    "disallowSpacesInCallExpression": true,
-    "disallowSpacesInsideArrayBrackets": true,
-    "disallowSpacesInsideParentheses": true,
-    "disallowQuotedKeysInObjects": true,
-    "disallowSpaceAfterObjectKeys": true,
-    "disallowSpaceAfterPrefixUnaryOperators": true,
-    "disallowSpaceBeforePostfixUnaryOperators": true,
-    "disallowSpaceBeforeBinaryOperators": [
-        ","
-    ],
-    "disallowMixedSpacesAndTabs": true,
-    "disallowTrailingWhitespace": true,
-    "requireTrailingComma": {
-        "ignoreSingleLine": true
-    },
-    "requireSpaceAfterComma": true,
-    "disallowYodaConditions": true,
-    "disallowKeywords": [
-        "with"
-    ],
-    "disallowKeywordsOnNewLine": [
-        "else"
-    ],
-    "disallowMultipleLineBreaks": true,
-    "disallowMultipleLineStrings": true,
-    "disallowMultipleVarDecl": true,
-    "disallowSpaceBeforeComma": true,
-    "disallowSpaceBeforeSemicolon": true,
-    "requireSpaceBeforeBlockStatements": true,
-    "requireParenthesesAroundIIFE": true,
-    "requireSpacesInConditionalExpression": true,
-    "requireBlocksOnNewline": 1,
-    "requireCommaBeforeLineBreak": true,
-    "requireSpaceBeforeBinaryOperators": true,
-    "requireSpaceAfterBinaryOperators": true,
-    "requireCamelCaseOrUpperCaseIdentifiers": true,
-    "requireLineFeedAtFileEnd": true,
-    "requireCapitalizedConstructors": true,
-    "requireDotNotation": true,
-    "requireSpacesInForStatement": true,
-    "requireSpacesInsideObjectBrackets": "all",
-    "requireSpaceBetweenArguments": true,
-    "requireCurlyBraces": [
-        "do"
-    ],
-    "requireSpaceAfterKeywords": [
-        "if",
-        "else",
-        "for",
-        "while",
-        "do",
-        "switch",
-        "case",
-        "return",
-        "try",
-        "catch",
-        "typeof"
-    ],
-    "requirePaddingNewLinesBeforeLineComments": {
-        "allExcept": "firstAfterCurly"
-    },
-    "requirePaddingNewLinesAfterBlocks": true,
-    "requireSemicolons": true,
-    "safeContextKeyword": "_this",
-    "validateLineBreaks": "LF",
-    "validateQuoteMarks": {
-        "mark": "'",
-        "escape": true,
-        "ignoreJSX": true
-    },
-    "validateIndentation": 2
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch"
+  ],
+  "requireOperatorBeforeLineBreak": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "maximumLineLength": {
+    "value": 80,
+    "allExcept": ["comments", "regex"]
+  },
+  "validateIndentation": 2,
+  "validateQuoteMarks": "'",
+
+  "disallowMultipleLineStrings": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowMultipleVarDecl": true,
+  "disallowKeywordsOnNewLine": ["else"],
+
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+    "&=", "|=", "^=", "+=",
+
+    "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+    "|", "^", "&&", "||", "===", "==", ">=",
+    "<=", "<", ">", "!=", "!=="
+  ],
+  "requireSpaceAfterBinaryOperators": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInForStatement": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSpacesInFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInsideArrayBrackets": "all",
+  "disallowSpacesInsideParentheses": true,
+
+  "disallowMultipleLineBreaks": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "disallowKeywords": ["with"],
+  "disallowSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInFunctionDeclaration": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInCallExpression": true,
+  "disallowSpaceAfterObjectKeys": true,
+  "requireSpaceBeforeObjectValues": true,
+  "requireCapitalizedConstructors": true,
+  "requireDotNotation": true,
+  "requireSemicolons": true,
+  "validateParameterSeparator": ", ",
+
+  "jsDoc": {
+    "checkAnnotations": "closurecompiler",
+    "checkParamNames": true,
+    "requireParamTypes": true,
+    "checkRedundantParams": true,
+    "checkReturnTypes": true,
+    "checkRedundantReturns": true,
+    "requireReturnTypes": true,
+    "checkTypes": true,
+    "checkRedundantAccess": true,
+    "requireNewlineAfterDescription": true
+  }
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,88 @@
+{
+    "esnext": true,
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInAnonymousFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInsideBrackets": true,
+    "disallowEmptyBlocks": true,
+    "disallowSpacesInCallExpression": true,
+    "disallowSpacesInsideArrayBrackets": true,
+    "disallowSpacesInsideParentheses": true,
+    "disallowQuotedKeysInObjects": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
+    "disallowSpaceBeforeBinaryOperators": [
+        ","
+    ],
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "requireTrailingComma": {
+        "ignoreSingleLine": true
+    },
+    "requireSpaceAfterComma": true,
+    "disallowYodaConditions": true,
+    "disallowKeywords": [
+        "with"
+    ],
+    "disallowKeywordsOnNewLine": [
+        "else"
+    ],
+    "disallowMultipleLineBreaks": true,
+    "disallowMultipleLineStrings": true,
+    "disallowMultipleVarDecl": true,
+    "disallowSpaceBeforeComma": true,
+    "disallowSpaceBeforeSemicolon": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "requireParenthesesAroundIIFE": true,
+    "requireSpacesInConditionalExpression": true,
+    "requireBlocksOnNewline": 1,
+    "requireCommaBeforeLineBreak": true,
+    "requireSpaceBeforeBinaryOperators": true,
+    "requireSpaceAfterBinaryOperators": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "requireLineFeedAtFileEnd": true,
+    "requireCapitalizedConstructors": true,
+    "requireDotNotation": true,
+    "requireSpacesInForStatement": true,
+    "requireSpacesInsideObjectBrackets": "all",
+    "requireSpaceBetweenArguments": true,
+    "requireCurlyBraces": [
+        "do"
+    ],
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "return",
+        "try",
+        "catch",
+        "typeof"
+    ],
+    "requirePaddingNewLinesBeforeLineComments": {
+        "allExcept": "firstAfterCurly"
+    },
+    "requirePaddingNewLinesAfterBlocks": true,
+    "requireSemicolons": true,
+    "safeContextKeyword": "_this",
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": {
+        "mark": "'",
+        "escape": true,
+        "ignoreJSX": true
+    },
+    "validateIndentation": 2
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,13 @@ gulp.task('copy-index', function(callback){
 });
 
 gulp.task('format-js', function () {
-  return gulp.src('themes*/community-theme-16/js/**/*.js')
+
+  return gulp.src([
+    './themes*/community-theme-16/js/**/*.js',
+    '!./themes*/community-theme-16/js/**/*.min.js',
+    '!./themes*/community-theme-16/js/autoload/**/*.js',
+    '!./themes*/community-theme-16/js/debug/**/*.js'
+  ])
     .pipe(jscs({ fix : true }))
     .pipe(gulp.dest('./'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,6 +131,7 @@ gulp.task('build', function(callback) {
     runSequence(
         ['create-folders', 'build-css'],
         'remove-trash',
+        'format-js',
         'copy-index',
         'create-zip',
         callback

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,13 @@
-var gulp   = require('gulp');
-var del    = require('del');
-var mkdirp = require('mkdirp');
-var glob   = require('glob');
-var exec   = require('child_process').exec;
-var argv   = require('yargs').argv;
-var fs     = require('fs-extra');
-var zip    = require('gulp-zip');
+var gulp        = require('gulp');
+var del         = require('del');
+var mkdirp      = require('mkdirp');
+var glob        = require('glob');
+var exec        = require('child_process').exec;
+var argv        = require('yargs').argv;
+var fs          = require('fs-extra');
+var zip         = require('gulp-zip');
 var runSequence = require('run-sequence');
+var jscs        = require('gulp-jscs');
 
 var createFolders = [
     './themes/community-theme-16/cache/',
@@ -92,6 +93,12 @@ gulp.task('copy-index', function(callback){
             });
         });
     });
+});
+
+gulp.task('format-js', function () {
+  return gulp.src('themes*/community-theme-16/js/**/*.js')
+    .pipe(jscs({ fix : true }))
+    .pipe(gulp.dest('./'));
 });
 
 gulp.task('create-zip', function(){

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "fs-extra": "^0.26.3",
     "glob": "^6.0.2",
     "gulp": "^3.9.0",
+    "gulp-jscs": "^3.0.2",
     "gulp-zip": "^3.0.2",
     "mkdirp": "^0.5.1",
     "run-sequence": "^1.1.5",


### PR DESCRIPTION
Adds ability to format `.js` files using `jscs` tools: https://github.com/jscs-dev/node-jscs .

Gulp command is `gulp format-js`, which formats all theme `.js` files (except vendor and minified).
