### PR TITLE
[*] HTML: Indent .tpl files with 2 spaces

### DIFF
--- a/themes/community-theme-16/404.tpl
+++ b/themes/community-theme-16/404.tpl
@@ -23,22 +23,22 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="pagenotfound">
-    <h1>{l s='This page is not available'}</h1>
+  <h1>{l s='This page is not available'}</h1>
 
-    <p>
-        {l s='We\'re sorry, but the Web address you\'ve entered is no longer available.'}
-    </p>
+  <p>
+    {l s='We\'re sorry, but the Web address you\'ve entered is no longer available.'}
+  </p>
 
-    <h3>{l s='To find a product, please type its name in the field below.'}</h3>
-    <form action="{$link->getPageLink('search')|escape:'html':'UTF-8'}" method="post" class="std">
-        <fieldset>
-            <div>
-                <label for="search_query">{l s='Search our product catalog:'}</label>
-                <input id="search_query" name="search_query" type="text" class="form-control grey" />
-                <button type="submit" name="Submit" value="OK" class="btn btn-default button button-small"><span>{l s='Ok'}</span></button>
-            </div>
-        </fieldset>
-    </form>
+  <h3>{l s='To find a product, please type its name in the field below.'}</h3>
+  <form action="{$link->getPageLink('search')|escape:'html':'UTF-8'}" method="post" class="std">
+    <fieldset>
+      <div>
+        <label for="search_query">{l s='Search our product catalog:'}</label>
+        <input id="search_query" name="search_query" type="text" class="form-control grey" />
+        <button type="submit" name="Submit" value="OK" class="btn btn-default button button-small"><span>{l s='Ok'}</span></button>
+      </div>
+    </fieldset>
+  </form>
 
-    <div class="buttons"><a class="btn btn-default button button-medium" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home'}"><span><i class="icon-chevron-left left"></i>{l s='Home page'}</span></a></div>
+  <div class="buttons"><a class="btn btn-default button button-medium" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home'}"><span><i class="icon-chevron-left left"></i>{l s='Home page'}</span></a></div>
 </div>

--- a/themes/community-theme-16/address.tpl
+++ b/themes/community-theme-16/address.tpl
@@ -24,213 +24,213 @@
 *}
 {capture name=path}{l s='Your addresses'}{/capture}
 <div class="box">
-    <h1 class="page-subheading">{l s='Your addresses'}</h1>
-    <p class="info-title">
-        {if isset($id_address) && (isset($smarty.post.alias) || isset($address->alias))}
-            {l s='Modify address'}
-            {if isset($smarty.post.alias)}
-                "{$smarty.post.alias}"
-            {else}
-                {if isset($address->alias)}"{$address->alias|escape:'html':'UTF-8'}"{/if}
-            {/if}
-        {else}
-            {l s='To add a new address, please fill out the form below.'}
-        {/if}
-    </p>
-    {include file="$tpl_dir./errors.tpl"}
-    <p class="required"><sup>*</sup>{l s='Required field'}</p>
-    <form action="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}" method="post" class="std" id="add_address">
-        <!--h3 class="page-subheading">{if isset($id_address)}{l s='Your address'}{else}{l s='New address'}{/if}</h3-->
-        {assign var="stateExist" value=false}
-        {assign var="postCodeExist" value=false}
-        {assign var="dniExist" value=false}
-        {assign var="homePhoneExist" value=false}
-        {assign var="mobilePhoneExist" value=false}
-        {assign var="atLeastOneExists" value=false}
-        {foreach from=$ordered_adr_fields item=field_name}
-            {if $field_name eq 'company'}
-                <div class="form-group">
-                    <label for="company">{l s='Company'}{if isset($required_fields) && in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                    <input class="form-control validate" data-validate="{$address_validation.$field_name.validate}" type="text" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{else}{if isset($address->company)}{$address->company|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if $field_name eq 'vat_number'}
-                <div id="vat_area">
-                    <div id="vat_number">
-                        <div class="form-group">
-                            <label for="vat-number">{l s='VAT number'}{if isset($required_fields) && in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control validate" data-validate="{$address_validation.$field_name.validate}" id="vat-number" name="vat_number" value="{if isset($smarty.post.vat_number)}{$smarty.post.vat_number}{else}{if isset($address->vat_number)}{$address->vat_number|escape:'html':'UTF-8'}{/if}{/if}" />
-                        </div>
-                    </div>
-                </div>
-            {/if}
-            {if $field_name eq 'dni'}
-            {assign var="dniExist" value=true}
-            <div class="required form-group dni">
-                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                <input class="form-control" data-validate="{$address_validation.$field_name.validate}" type="text" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{else}{if isset($address->dni)}{$address->dni|escape:'html':'UTF-8'}{/if}{/if}" />
-                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-            </div>
-            {/if}
-            {if $field_name eq 'firstname'}
-                <div class="required form-group">
-                    <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                    <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" name="firstname" id="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{else}{if isset($address->firstname)}{$address->firstname|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if $field_name eq 'lastname'}
-                <div class="required form-group">
-                    <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                    <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{else}{if isset($address->lastname)}{$address->lastname|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if $field_name eq 'address1'}
-                <div class="required form-group">
-                    <label for="address1">{l s='Address'} <sup>*</sup></label>
-                    <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="address1" name="address1" value="{if isset($smarty.post.address1)}{$smarty.post.address1}{else}{if isset($address->address1)}{$address->address1|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if $field_name eq 'address2'}
-                <div class="required form-group">
-                    <label for="address2">{l s='Address (Line 2)'}{if isset($required_fields) && in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                    <input class="validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="address2" name="address2" value="{if isset($smarty.post.address2)}{$smarty.post.address2}{else}{if isset($address->address2)}{$address->address2|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if $field_name eq 'postcode'}
-                {assign var="postCodeExist" value=true}
-                <div class="required postcode form-group unvisible">
-                    <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                    <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="postcode" name="postcode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{else}{if isset($address->postcode)}{$address->postcode|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if $field_name eq 'city'}
-                <div class="required form-group">
-                    <label for="city">{l s='City'} <sup>*</sup></label>
-                    <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" name="city" id="city" value="{if isset($smarty.post.city)}{$smarty.post.city}{else}{if isset($address->city)}{$address->city|escape:'html':'UTF-8'}{/if}{/if}" maxlength="64" />
-                </div>
-                {* if customer hasn't update his layout address, country has to be verified but it's deprecated *}
-            {/if}
-            {if $field_name eq 'Country:name' || $field_name eq 'country' || $field_name eq 'Country:iso_code'}
-                <div class="required form-group">
-                    <label for="id_country">{l s='Country'} <sup>*</sup></label>
-                    <select id="id_country" class="form-control" name="id_country">{$countries_list}</select>
-                </div>
-            {/if}
-            {if $field_name eq 'State:name'}
-                {assign var="stateExist" value=true}
-                <div class="required id_state form-group">
-                    <label for="id_state">{l s='State'} <sup>*</sup></label>
-                    <select name="id_state" id="id_state" class="form-control">
-                        <option value="">-</option>
-                    </select>
-                </div>
-            {/if}
-            {if $field_name eq 'phone'}
-                {assign var="homePhoneExist" value=true}
-                <div class="form-group phone-number">
-                    <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                    <input class="{if isset($one_phone_at_least) && $one_phone_at_least}is_required{/if} validate form-control" data-validate="{$address_validation.phone.validate}" type="tel" id="phone" name="phone" value="{if isset($smarty.post.phone)}{$smarty.post.phone}{else}{if isset($address->phone)}{$address->phone|escape:'html':'UTF-8'}{/if}{/if}"  />
-                </div>
-                <div class="clearfix"></div>
-            {/if}
-            {if $field_name eq 'phone_mobile'}
-                {assign var="mobilePhoneExist" value=true}
-                <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                    <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                    <input class="validate form-control" data-validate="{$address_validation.phone_mobile.validate}" type="tel" id="phone_mobile" name="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{else}{if isset($address->phone_mobile)}{$address->phone_mobile|escape:'html':'UTF-8'}{/if}{/if}" />
-                </div>
-            {/if}
-            {if ($field_name eq 'phone_mobile') || ($field_name eq 'phone_mobile') && !isset($atLeastOneExists) && isset($one_phone_at_least) && $one_phone_at_least}
-                {assign var="atLeastOneExists" value=true}
-                <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
-            {/if}
-        {/foreach}
-        {if !$postCodeExist}
-            <div class="required postcode form-group unvisible">
-                <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                <input class="is_required validate form-control" data-validate="{$address_validation.postcode.validate}" type="text" id="postcode" name="postcode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{else}{if isset($address->postcode)}{$address->postcode|escape:'html':'UTF-8'}{/if}{/if}" />
-            </div>
-        {/if}
-        {if !$stateExist}
-            <div class="required id_state form-group unvisible">
-                <label for="id_state">{l s='State'} <sup>*</sup></label>
-                <select name="id_state" id="id_state" class="form-control">
-                    <option value="">-</option>
-                </select>
-            </div>
-        {/if}
-        {if !$dniExist}
-            <div class="required dni form-group unvisible">
-                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                <input class="is_required form-control" data-validate="{$address_validation.dni.validate}" type="text" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{else}{if isset($address->dni)}{$address->dni|escape:'html':'UTF-8'}{/if}{/if}" />
-                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-            </div>
-        {/if}
+  <h1 class="page-subheading">{l s='Your addresses'}</h1>
+  <p class="info-title">
+    {if isset($id_address) && (isset($smarty.post.alias) || isset($address->alias))}
+      {l s='Modify address'}
+      {if isset($smarty.post.alias)}
+        "{$smarty.post.alias}"
+      {else}
+        {if isset($address->alias)}"{$address->alias|escape:'html':'UTF-8'}"{/if}
+      {/if}
+    {else}
+      {l s='To add a new address, please fill out the form below.'}
+    {/if}
+  </p>
+  {include file="$tpl_dir./errors.tpl"}
+  <p class="required"><sup>*</sup>{l s='Required field'}</p>
+  <form action="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}" method="post" class="std" id="add_address">
+    <!--h3 class="page-subheading">{if isset($id_address)}{l s='Your address'}{else}{l s='New address'}{/if}</h3-->
+    {assign var="stateExist" value=false}
+    {assign var="postCodeExist" value=false}
+    {assign var="dniExist" value=false}
+    {assign var="homePhoneExist" value=false}
+    {assign var="mobilePhoneExist" value=false}
+    {assign var="atLeastOneExists" value=false}
+    {foreach from=$ordered_adr_fields item=field_name}
+      {if $field_name eq 'company'}
         <div class="form-group">
-            <label for="other">{l s='Additional information'}</label>
-            <textarea class="validate form-control" data-validate="{$address_validation.other.validate}" id="other" name="other" cols="26" rows="3" >{if isset($smarty.post.other)}{$smarty.post.other}{else}{if isset($address->other)}{$address->other|escape:'html':'UTF-8'}{/if}{/if}</textarea>
+          <label for="company">{l s='Company'}{if isset($required_fields) && in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+          <input class="form-control validate" data-validate="{$address_validation.$field_name.validate}" type="text" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{else}{if isset($address->company)}{$address->company|escape:'html':'UTF-8'}{/if}{/if}" />
         </div>
-        {if !$homePhoneExist}
-            <div class="form-group phone-number">
-                <label for="phone">{l s='Home phone'}</label>
-                <input class="{if isset($one_phone_at_least) && $one_phone_at_least}is_required{/if} validate form-control" data-validate="{$address_validation.phone.validate}" type="tel" id="phone" name="phone" value="{if isset($smarty.post.phone)}{$smarty.post.phone}{else}{if isset($address->phone)}{$address->phone|escape:'html':'UTF-8'}{/if}{/if}"  />
+      {/if}
+      {if $field_name eq 'vat_number'}
+        <div id="vat_area">
+          <div id="vat_number">
+            <div class="form-group">
+              <label for="vat-number">{l s='VAT number'}{if isset($required_fields) && in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+              <input type="text" class="form-control validate" data-validate="{$address_validation.$field_name.validate}" id="vat-number" name="vat_number" value="{if isset($smarty.post.vat_number)}{$smarty.post.vat_number}{else}{if isset($address->vat_number)}{$address->vat_number|escape:'html':'UTF-8'}{/if}{/if}" />
             </div>
-        {/if}
+          </div>
+        </div>
+      {/if}
+      {if $field_name eq 'dni'}
+        {assign var="dniExist" value=true}
+        <div class="required form-group dni">
+          <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+          <input class="form-control" data-validate="{$address_validation.$field_name.validate}" type="text" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{else}{if isset($address->dni)}{$address->dni|escape:'html':'UTF-8'}{/if}{/if}" />
+          <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+        </div>
+      {/if}
+      {if $field_name eq 'firstname'}
+        <div class="required form-group">
+          <label for="firstname">{l s='First name'} <sup>*</sup></label>
+          <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" name="firstname" id="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{else}{if isset($address->firstname)}{$address->firstname|escape:'html':'UTF-8'}{/if}{/if}" />
+        </div>
+      {/if}
+      {if $field_name eq 'lastname'}
+        <div class="required form-group">
+          <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+          <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{else}{if isset($address->lastname)}{$address->lastname|escape:'html':'UTF-8'}{/if}{/if}" />
+        </div>
+      {/if}
+      {if $field_name eq 'address1'}
+        <div class="required form-group">
+          <label for="address1">{l s='Address'} <sup>*</sup></label>
+          <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="address1" name="address1" value="{if isset($smarty.post.address1)}{$smarty.post.address1}{else}{if isset($address->address1)}{$address->address1|escape:'html':'UTF-8'}{/if}{/if}" />
+        </div>
+      {/if}
+      {if $field_name eq 'address2'}
+        <div class="required form-group">
+          <label for="address2">{l s='Address (Line 2)'}{if isset($required_fields) && in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+          <input class="validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="address2" name="address2" value="{if isset($smarty.post.address2)}{$smarty.post.address2}{else}{if isset($address->address2)}{$address->address2|escape:'html':'UTF-8'}{/if}{/if}" />
+        </div>
+      {/if}
+      {if $field_name eq 'postcode'}
+        {assign var="postCodeExist" value=true}
+        <div class="required postcode form-group unvisible">
+          <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
+          <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" id="postcode" name="postcode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{else}{if isset($address->postcode)}{$address->postcode|escape:'html':'UTF-8'}{/if}{/if}" />
+        </div>
+      {/if}
+      {if $field_name eq 'city'}
+        <div class="required form-group">
+          <label for="city">{l s='City'} <sup>*</sup></label>
+          <input class="is_required validate form-control" data-validate="{$address_validation.$field_name.validate}" type="text" name="city" id="city" value="{if isset($smarty.post.city)}{$smarty.post.city}{else}{if isset($address->city)}{$address->city|escape:'html':'UTF-8'}{/if}{/if}" maxlength="64" />
+        </div>
+        {* if customer hasn't update his layout address, country has to be verified but it's deprecated *}
+      {/if}
+      {if $field_name eq 'Country:name' || $field_name eq 'country' || $field_name eq 'Country:iso_code'}
+        <div class="required form-group">
+          <label for="id_country">{l s='Country'} <sup>*</sup></label>
+          <select id="id_country" class="form-control" name="id_country">{$countries_list}</select>
+        </div>
+      {/if}
+      {if $field_name eq 'State:name'}
+        {assign var="stateExist" value=true}
+        <div class="required id_state form-group">
+          <label for="id_state">{l s='State'} <sup>*</sup></label>
+          <select name="id_state" id="id_state" class="form-control">
+            <option value="">-</option>
+          </select>
+        </div>
+      {/if}
+      {if $field_name eq 'phone'}
+        {assign var="homePhoneExist" value=true}
+        <div class="form-group phone-number">
+          <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+          <input class="{if isset($one_phone_at_least) && $one_phone_at_least}is_required{/if} validate form-control" data-validate="{$address_validation.phone.validate}" type="tel" id="phone" name="phone" value="{if isset($smarty.post.phone)}{$smarty.post.phone}{else}{if isset($address->phone)}{$address->phone|escape:'html':'UTF-8'}{/if}{/if}"  />
+        </div>
         <div class="clearfix"></div>
-        {if !$mobilePhoneExist}
-            <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                <input class="validate form-control" data-validate="{$address_validation.phone_mobile.validate}" type="tel" id="phone_mobile" name="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{else}{if isset($address->phone_mobile)}{$address->phone_mobile|escape:'html':'UTF-8'}{/if}{/if}" />
-            </div>
-        {/if}
-        {if isset($one_phone_at_least) && $one_phone_at_least && !$atLeastOneExists}
-            <p class="inline-infos required">{l s='You must register at least one phone number.'}</p>
-        {/if}
-        <div class="required form-group" id="adress_alias">
-            <label for="alias">{l s='Please assign an address title for future reference.'} <sup>*</sup></label>
-            <input type="text" id="alias" class="is_required validate form-control" data-validate="{$address_validation.alias.validate}" name="alias" value="{if isset($smarty.post.alias)}{$smarty.post.alias}{elseif isset($address->alias)}{$address->alias|escape:'html':'UTF-8'}{elseif !$select_address}{l s='My address'}{/if}" />
+      {/if}
+      {if $field_name eq 'phone_mobile'}
+        {assign var="mobilePhoneExist" value=true}
+        <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+          <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+          <input class="validate form-control" data-validate="{$address_validation.phone_mobile.validate}" type="tel" id="phone_mobile" name="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{else}{if isset($address->phone_mobile)}{$address->phone_mobile|escape:'html':'UTF-8'}{/if}{/if}" />
         </div>
-        <p class="submit2">
-            {if isset($id_address)}<input type="hidden" name="id_address" value="{$id_address|intval}" />{/if}
-            {if isset($back)}<input type="hidden" name="back" value="{$back}" />{/if}
-            {if isset($mod)}<input type="hidden" name="mod" value="{$mod}" />{/if}
-            {if isset($select_address)}<input type="hidden" name="select_address" value="{$select_address|intval}" />{/if}
-            <input type="hidden" name="token" value="{$token}" />
-            <button type="submit" name="submitAddress" id="submitAddress" class="btn btn-default button button-medium">
-                <span>
-                    {l s='Save'}
-                    <i class="icon-chevron-right right"></i>
-                </span>
-            </button>
-        </p>
-    </form>
+      {/if}
+      {if ($field_name eq 'phone_mobile') || ($field_name eq 'phone_mobile') && !isset($atLeastOneExists) && isset($one_phone_at_least) && $one_phone_at_least}
+        {assign var="atLeastOneExists" value=true}
+        <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
+      {/if}
+    {/foreach}
+    {if !$postCodeExist}
+      <div class="required postcode form-group unvisible">
+        <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
+        <input class="is_required validate form-control" data-validate="{$address_validation.postcode.validate}" type="text" id="postcode" name="postcode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{else}{if isset($address->postcode)}{$address->postcode|escape:'html':'UTF-8'}{/if}{/if}" />
+      </div>
+    {/if}
+    {if !$stateExist}
+      <div class="required id_state form-group unvisible">
+        <label for="id_state">{l s='State'} <sup>*</sup></label>
+        <select name="id_state" id="id_state" class="form-control">
+          <option value="">-</option>
+        </select>
+      </div>
+    {/if}
+    {if !$dniExist}
+      <div class="required dni form-group unvisible">
+        <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+        <input class="is_required form-control" data-validate="{$address_validation.dni.validate}" type="text" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{else}{if isset($address->dni)}{$address->dni|escape:'html':'UTF-8'}{/if}{/if}" />
+        <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+      </div>
+    {/if}
+    <div class="form-group">
+      <label for="other">{l s='Additional information'}</label>
+      <textarea class="validate form-control" data-validate="{$address_validation.other.validate}" id="other" name="other" cols="26" rows="3" >{if isset($smarty.post.other)}{$smarty.post.other}{else}{if isset($address->other)}{$address->other|escape:'html':'UTF-8'}{/if}{/if}</textarea>
+    </div>
+    {if !$homePhoneExist}
+      <div class="form-group phone-number">
+        <label for="phone">{l s='Home phone'}</label>
+        <input class="{if isset($one_phone_at_least) && $one_phone_at_least}is_required{/if} validate form-control" data-validate="{$address_validation.phone.validate}" type="tel" id="phone" name="phone" value="{if isset($smarty.post.phone)}{$smarty.post.phone}{else}{if isset($address->phone)}{$address->phone|escape:'html':'UTF-8'}{/if}{/if}"  />
+      </div>
+    {/if}
+    <div class="clearfix"></div>
+    {if !$mobilePhoneExist}
+      <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+        <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+        <input class="validate form-control" data-validate="{$address_validation.phone_mobile.validate}" type="tel" id="phone_mobile" name="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{else}{if isset($address->phone_mobile)}{$address->phone_mobile|escape:'html':'UTF-8'}{/if}{/if}" />
+      </div>
+    {/if}
+    {if isset($one_phone_at_least) && $one_phone_at_least && !$atLeastOneExists}
+      <p class="inline-infos required">{l s='You must register at least one phone number.'}</p>
+    {/if}
+    <div class="required form-group" id="adress_alias">
+      <label for="alias">{l s='Please assign an address title for future reference.'} <sup>*</sup></label>
+      <input type="text" id="alias" class="is_required validate form-control" data-validate="{$address_validation.alias.validate}" name="alias" value="{if isset($smarty.post.alias)}{$smarty.post.alias}{elseif isset($address->alias)}{$address->alias|escape:'html':'UTF-8'}{elseif !$select_address}{l s='My address'}{/if}" />
+    </div>
+    <p class="submit2">
+      {if isset($id_address)}<input type="hidden" name="id_address" value="{$id_address|intval}" />{/if}
+      {if isset($back)}<input type="hidden" name="back" value="{$back}" />{/if}
+      {if isset($mod)}<input type="hidden" name="mod" value="{$mod}" />{/if}
+      {if isset($select_address)}<input type="hidden" name="select_address" value="{$select_address|intval}" />{/if}
+      <input type="hidden" name="token" value="{$token}" />
+      <button type="submit" name="submitAddress" id="submitAddress" class="btn btn-default button button-medium">
+        <span>
+          {l s='Save'}
+          <i class="icon-chevron-right right"></i>
+        </span>
+      </button>
+    </p>
+  </form>
 </div>
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-defaul button button-small" href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}">
-            <span><i class="icon-chevron-left"></i> {l s='Back to your addresses'}</span>
-        </a>
-    </li>
+  <li>
+    <a class="btn btn-defaul button button-small" href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}">
+      <span><i class="icon-chevron-left"></i> {l s='Back to your addresses'}</span>
+    </a>
+  </li>
 </ul>
 {strip}
-{if isset($smarty.post.id_state) && $smarty.post.id_state}
+  {if isset($smarty.post.id_state) && $smarty.post.id_state}
     {addJsDef idSelectedState=$smarty.post.id_state|intval}
-{elseif isset($address->id_state) && $address->id_state}
+  {elseif isset($address->id_state) && $address->id_state}
     {addJsDef idSelectedState=$address->id_state|intval}
-{else}
+  {else}
     {addJsDef idSelectedState=false}
-{/if}
-{if isset($smarty.post.id_country) && $smarty.post.id_country}
+  {/if}
+  {if isset($smarty.post.id_country) && $smarty.post.id_country}
     {addJsDef idSelectedCountry=$smarty.post.id_country|intval}
-{elseif isset($address->id_country) && $address->id_country}
+  {elseif isset($address->id_country) && $address->id_country}
     {addJsDef idSelectedCountry=$address->id_country|intval}
-{else}
+  {else}
     {addJsDef idSelectedCountry=false}
-{/if}
-{if isset($countries)}
+  {/if}
+  {if isset($countries)}
     {addJsDef countries=$countries}
-{/if}
-{if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
+  {/if}
+  {if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
     {addJsDef vatnumber_ajax_call=$vatnumber_ajax_call}
-{/if}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/addresses.tpl
+++ b/themes/community-theme-16/addresses.tpl
@@ -26,45 +26,45 @@
 <h1 class="page-heading">{l s='My addresses'}</h1>
 <p>{l s='Please configure your default billing and delivery addresses when placing an order. You may also add additional addresses, which can be useful for sending gifts or receiving an order at your office.'}</p>
 {if isset($multipleAddresses) && $multipleAddresses}
-<div class="addresses">
+  <div class="addresses">
     <p><strong class="dark">{l s='Your addresses are listed below.'}</strong></p>
     <p class="p-indent">{l s='Be sure to update your personal information if it has changed.'}</p>
     {assign var="adrs_style" value=$addresses_style}
     <div class="bloc_adresses row">
-    {foreach from=$multipleAddresses item=address name=myLoop}
-        <div class="col-xs-12 col-sm-6 address">
-            <ul class="{if $smarty.foreach.myLoop.last}last_item{elseif $smarty.foreach.myLoop.first}first_item{/if}{if $smarty.foreach.myLoop.index % 2} alternate_item{else} item{/if} box">
-                <li><h3 class="page-subheading">{$address.object.alias}</h3></li>
-                {foreach from=$address.ordered name=adr_loop item=pattern}
-                    {assign var=addressKey value=" "|explode:$pattern}
-                    <li>
-                    {foreach from=$addressKey item=key name="word_loop"}
-                        <span {if isset($addresses_style[$key])} class="{$addresses_style[$key]}"{/if}>
-                            {$address.formated[$key|replace:',':'']|escape:'html':'UTF-8'}
-                        </span>
-                    {/foreach}
-                    </li>
-                {/foreach}
-                <li class="address_update">
-                <a class="btn btn-default button button-small" href="{$link->getPageLink('address', true, null, "id_address={$address.object.id|intval}")|escape:'html':'UTF-8'}" title="{l s='Update'}"><span>{l s='Update'}<i class="icon-chevron-right right"></i></span></a>
-                <a class="btn btn-default button button-small" href="{$link->getPageLink('address', true, null, "id_address={$address.object.id|intval}&delete")|escape:'html':'UTF-8'}" data-id="addresses_confirm" title="{l s='Delete'}"><span>{l s='Delete'}<i class="icon-remove right"></i></span></a></li>
-            </ul>
-        </div>
-    {if $smarty.foreach.myLoop.index % 2 && !$smarty.foreach.myLoop.last}
+      {foreach from=$multipleAddresses item=address name=myLoop}
+      <div class="col-xs-12 col-sm-6 address">
+        <ul class="{if $smarty.foreach.myLoop.last}last_item{elseif $smarty.foreach.myLoop.first}first_item{/if}{if $smarty.foreach.myLoop.index % 2} alternate_item{else} item{/if} box">
+          <li><h3 class="page-subheading">{$address.object.alias}</h3></li>
+          {foreach from=$address.ordered name=adr_loop item=pattern}
+            {assign var=addressKey value=" "|explode:$pattern}
+            <li>
+              {foreach from=$addressKey item=key name="word_loop"}
+                <span {if isset($addresses_style[$key])} class="{$addresses_style[$key]}"{/if}>
+                  {$address.formated[$key|replace:',':'']|escape:'html':'UTF-8'}
+                </span>
+              {/foreach}
+            </li>
+          {/foreach}
+          <li class="address_update">
+            <a class="btn btn-default button button-small" href="{$link->getPageLink('address', true, null, "id_address={$address.object.id|intval}")|escape:'html':'UTF-8'}" title="{l s='Update'}"><span>{l s='Update'}<i class="icon-chevron-right right"></i></span></a>
+            <a class="btn btn-default button button-small" href="{$link->getPageLink('address', true, null, "id_address={$address.object.id|intval}&delete")|escape:'html':'UTF-8'}" data-id="addresses_confirm" title="{l s='Delete'}"><span>{l s='Delete'}<i class="icon-remove right"></i></span></a></li>
+        </ul>
+      </div>
+      {if $smarty.foreach.myLoop.index % 2 && !$smarty.foreach.myLoop.last}
     </div>
     <div class="bloc_adresses row">
-    {/if}
-    {/foreach}
+      {/if}
+      {/foreach}
     </div>
-</div>
+  </div>
 {else}
-    <p class="alert alert-warning">{l s='No addresses are available.'}&nbsp;<a href="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}">{l s='Add a new address'}</a></p>
+  <p class="alert alert-warning">{l s='No addresses are available.'}&nbsp;<a href="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}">{l s='Add a new address'}</a></p>
 {/if}
 <div class="clearfix main-page-indent">
-    <a href="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}" title="{l s='Add an address'}" class="btn btn-default button button-medium"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
+  <a href="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}" title="{l s='Add an address'}" class="btn btn-default button button-medium"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
 </div>
 <ul class="footer_links clearfix">
-    <li><a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}"><span><i class="icon-chevron-left"></i> {l s='Back to your account'}</span></a></li>
-    <li><a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}"><span><i class="icon-chevron-left"></i> {l s='Home'}</span></a></li>
+  <li><a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}"><span><i class="icon-chevron-left"></i> {l s='Back to your account'}</span></a></li>
+  <li><a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}"><span><i class="icon-chevron-left"></i> {l s='Home'}</span></a></li>
 </ul>
 {addJsDefL name=addressesConfirm}{l s='Are you sure?' js=1}{/addJsDefL}

--- a/themes/community-theme-16/authentication.tpl
+++ b/themes/community-theme-16/authentication.tpl
@@ -23,10 +23,10 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {capture name=path}
-    {if !isset($email_create)}{l s='Authentication'}{else}
-        <a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Authentication'}">{l s='Authentication'}</a>
-        <span class="navigation-pipe">{$navigationPipe}</span>{l s='Create your account'}
-    {/if}
+  {if !isset($email_create)}{l s='Authentication'}{else}
+    <a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Authentication'}">{l s='Authentication'}</a>
+    <span class="navigation-pipe">{$navigationPipe}</span>{l s='Create your account'}
+  {/if}
 {/capture}
 <h1 class="page-heading">{if !isset($email_create)}{l s='Authentication'}{else}{l s='Create an account'}{/if}</h1>
 {if isset($back) && preg_match("/^http/", $back)}{assign var='current_step' value='login'}{include file="$tpl_dir./order-steps.tpl"}{/if}
@@ -35,7 +35,7 @@
 {assign var="postCodeExist" value=false}
 {assign var="dniExist" value=false}
 {if !isset($email_create)}
-    <!--{if isset($authentification_error)}
+  <!--{if isset($authentification_error)}
     <div class="alert alert-danger">
         {if {$authentification_error|@count} == 1}
             <p>{l s='There\'s at least one error'} :</p>
@@ -48,370 +48,370 @@
             {/foreach}
         </ol>
     </div>
-    {/if}-->
-    <div class="row">
-        <div class="col-xs-12 col-sm-6">
-            <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="create-account_form" class="box">
-                <h3 class="page-subheading">{l s='Create an account'}</h3>
-                <div class="form_content clearfix">
-                    <p>{l s='Please enter your email address to create an account.'}</p>
-                    <div class="alert alert-danger" id="create_account_error" style="display:none"></div>
-                    <div class="form-group">
-                        <label for="email_create">{l s='Email address'}</label>
-                        <input type="email" class="is_required validate account_input form-control" data-validate="isEmail" id="email_create" name="email_create" value="{if isset($smarty.post.email_create)}{$smarty.post.email_create|stripslashes}{/if}" />
-                    </div>
-                    <div class="submit">
-                        {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
-                        <button class="btn btn-default button button-medium exclusive" type="submit" id="SubmitCreate" name="SubmitCreate">
-                            <span>
-                                <i class="icon-user left"></i>
-                                {l s='Create an account'}
-                            </span>
-                        </button>
-                        <input type="hidden" class="hidden" name="SubmitCreate" value="{l s='Create an account'}" />
-                    </div>
-                </div>
-            </form>
+{/if}-->
+  <div class="row">
+    <div class="col-xs-12 col-sm-6">
+      <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="create-account_form" class="box">
+        <h3 class="page-subheading">{l s='Create an account'}</h3>
+        <div class="form_content clearfix">
+          <p>{l s='Please enter your email address to create an account.'}</p>
+          <div class="alert alert-danger" id="create_account_error" style="display:none"></div>
+          <div class="form-group">
+            <label for="email_create">{l s='Email address'}</label>
+            <input type="email" class="is_required validate account_input form-control" data-validate="isEmail" id="email_create" name="email_create" value="{if isset($smarty.post.email_create)}{$smarty.post.email_create|stripslashes}{/if}" />
+          </div>
+          <div class="submit">
+            {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+            <button class="btn btn-default button button-medium exclusive" type="submit" id="SubmitCreate" name="SubmitCreate">
+              <span>
+                <i class="icon-user left"></i>
+                {l s='Create an account'}
+              </span>
+            </button>
+            <input type="hidden" class="hidden" name="SubmitCreate" value="{l s='Create an account'}" />
+          </div>
         </div>
-        <div class="col-xs-12 col-sm-6">
-            <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
-                <h3 class="page-subheading">{l s='Already registered?'}</h3>
-                <div class="form_content clearfix">
-                    <div class="form-group">
-                        <label for="email">{l s='Email address'}</label>
-                        <input class="is_required validate account_input form-control" data-validate="isEmail" type="email" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" />
-                    </div>
-                    <div class="form-group">
-                        <label for="passwd">{l s='Password'}</label>
-                        <input class="is_required validate account_input form-control" type="password" data-validate="isPasswd" id="passwd" name="passwd" value="" />
-                    </div>
-                    <p class="lost_password form-group"><a href="{$link->getPageLink('password')|escape:'html':'UTF-8'}" title="{l s='Recover your forgotten password'}" rel="nofollow">{l s='Forgot your password?'}</a></p>
-                    <p class="submit">
-                        {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
-                        <button type="submit" id="SubmitLogin" name="SubmitLogin" class="button btn btn-default button-medium">
-                            <span>
-                                <i class="icon-lock left"></i>
-                                {l s='Sign in'}
-                            </span>
-                        </button>
-                    </p>
-                </div>
-            </form>
-        </div>
+      </form>
     </div>
-    {if isset($inOrderProcess) && $inOrderProcess && $PS_GUEST_CHECKOUT_ENABLED}
-        <form action="{$link->getPageLink('authentication', true, NULL, "back=$back")|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std clearfix">
-            <div class="box">
-                <div id="opc_account_form" style="display: block; ">
-                    <h3 class="page-heading bottom-indent">{l s='Instant checkout'}</h3>
-                    <p class="required"><sup>*</sup>{l s='Required field'}</p>
-                    <!-- Account -->
-                    <div class="required form-group">
-                        <label for="guest_email">{l s='Email address'} <sup>*</sup></label>
-                        <input type="text" class="is_required validate form-control" data-validate="isEmail" id="guest_email" name="guest_email" value="{if isset($smarty.post.guest_email)}{$smarty.post.guest_email}{/if}" />
-                    </div>
-                    <div class="cleafix gender-line">
-                        <label>{l s='Title'}</label>
-                        {foreach from=$genders key=k item=gender}
-                            <div class="radio-inline">
-                                <label for="id_gender{$gender->id}" class="top">
-                                    <input type="radio" name="id_gender" id="id_gender{$gender->id}" value="{$gender->id}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id} checked="checked"{/if} />
-                                    {$gender->name}
-                                </label>
-                            </div>
-                        {/foreach}
-                    </div>
-                    <div class="required form-group">
-                        <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                        <input type="text" class="is_required validate form-control" data-validate="isName" id="firstname" name="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{/if}" />
-                    </div>
-                    <div class="required form-group">
-                        <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                        <input type="text" class="is_required validate form-control" data-validate="isName" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{/if}" />
-                    </div>
-                    <div class="form-group date-select">
-                        <label>{l s='Date of Birth'}</label>
-                        <div class="row">
-                            <div class="col-xs-4">
-                                <select id="days" name="days" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$days item=day}
-                                        <option value="{$day}" {if ($sl_day == $day)} selected="selected"{/if}>{$day}&nbsp;&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                                {*
-                                    {l s='January'}
-                                    {l s='February'}
-                                    {l s='March'}
-                                    {l s='April'}
-                                    {l s='May'}
-                                    {l s='June'}
-                                    {l s='July'}
-                                    {l s='August'}
-                                    {l s='September'}
-                                    {l s='October'}
-                                    {l s='November'}
-                                    {l s='December'}
-                                *}
-                            </div>
-                            <div class="col-xs-4">
-                                <select id="months" name="months" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$months key=k item=month}
-                                        <option value="{$k}" {if ($sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                            <div class="col-xs-4">
-                                <select id="years" name="years" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$years item=year}
-                                        <option value="{$year}" {if ($sl_year == $year)} selected="selected"{/if}>{$year}&nbsp;&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    {if isset($newsletter) && $newsletter}
-                        <div class="checkbox">
-                            <label for="newsletter">
-                            <input type="checkbox" name="newsletter" id="newsletter" value="1" {if isset($smarty.post.newsletter) && $smarty.post.newsletter == '1'}checked="checked"{/if} />
-                            {l s='Sign up for our newsletter!'}</label>
-                        </div>
-                    {/if}
-                    {if isset($optin) && $optin}
-                        <div class="checkbox">
-                            <label for="optin">
-                            <input type="checkbox" name="optin" id="optin" value="1" {if isset($smarty.post.optin) && $smarty.post.optin == '1'}checked="checked"{/if} />
-                            {l s='Receive special offers from our partners!'}</label>
-                        </div>
-                    {/if}
-                    <h3 class="page-heading bottom-indent top-indent">{l s='Delivery address'}</h3>
-                    {foreach from=$dlv_all_fields item=field_name}
-                        {if $field_name eq "company"}
-                            <div class="form-group">
-                                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
-                            </div>
-                        {elseif $field_name eq "vat_number"}
-                            <div id="vat_number" style="display:none;">
-                                <div class="form-group">
-                                    <label for="vat-number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                    <input id="vat-number" type="text" class="form-control" name="vat_number" value="{if isset($smarty.post.vat_number)}{$smarty.post.vat_number}{/if}" />
-                                </div>
-                            </div>
-                            {elseif $field_name eq "dni"}
-                            {assign var='dniExist' value=true}
-                            <div class="required dni form-group">
-                                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                                <input type="text" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{/if}" />
-                                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                            </div>
-                        {elseif $field_name eq "address1"}
-                            <div class="required form-group">
-                                <label for="address1">{l s='Address'} <sup>*</sup></label>
-                                <input type="text" class="form-control" name="address1" id="address1" value="{if isset($smarty.post.address1)}{$smarty.post.address1}{/if}" />
-                            </div>
-                        {elseif $field_name eq "address2"}
-                            <div class="form-group is_customer_param">
-                                <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="form-control" name="address2" id="address2" value="{if isset($smarty.post.address2)}{$smarty.post.address2}{/if}" />
-                            </div>
-                        {elseif $field_name eq "postcode"}
-                            {assign var='postCodeExist' value=true}
-                            <div class="required postcode form-group">
-                                <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                                <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
-                            </div>
-                        {elseif $field_name eq "city"}
-                            <div class="required form-group">
-                                <label for="city">{l s='City'} <sup>*</sup></label>
-                                <input type="text" class="form-control" name="city" id="city" value="{if isset($smarty.post.city)}{$smarty.post.city}{/if}" />
-                            </div>
-                            <!-- if customer hasn't update his layout address, country has to be verified but it's deprecated -->
-                        {elseif $field_name eq "Country:name" || $field_name eq "country"}
-                            <div class="required select form-group">
-                                <label for="id_country">{l s='Country'} <sup>*</sup></label>
-                                <select name="id_country" id="id_country" class="form-control">
-                                    {foreach from=$countries item=v}
-                                        <option value="{$v.id_country}"{if (isset($smarty.post.id_country) AND  $smarty.post.id_country == $v.id_country) OR (!isset($smarty.post.id_country) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name}</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                        {elseif $field_name eq "State:name"}
-                            {assign var='stateExist' value=true}
-                            <div class="required id_state select form-group">
-                                <label for="id_state">{l s='State'} <sup>*</sup></label>
-                                <select name="id_state" id="id_state" class="form-control">
-                                    <option value="">-</option>
-                                </select>
-                            </div>
-                        {/if}
-                    {/foreach}
-                    {if $stateExist eq false}
-                        <div class="required id_state select unvisible form-group">
-                            <label for="id_state">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state" id="id_state" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </div>
-                    {/if}
-                    {if $postCodeExist eq false}
-                        <div class="required postcode unvisible form-group">
-                            <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                            <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
-                        </div>
-                    {/if}
-                    {if $dniExist eq false}
-                        <div class="required form-group dni">
-                            <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                            <input type="text" class="text form-control" name="dni" id="dni" value="{if isset($smarty.post.dni) && $smarty.post.dni}{$smarty.post.dni}{/if}" />
-                            <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                        </div>
-                    {/if}
-                    <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                        <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
-                        <input type="text" class="form-control" name="phone_mobile" id="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{/if}" />
-                    </div>
-                    <input type="hidden" name="alias" id="alias" value="{l s='My address'}" />
-                    <input type="hidden" name="is_new_customer" id="is_new_customer" value="0" />
-                    <div class="checkbox">
-                        <label for="invoice_address">
-                        <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($smarty.post.invoice_address) && $smarty.post.invoice_address)} checked="checked"{/if} autocomplete="off"/>
-                        {l s='Please use another address for invoice'}</label>
-                    </div>
-                    <div id="opc_invoice_address"  class="unvisible">
-                        {assign var=stateExist value=false}
-                        {assign var=postCodeExist value=false}
-                        {assign var=dniExist value=false}
-                        <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
-                        {foreach from=$inv_all_fields item=field_name}
-                        {if $field_name eq "company"}
-                        <div class="form-group">
-                            <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="text form-control" id="company_invoice" name="company_invoice" value="{if isset($smarty.post.company_invoice) && $smarty.post.company_invoice}{$smarty.post.company_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "vat_number"}
-                        <div id="vat_number_block_invoice" style="display:none;">
-                            <div class="form-group">
-                                <label for="vat_number_invoice">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="form-control" id="vat_number_invoice" name="vat_number_invoice" value="{if isset($smarty.post.vat_number_invoice) && $smarty.post.vat_number_invoice}{$smarty.post.vat_number_invoice}{/if}" />
-                            </div>
-                        </div>
-                        {elseif $field_name eq "dni"}
-                        {assign var=dniExist value=true}
-                        <div class="required form-group dni_invoice">
-                            <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
-                            <input type="text" class="text form-control" name="dni_invoice" id="dni_invoice" value="{if isset($smarty.post.dni_invoice) && $smarty.post.dni_invoice}{$smarty.post.dni_invoice}{/if}" />
-                            <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                        </div>
-                        {elseif $field_name eq "firstname"}
-                        <div class="required form-group">
-                            <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
-                            <input type="text" class="form-control" id="firstname_invoice" name="firstname_invoice" value="{if isset($smarty.post.firstname_invoice) && $smarty.post.firstname_invoice}{$smarty.post.firstname_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "lastname"}
-                        <div class="required form-group">
-                            <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
-                            <input type="text" class="form-control" id="lastname_invoice" name="lastname_invoice" value="{if isset($smarty.post.lastname_invoice) && $smarty.post.lastname_invoice}{$smarty.post.lastname_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "address1"}
-                        <div class="required form-group">
-                            <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
-                            <input type="text" class="form-control" name="address1_invoice" id="address1_invoice" value="{if isset($smarty.post.address1_invoice) && $smarty.post.address1_invoice}{$smarty.post.address1_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "address2"}
-                        <div class="form-group is_customer_param">
-                            <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control" name="address2_invoice" id="address2_invoice" value="{if isset($smarty.post.address2_invoice) && $smarty.post.address2_invoice}{$smarty.post.address2_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "postcode"}
-                        {$postCodeExist = true}
-                        <div class="required postcode_invoice form-group">
-                            <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                            <input type="text" class="validate form-control" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($smarty.post.postcode_invoice) && $smarty.post.postcode_invoice}{$smarty.post.postcode_invoice}{/if}"/>
-                        </div>
-                        {elseif $field_name eq "city"}
-                        <div class="required form-group">
-                            <label for="city_invoice">{l s='City'} <sup>*</sup></label>
-                            <input type="text" class="form-control" name="city_invoice" id="city_invoice" value="{if isset($smarty.post.city_invoice) && $smarty.post.city_invoice}{$smarty.post.city_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "country" || $field_name eq "Country:name"}
-                        <div class="required form-group">
-                            <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
-                            <select name="id_country_invoice" id="id_country_invoice" class="form-control">
-                                <option value="">-</option>
-                                {foreach from=$countries item=v}
-                                <option value="{$v.id_country}"{if (isset($smarty.post.id_country_invoice) && $smarty.post.id_country_invoice == $v.id_country) OR (!isset($smarty.post.id_country_invoice) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
-                                {/foreach}
-                            </select>
-                        </div>
-                        {elseif $field_name eq "state" || $field_name eq 'State:name'}
-                        {$stateExist = true}
-                        <div class="required id_state_invoice form-group" style="display:none;">
-                            <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state_invoice" id="id_state_invoice" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </div>
-                        {/if}
-                        {/foreach}
-                        {if !$postCodeExist}
-                        <div class="required postcode_invoice form-group unvisible">
-                            <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                            <input type="text" class="form-control" name="postcode_invoice" id="postcode_invoice" value="{if isset($smarty.post.postcode_invoice) && $smarty.post.postcode_invoice}{$smarty.post.postcode_invoice}{/if}"/>
-                        </div>
-                        {/if}
-                        {if !$stateExist}
-                        <div class="required id_state_invoice form-group unvisible">
-                            <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state_invoice" id="id_state_invoice" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </div>
-                        {/if}
-                        {if $dniExist eq false}
-                            <div class="required form-group dni_invoice">
-                                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                                <input type="text" class="text form-control" name="dni_invoice" id="dni_invoice" value="{if isset($smarty.post.dni_invoice) && $smarty.post.dni_invoice}{$smarty.post.dni_invoice}{/if}" />
-                                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                            </div>
-                        {/if}
-                        <div class="form-group is_customer_param">
-                            <label for="other_invoice">{l s='Additional information'}</label>
-                            <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
-                        </div>
-                        {if isset($one_phone_at_least) && $one_phone_at_least}
-                            <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
-                        {/if}
-                        <div class="form-group is_customer_param">
-                            <label for="phone_invoice">{l s='Home phone'}</label>
-                            <input type="text" class="form-control" name="phone_invoice" id="phone_invoice" value="{if isset($smarty.post.phone_invoice) && $smarty.post.phone_invoice}{$smarty.post.phone_invoice}{/if}" />
-                        </div>
-                        <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                            <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control" name="phone_mobile_invoice" id="phone_mobile_invoice" value="{if isset($smarty.post.phone_mobile_invoice) && $smarty.post.phone_mobile_invoice}{$smarty.post.phone_mobile_invoice}{/if}" />
-                        </div>
-                        <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
-                    </div>
-                    <!-- END Account -->
-                </div>
-                {$HOOK_CREATE_ACCOUNT_FORM}
+    <div class="col-xs-12 col-sm-6">
+      <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
+        <h3 class="page-subheading">{l s='Already registered?'}</h3>
+        <div class="form_content clearfix">
+          <div class="form-group">
+            <label for="email">{l s='Email address'}</label>
+            <input class="is_required validate account_input form-control" data-validate="isEmail" type="email" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" />
+          </div>
+          <div class="form-group">
+            <label for="passwd">{l s='Password'}</label>
+            <input class="is_required validate account_input form-control" type="password" data-validate="isPasswd" id="passwd" name="passwd" value="" />
+          </div>
+          <p class="lost_password form-group"><a href="{$link->getPageLink('password')|escape:'html':'UTF-8'}" title="{l s='Recover your forgotten password'}" rel="nofollow">{l s='Forgot your password?'}</a></p>
+          <p class="submit">
+            {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+            <button type="submit" id="SubmitLogin" name="SubmitLogin" class="button btn btn-default button-medium">
+              <span>
+                <i class="icon-lock left"></i>
+                {l s='Sign in'}
+              </span>
+            </button>
+          </p>
+        </div>
+      </form>
+    </div>
+  </div>
+  {if isset($inOrderProcess) && $inOrderProcess && $PS_GUEST_CHECKOUT_ENABLED}
+    <form action="{$link->getPageLink('authentication', true, NULL, "back=$back")|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std clearfix">
+      <div class="box">
+        <div id="opc_account_form" style="display: block; ">
+          <h3 class="page-heading bottom-indent">{l s='Instant checkout'}</h3>
+          <p class="required"><sup>*</sup>{l s='Required field'}</p>
+          <!-- Account -->
+          <div class="required form-group">
+            <label for="guest_email">{l s='Email address'} <sup>*</sup></label>
+            <input type="text" class="is_required validate form-control" data-validate="isEmail" id="guest_email" name="guest_email" value="{if isset($smarty.post.guest_email)}{$smarty.post.guest_email}{/if}" />
+          </div>
+          <div class="cleafix gender-line">
+            <label>{l s='Title'}</label>
+            {foreach from=$genders key=k item=gender}
+              <div class="radio-inline">
+                <label for="id_gender{$gender->id}" class="top">
+                  <input type="radio" name="id_gender" id="id_gender{$gender->id}" value="{$gender->id}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id} checked="checked"{/if} />
+                  {$gender->name}
+                </label>
+              </div>
+            {/foreach}
+          </div>
+          <div class="required form-group">
+            <label for="firstname">{l s='First name'} <sup>*</sup></label>
+            <input type="text" class="is_required validate form-control" data-validate="isName" id="firstname" name="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{/if}" />
+          </div>
+          <div class="required form-group">
+            <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+            <input type="text" class="is_required validate form-control" data-validate="isName" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{/if}" />
+          </div>
+          <div class="form-group date-select">
+            <label>{l s='Date of Birth'}</label>
+            <div class="row">
+              <div class="col-xs-4">
+                <select id="days" name="days" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$days item=day}
+                    <option value="{$day}" {if ($sl_day == $day)} selected="selected"{/if}>{$day}&nbsp;&nbsp;</option>
+                  {/foreach}
+                </select>
+                {*
+                    {l s='January'}
+                    {l s='February'}
+                    {l s='March'}
+                    {l s='April'}
+                    {l s='May'}
+                    {l s='June'}
+                    {l s='July'}
+                    {l s='August'}
+                    {l s='September'}
+                    {l s='October'}
+                    {l s='November'}
+                    {l s='December'}
+                *}
+              </div>
+              <div class="col-xs-4">
+                <select id="months" name="months" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$months key=k item=month}
+                    <option value="{$k}" {if ($sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+                  {/foreach}
+                </select>
+              </div>
+              <div class="col-xs-4">
+                <select id="years" name="years" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$years item=year}
+                    <option value="{$year}" {if ($sl_year == $year)} selected="selected"{/if}>{$year}&nbsp;&nbsp;</option>
+                  {/foreach}
+                </select>
+              </div>
             </div>
-            <p class="cart_navigation required submit clearfix">
-                <span><sup>*</sup>{l s='Required field'}</span>
-                <input type="hidden" name="display_guest_checkout" value="1" />
-                <button type="submit" class="button btn btn-default button-medium" name="submitGuestAccount" id="submitGuestAccount">
-                    <span>
-                        {l s='Proceed to checkout'}
-                        <i class="icon-chevron-right right"></i>
-                    </span>
-                </button>
-            </p>
-        </form>
-    {/if}
+          </div>
+          {if isset($newsletter) && $newsletter}
+            <div class="checkbox">
+              <label for="newsletter">
+                <input type="checkbox" name="newsletter" id="newsletter" value="1" {if isset($smarty.post.newsletter) && $smarty.post.newsletter == '1'}checked="checked"{/if} />
+                {l s='Sign up for our newsletter!'}</label>
+            </div>
+          {/if}
+          {if isset($optin) && $optin}
+            <div class="checkbox">
+              <label for="optin">
+                <input type="checkbox" name="optin" id="optin" value="1" {if isset($smarty.post.optin) && $smarty.post.optin == '1'}checked="checked"{/if} />
+                {l s='Receive special offers from our partners!'}</label>
+            </div>
+          {/if}
+          <h3 class="page-heading bottom-indent top-indent">{l s='Delivery address'}</h3>
+          {foreach from=$dlv_all_fields item=field_name}
+            {if $field_name eq "company"}
+              <div class="form-group">
+                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
+              </div>
+            {elseif $field_name eq "vat_number"}
+              <div id="vat_number" style="display:none;">
+                <div class="form-group">
+                  <label for="vat-number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input id="vat-number" type="text" class="form-control" name="vat_number" value="{if isset($smarty.post.vat_number)}{$smarty.post.vat_number}{/if}" />
+                </div>
+              </div>
+            {elseif $field_name eq "dni"}
+              {assign var='dniExist' value=true}
+              <div class="required dni form-group">
+                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                <input type="text" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{/if}" />
+                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+              </div>
+            {elseif $field_name eq "address1"}
+              <div class="required form-group">
+                <label for="address1">{l s='Address'} <sup>*</sup></label>
+                <input type="text" class="form-control" name="address1" id="address1" value="{if isset($smarty.post.address1)}{$smarty.post.address1}{/if}" />
+              </div>
+            {elseif $field_name eq "address2"}
+              <div class="form-group is_customer_param">
+                <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="form-control" name="address2" id="address2" value="{if isset($smarty.post.address2)}{$smarty.post.address2}{/if}" />
+              </div>
+            {elseif $field_name eq "postcode"}
+              {assign var='postCodeExist' value=true}
+              <div class="required postcode form-group">
+                <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
+              </div>
+            {elseif $field_name eq "city"}
+              <div class="required form-group">
+                <label for="city">{l s='City'} <sup>*</sup></label>
+                <input type="text" class="form-control" name="city" id="city" value="{if isset($smarty.post.city)}{$smarty.post.city}{/if}" />
+              </div>
+              <!-- if customer hasn't update his layout address, country has to be verified but it's deprecated -->
+            {elseif $field_name eq "Country:name" || $field_name eq "country"}
+              <div class="required select form-group">
+                <label for="id_country">{l s='Country'} <sup>*</sup></label>
+                <select name="id_country" id="id_country" class="form-control">
+                  {foreach from=$countries item=v}
+                    <option value="{$v.id_country}"{if (isset($smarty.post.id_country) AND  $smarty.post.id_country == $v.id_country) OR (!isset($smarty.post.id_country) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name}</option>
+                  {/foreach}
+                </select>
+              </div>
+            {elseif $field_name eq "State:name"}
+              {assign var='stateExist' value=true}
+              <div class="required id_state select form-group">
+                <label for="id_state">{l s='State'} <sup>*</sup></label>
+                <select name="id_state" id="id_state" class="form-control">
+                  <option value="">-</option>
+                </select>
+              </div>
+            {/if}
+          {/foreach}
+          {if $stateExist eq false}
+            <div class="required id_state select unvisible form-group">
+              <label for="id_state">{l s='State'} <sup>*</sup></label>
+              <select name="id_state" id="id_state" class="form-control">
+                <option value="">-</option>
+              </select>
+            </div>
+          {/if}
+          {if $postCodeExist eq false}
+            <div class="required postcode unvisible form-group">
+              <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
+              <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
+            </div>
+          {/if}
+          {if $dniExist eq false}
+            <div class="required form-group dni">
+              <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+              <input type="text" class="text form-control" name="dni" id="dni" value="{if isset($smarty.post.dni) && $smarty.post.dni}{$smarty.post.dni}{/if}" />
+              <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+            </div>
+          {/if}
+          <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+            <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+            <input type="text" class="form-control" name="phone_mobile" id="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{/if}" />
+          </div>
+          <input type="hidden" name="alias" id="alias" value="{l s='My address'}" />
+          <input type="hidden" name="is_new_customer" id="is_new_customer" value="0" />
+          <div class="checkbox">
+            <label for="invoice_address">
+              <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($smarty.post.invoice_address) && $smarty.post.invoice_address)} checked="checked"{/if} autocomplete="off"/>
+              {l s='Please use another address for invoice'}</label>
+          </div>
+          <div id="opc_invoice_address"  class="unvisible">
+            {assign var=stateExist value=false}
+            {assign var=postCodeExist value=false}
+            {assign var=dniExist value=false}
+            <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
+            {foreach from=$inv_all_fields item=field_name}
+              {if $field_name eq "company"}
+                <div class="form-group">
+                  <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="text form-control" id="company_invoice" name="company_invoice" value="{if isset($smarty.post.company_invoice) && $smarty.post.company_invoice}{$smarty.post.company_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "vat_number"}
+                <div id="vat_number_block_invoice" style="display:none;">
+                  <div class="form-group">
+                    <label for="vat_number_invoice">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                    <input type="text" class="form-control" id="vat_number_invoice" name="vat_number_invoice" value="{if isset($smarty.post.vat_number_invoice) && $smarty.post.vat_number_invoice}{$smarty.post.vat_number_invoice}{/if}" />
+                  </div>
+                </div>
+              {elseif $field_name eq "dni"}
+                {assign var=dniExist value=true}
+                <div class="required form-group dni_invoice">
+                  <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
+                  <input type="text" class="text form-control" name="dni_invoice" id="dni_invoice" value="{if isset($smarty.post.dni_invoice) && $smarty.post.dni_invoice}{$smarty.post.dni_invoice}{/if}" />
+                  <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                </div>
+              {elseif $field_name eq "firstname"}
+                <div class="required form-group">
+                  <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
+                  <input type="text" class="form-control" id="firstname_invoice" name="firstname_invoice" value="{if isset($smarty.post.firstname_invoice) && $smarty.post.firstname_invoice}{$smarty.post.firstname_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "lastname"}
+                <div class="required form-group">
+                  <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
+                  <input type="text" class="form-control" id="lastname_invoice" name="lastname_invoice" value="{if isset($smarty.post.lastname_invoice) && $smarty.post.lastname_invoice}{$smarty.post.lastname_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "address1"}
+                <div class="required form-group">
+                  <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
+                  <input type="text" class="form-control" name="address1_invoice" id="address1_invoice" value="{if isset($smarty.post.address1_invoice) && $smarty.post.address1_invoice}{$smarty.post.address1_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "address2"}
+                <div class="form-group is_customer_param">
+                  <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="form-control" name="address2_invoice" id="address2_invoice" value="{if isset($smarty.post.address2_invoice) && $smarty.post.address2_invoice}{$smarty.post.address2_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "postcode"}
+                {$postCodeExist = true}
+                <div class="required postcode_invoice form-group">
+                  <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                  <input type="text" class="validate form-control" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($smarty.post.postcode_invoice) && $smarty.post.postcode_invoice}{$smarty.post.postcode_invoice}{/if}"/>
+                </div>
+              {elseif $field_name eq "city"}
+                <div class="required form-group">
+                  <label for="city_invoice">{l s='City'} <sup>*</sup></label>
+                  <input type="text" class="form-control" name="city_invoice" id="city_invoice" value="{if isset($smarty.post.city_invoice) && $smarty.post.city_invoice}{$smarty.post.city_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "country" || $field_name eq "Country:name"}
+                <div class="required form-group">
+                  <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
+                  <select name="id_country_invoice" id="id_country_invoice" class="form-control">
+                    <option value="">-</option>
+                    {foreach from=$countries item=v}
+                      <option value="{$v.id_country}"{if (isset($smarty.post.id_country_invoice) && $smarty.post.id_country_invoice == $v.id_country) OR (!isset($smarty.post.id_country_invoice) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+                    {/foreach}
+                  </select>
+                </div>
+              {elseif $field_name eq "state" || $field_name eq 'State:name'}
+                {$stateExist = true}
+                <div class="required id_state_invoice form-group" style="display:none;">
+                  <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                  <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                    <option value="">-</option>
+                  </select>
+                </div>
+              {/if}
+            {/foreach}
+            {if !$postCodeExist}
+              <div class="required postcode_invoice form-group unvisible">
+                <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                <input type="text" class="form-control" name="postcode_invoice" id="postcode_invoice" value="{if isset($smarty.post.postcode_invoice) && $smarty.post.postcode_invoice}{$smarty.post.postcode_invoice}{/if}"/>
+              </div>
+            {/if}
+            {if !$stateExist}
+              <div class="required id_state_invoice form-group unvisible">
+                <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                  <option value="">-</option>
+                </select>
+              </div>
+            {/if}
+            {if $dniExist eq false}
+              <div class="required form-group dni_invoice">
+                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                <input type="text" class="text form-control" name="dni_invoice" id="dni_invoice" value="{if isset($smarty.post.dni_invoice) && $smarty.post.dni_invoice}{$smarty.post.dni_invoice}{/if}" />
+                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+              </div>
+            {/if}
+            <div class="form-group is_customer_param">
+              <label for="other_invoice">{l s='Additional information'}</label>
+              <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
+            </div>
+            {if isset($one_phone_at_least) && $one_phone_at_least}
+              <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+            {/if}
+            <div class="form-group is_customer_param">
+              <label for="phone_invoice">{l s='Home phone'}</label>
+              <input type="text" class="form-control" name="phone_invoice" id="phone_invoice" value="{if isset($smarty.post.phone_invoice) && $smarty.post.phone_invoice}{$smarty.post.phone_invoice}{/if}" />
+            </div>
+            <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+              <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+              <input type="text" class="form-control" name="phone_mobile_invoice" id="phone_mobile_invoice" value="{if isset($smarty.post.phone_mobile_invoice) && $smarty.post.phone_mobile_invoice}{$smarty.post.phone_mobile_invoice}{/if}" />
+            </div>
+            <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
+          </div>
+          <!-- END Account -->
+        </div>
+        {$HOOK_CREATE_ACCOUNT_FORM}
+      </div>
+      <p class="cart_navigation required submit clearfix">
+        <span><sup>*</sup>{l s='Required field'}</span>
+        <input type="hidden" name="display_guest_checkout" value="1" />
+        <button type="submit" class="button btn btn-default button-medium" name="submitGuestAccount" id="submitGuestAccount">
+          <span>
+            {l s='Proceed to checkout'}
+            <i class="icon-chevron-right right"></i>
+          </span>
+        </button>
+      </p>
+    </form>
+  {/if}
 {else}
-    <!--{if isset($account_error)}
+  <!--{if isset($account_error)}
     <div class="error">
         {if {$account_error|@count} == 1}
             <p>{l s='There\'s at least one error'} :</p>
@@ -425,285 +425,285 @@
         </ol>
     </div>
     {/if}-->
-    <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="account-creation_form" class="std box">
-        {$HOOK_CREATE_ACCOUNT_TOP}
-        <div class="account_creation">
-            <h3 class="page-subheading">{l s='Your personal information'}</h3>
-            <p class="required"><sup>*</sup>{l s='Required field'}</p>
-            <div class="clearfix">
-                <label>{l s='Title'}</label>
-                <br />
-                {foreach from=$genders key=k item=gender}
-                    <div class="radio-inline">
-                        <label for="id_gender{$gender->id}" class="top">
-                            <input type="radio" name="id_gender" id="id_gender{$gender->id}" value="{$gender->id}" {if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id}checked="checked"{/if} />
-                        {$gender->name}
-                        </label>
-                    </div>
-                {/foreach}
-            </div>
-            <div class="required form-group">
-                <label for="customer_firstname">{l s='First name'} <sup>*</sup></label>
-                <input onkeyup="$('#firstname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isName" id="customer_firstname" name="customer_firstname" value="{if isset($smarty.post.customer_firstname)}{$smarty.post.customer_firstname}{/if}" />
-            </div>
-            <div class="required form-group">
-                <label for="customer_lastname">{l s='Last name'} <sup>*</sup></label>
-                <input onkeyup="$('#lastname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isName" id="customer_lastname" name="customer_lastname" value="{if isset($smarty.post.customer_lastname)}{$smarty.post.customer_lastname}{/if}" />
-            </div>
-            <div class="required form-group">
-                <label for="email">{l s='Email'} <sup>*</sup></label>
-                <input type="email" class="is_required validate form-control" data-validate="isEmail" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email}{/if}" />
-            </div>
-            <div class="required password form-group">
-                <label for="passwd">{l s='Password'} <sup>*</sup></label>
-                <input type="password" class="is_required validate form-control" data-validate="isPasswd" name="passwd" id="passwd" />
-                <span class="form_info">{l s='(Five characters minimum)'}</span>
-            </div>
-            <div class="form-group">
-                <label>{l s='Date of Birth'}</label>
-                <div class="row">
-                    <div class="col-xs-4">
-                        <select id="days" name="days" class="form-control">
-                            <option value="">-</option>
-                            {foreach from=$days item=day}
-                                <option value="{$day}" {if ($sl_day == $day)} selected="selected"{/if}>{$day}&nbsp;&nbsp;</option>
-                            {/foreach}
-                        </select>
-                        {*
-                            {l s='January'}
-                            {l s='February'}
-                            {l s='March'}
-                            {l s='April'}
-                            {l s='May'}
-                            {l s='June'}
-                            {l s='July'}
-                            {l s='August'}
-                            {l s='September'}
-                            {l s='October'}
-                            {l s='November'}
-                            {l s='December'}
-                        *}
-                    </div>
-                    <div class="col-xs-4">
-                        <select id="months" name="months" class="form-control">
-                            <option value="">-</option>
-                            {foreach from=$months key=k item=month}
-                                <option value="{$k}" {if ($sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
-                            {/foreach}
-                        </select>
-                    </div>
-                    <div class="col-xs-4">
-                        <select id="years" name="years" class="form-control">
-                            <option value="">-</option>
-                            {foreach from=$years item=year}
-                                <option value="{$year}" {if ($sl_year == $year)} selected="selected"{/if}>{$year}&nbsp;&nbsp;</option>
-                            {/foreach}
-                        </select>
-                    </div>
-                </div>
-            </div>
-            {if isset($newsletter) && $newsletter}
-                <div class="checkbox">
-                    <input type="checkbox" name="newsletter" id="newsletter" value="1" {if isset($smarty.post.newsletter) AND $smarty.post.newsletter == 1} checked="checked"{/if} />
-                    <label for="newsletter">{l s='Sign up for our newsletter!'}</label>
-                    {if array_key_exists('newsletter', $field_required)}
-                        <sup> *</sup>
-                    {/if}
-                </div>
-            {/if}
-            {if isset($optin) && $optin}
-                <div class="checkbox">
-                    <input type="checkbox" name="optin" id="optin" value="1" {if isset($smarty.post.optin) AND $smarty.post.optin == 1} checked="checked"{/if} />
-                    <label for="optin">{l s='Receive special offers from our partners!'}</label>
-                    {if array_key_exists('optin', $field_required)}
-                        <sup> *</sup>
-                    {/if}
-                </div>
-            {/if}
+  <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="account-creation_form" class="std box">
+    {$HOOK_CREATE_ACCOUNT_TOP}
+    <div class="account_creation">
+      <h3 class="page-subheading">{l s='Your personal information'}</h3>
+      <p class="required"><sup>*</sup>{l s='Required field'}</p>
+      <div class="clearfix">
+        <label>{l s='Title'}</label>
+        <br />
+        {foreach from=$genders key=k item=gender}
+          <div class="radio-inline">
+            <label for="id_gender{$gender->id}" class="top">
+              <input type="radio" name="id_gender" id="id_gender{$gender->id}" value="{$gender->id}" {if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id}checked="checked"{/if} />
+              {$gender->name}
+            </label>
+          </div>
+        {/foreach}
+      </div>
+      <div class="required form-group">
+        <label for="customer_firstname">{l s='First name'} <sup>*</sup></label>
+        <input onkeyup="$('#firstname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isName" id="customer_firstname" name="customer_firstname" value="{if isset($smarty.post.customer_firstname)}{$smarty.post.customer_firstname}{/if}" />
+      </div>
+      <div class="required form-group">
+        <label for="customer_lastname">{l s='Last name'} <sup>*</sup></label>
+        <input onkeyup="$('#lastname').val(this.value);" type="text" class="is_required validate form-control" data-validate="isName" id="customer_lastname" name="customer_lastname" value="{if isset($smarty.post.customer_lastname)}{$smarty.post.customer_lastname}{/if}" />
+      </div>
+      <div class="required form-group">
+        <label for="email">{l s='Email'} <sup>*</sup></label>
+        <input type="email" class="is_required validate form-control" data-validate="isEmail" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email}{/if}" />
+      </div>
+      <div class="required password form-group">
+        <label for="passwd">{l s='Password'} <sup>*</sup></label>
+        <input type="password" class="is_required validate form-control" data-validate="isPasswd" name="passwd" id="passwd" />
+        <span class="form_info">{l s='(Five characters minimum)'}</span>
+      </div>
+      <div class="form-group">
+        <label>{l s='Date of Birth'}</label>
+        <div class="row">
+          <div class="col-xs-4">
+            <select id="days" name="days" class="form-control">
+              <option value="">-</option>
+              {foreach from=$days item=day}
+                <option value="{$day}" {if ($sl_day == $day)} selected="selected"{/if}>{$day}&nbsp;&nbsp;</option>
+              {/foreach}
+            </select>
+            {*
+                {l s='January'}
+                {l s='February'}
+                {l s='March'}
+                {l s='April'}
+                {l s='May'}
+                {l s='June'}
+                {l s='July'}
+                {l s='August'}
+                {l s='September'}
+                {l s='October'}
+                {l s='November'}
+                {l s='December'}
+            *}
+          </div>
+          <div class="col-xs-4">
+            <select id="months" name="months" class="form-control">
+              <option value="">-</option>
+              {foreach from=$months key=k item=month}
+                <option value="{$k}" {if ($sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+              {/foreach}
+            </select>
+          </div>
+          <div class="col-xs-4">
+            <select id="years" name="years" class="form-control">
+              <option value="">-</option>
+              {foreach from=$years item=year}
+                <option value="{$year}" {if ($sl_year == $year)} selected="selected"{/if}>{$year}&nbsp;&nbsp;</option>
+              {/foreach}
+            </select>
+          </div>
         </div>
-        {if $b2b_enable}
-            <div class="account_creation">
-                <h3 class="page-subheading">{l s='Your company information'}</h3>
-                <p class="form-group">
-                    <label for="">{l s='Company'}</label>
-                    <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
-                </p>
-                <p class="form-group">
-                    <label for="siret">{l s='SIRET'}</label>
-                    <input type="text" class="form-control" id="siret" name="siret" value="{if isset($smarty.post.siret)}{$smarty.post.siret}{/if}" />
-                </p>
-                <p class="form-group">
-                    <label for="ape">{l s='APE'}</label>
-                    <input type="text" class="form-control" id="ape" name="ape" value="{if isset($smarty.post.ape)}{$smarty.post.ape}{/if}" />
-                </p>
-                <p class="form-group">
-                    <label for="website">{l s='Website'}</label>
-                    <input type="text" class="form-control" id="website" name="website" value="{if isset($smarty.post.website)}{$smarty.post.website}{/if}" />
-                </p>
-            </div>
-        {/if}
-        {if isset($PS_REGISTRATION_PROCESS_TYPE) && $PS_REGISTRATION_PROCESS_TYPE}
-            <div class="account_creation">
-                <h3 class="page-subheading">{l s='Your address'}</h3>
-                {foreach from=$dlv_all_fields item=field_name}
-                    {if $field_name eq "company"}
-                        {if !$b2b_enable}
-                            <p class="form-group">
-                                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
-                            </p>
-                        {/if}
-                    {elseif $field_name eq "vat_number"}
-                        <div id="vat_number" style="display:none;">
-                            <p class="form-group">
-                                <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="form-control" id="vat_number" name="vat_number" value="{if isset($smarty.post.vat_number)}{$smarty.post.vat_number}{/if}" />
-                            </p>
-                        </div>
-                    {elseif $field_name eq "firstname"}
-                        <p class="required form-group">
-                            <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                            <input type="text" class="form-control" id="firstname" name="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{/if}" />
-                        </p>
-                    {elseif $field_name eq "lastname"}
-                        <p class="required form-group">
-                            <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                            <input type="text" class="form-control" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{/if}" />
-                        </p>
-                    {elseif $field_name eq "address1"}
-                        <p class="required form-group">
-                            <label for="address1">{l s='Address'} <sup>*</sup></label>
-                            <input type="text" class="form-control" name="address1" id="address1" value="{if isset($smarty.post.address1)}{$smarty.post.address1}{/if}" />
-                            <span class="inline-infos">{l s='Street address, P.O. Box, Company name, etc.'}</span>
-                        </p>
-                    {elseif $field_name eq "address2"}
-                        <p class="form-group is_customer_param">
-                            <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control" name="address2" id="address2" value="{if isset($smarty.post.address2)}{$smarty.post.address2}{/if}" />
-                            <span class="inline-infos">{l s='Apartment, suite, unit, building, floor, etc...'}</span>
-                        </p>
-                    {elseif $field_name eq "postcode"}
-                        {assign var='postCodeExist' value=true}
-                        <p class="required postcode form-group">
-                            <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                            <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
-                        </p>
-                    {elseif $field_name eq "city"}
-                        <p class="required form-group">
-                            <label for="city">{l s='City'} <sup>*</sup></label>
-                            <input type="text" class="form-control" name="city" id="city" value="{if isset($smarty.post.city)}{$smarty.post.city}{/if}" />
-                        </p>
-                        <!-- if customer hasn't update his layout address, country has to be verified but it's deprecated -->
-                    {elseif $field_name eq "Country:name" || $field_name eq "country"}
-                        <p class="required select form-group">
-                            <label for="id_country">{l s='Country'} <sup>*</sup></label>
-                            <select name="id_country" id="id_country" class="form-control">
-                                <option value="">-</option>
-                                {foreach from=$countries item=v}
-                                <option value="{$v.id_country}"{if (isset($smarty.post.id_country) AND $smarty.post.id_country == $v.id_country) OR (!isset($smarty.post.id_country) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name}</option>
-                                {/foreach}
-                            </select>
-                        </p>
-                    {elseif $field_name eq "State:name" || $field_name eq 'state'}
-                        {assign var='stateExist' value=true}
-                        <p class="required id_state select form-group">
-                            <label for="id_state">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state" id="id_state" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </p>
-                    {/if}
-                {/foreach}
-                {if $postCodeExist eq false}
-                    <p class="required postcode form-group unvisible">
-                        <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                        <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
-                    </p>
-                {/if}
-                {if $stateExist eq false}
-                    <p class="required id_state select unvisible form-group">
-                        <label for="id_state">{l s='State'} <sup>*</sup></label>
-                        <select name="id_state" id="id_state" class="form-control">
-                            <option value="">-</option>
-                        </select>
-                    </p>
-                {/if}
-                <p class="textarea form-group">
-                    <label for="other">{l s='Additional information'}</label>
-                    <textarea class="form-control" name="other" id="other" cols="26" rows="3">{if isset($smarty.post.other)}{$smarty.post.other}{/if}</textarea>
-                </p>
-                <p class="form-group">
-                    <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                    <input type="text" class="form-control" name="phone" id="phone" value="{if isset($smarty.post.phone)}{$smarty.post.phone}{/if}" />
-                </p>
-                <p class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                    <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                    <input type="text" class="form-control" name="phone_mobile" id="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{/if}" />
-                </p>
-                {if isset($one_phone_at_least) && $one_phone_at_least}
-                    {assign var="atLeastOneExists" value=true}
-                    <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
-                {/if}
-                <p class="required form-group" id="address_alias">
-                    <label for="alias">{l s='Assign an address alias for future reference.'} <sup>*</sup></label>
-                    <input type="text" class="form-control" name="alias" id="alias" value="{if isset($smarty.post.alias)}{$smarty.post.alias}{else}{l s='My address'}{/if}" />
-                </p>
-            </div>
-            <div class="account_creation dni">
-                <h3 class="page-subheading">{l s='Tax identification'}</h3>
-                <p class="required form-group">
-                    <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                    <input type="text" class="form-control" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{/if}" />
-                    <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                </p>
-            </div>
-        {/if}
-        {$HOOK_CREATE_ACCOUNT_FORM}
-        <div class="submit clearfix">
-            <input type="hidden" name="email_create" value="1" />
-            <input type="hidden" name="is_new_customer" value="1" />
-            {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
-            <button type="submit" name="submitAccount" id="submitAccount" class="btn btn-default button button-medium">
-                <span>{l s='Register'}<i class="icon-chevron-right right"></i></span>
-            </button>
-            <p class="pull-right required"><span><sup>*</sup>{l s='Required field'}</span></p>
+      </div>
+      {if isset($newsletter) && $newsletter}
+        <div class="checkbox">
+          <input type="checkbox" name="newsletter" id="newsletter" value="1" {if isset($smarty.post.newsletter) AND $smarty.post.newsletter == 1} checked="checked"{/if} />
+          <label for="newsletter">{l s='Sign up for our newsletter!'}</label>
+          {if array_key_exists('newsletter', $field_required)}
+            <sup> *</sup>
+          {/if}
         </div>
-    </form>
+      {/if}
+      {if isset($optin) && $optin}
+        <div class="checkbox">
+          <input type="checkbox" name="optin" id="optin" value="1" {if isset($smarty.post.optin) AND $smarty.post.optin == 1} checked="checked"{/if} />
+          <label for="optin">{l s='Receive special offers from our partners!'}</label>
+          {if array_key_exists('optin', $field_required)}
+            <sup> *</sup>
+          {/if}
+        </div>
+      {/if}
+    </div>
+    {if $b2b_enable}
+      <div class="account_creation">
+        <h3 class="page-subheading">{l s='Your company information'}</h3>
+        <p class="form-group">
+          <label for="">{l s='Company'}</label>
+          <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
+        </p>
+        <p class="form-group">
+          <label for="siret">{l s='SIRET'}</label>
+          <input type="text" class="form-control" id="siret" name="siret" value="{if isset($smarty.post.siret)}{$smarty.post.siret}{/if}" />
+        </p>
+        <p class="form-group">
+          <label for="ape">{l s='APE'}</label>
+          <input type="text" class="form-control" id="ape" name="ape" value="{if isset($smarty.post.ape)}{$smarty.post.ape}{/if}" />
+        </p>
+        <p class="form-group">
+          <label for="website">{l s='Website'}</label>
+          <input type="text" class="form-control" id="website" name="website" value="{if isset($smarty.post.website)}{$smarty.post.website}{/if}" />
+        </p>
+      </div>
+    {/if}
+    {if isset($PS_REGISTRATION_PROCESS_TYPE) && $PS_REGISTRATION_PROCESS_TYPE}
+      <div class="account_creation">
+        <h3 class="page-subheading">{l s='Your address'}</h3>
+        {foreach from=$dlv_all_fields item=field_name}
+          {if $field_name eq "company"}
+            {if !$b2b_enable}
+              <p class="form-group">
+                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
+              </p>
+            {/if}
+          {elseif $field_name eq "vat_number"}
+            <div id="vat_number" style="display:none;">
+              <p class="form-group">
+                <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="form-control" id="vat_number" name="vat_number" value="{if isset($smarty.post.vat_number)}{$smarty.post.vat_number}{/if}" />
+              </p>
+            </div>
+          {elseif $field_name eq "firstname"}
+            <p class="required form-group">
+              <label for="firstname">{l s='First name'} <sup>*</sup></label>
+              <input type="text" class="form-control" id="firstname" name="firstname" value="{if isset($smarty.post.firstname)}{$smarty.post.firstname}{/if}" />
+            </p>
+          {elseif $field_name eq "lastname"}
+            <p class="required form-group">
+              <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+              <input type="text" class="form-control" id="lastname" name="lastname" value="{if isset($smarty.post.lastname)}{$smarty.post.lastname}{/if}" />
+            </p>
+          {elseif $field_name eq "address1"}
+            <p class="required form-group">
+              <label for="address1">{l s='Address'} <sup>*</sup></label>
+              <input type="text" class="form-control" name="address1" id="address1" value="{if isset($smarty.post.address1)}{$smarty.post.address1}{/if}" />
+              <span class="inline-infos">{l s='Street address, P.O. Box, Company name, etc.'}</span>
+            </p>
+          {elseif $field_name eq "address2"}
+            <p class="form-group is_customer_param">
+              <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+              <input type="text" class="form-control" name="address2" id="address2" value="{if isset($smarty.post.address2)}{$smarty.post.address2}{/if}" />
+              <span class="inline-infos">{l s='Apartment, suite, unit, building, floor, etc...'}</span>
+            </p>
+          {elseif $field_name eq "postcode"}
+            {assign var='postCodeExist' value=true}
+            <p class="required postcode form-group">
+              <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
+              <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
+            </p>
+          {elseif $field_name eq "city"}
+            <p class="required form-group">
+              <label for="city">{l s='City'} <sup>*</sup></label>
+              <input type="text" class="form-control" name="city" id="city" value="{if isset($smarty.post.city)}{$smarty.post.city}{/if}" />
+            </p>
+            <!-- if customer hasn't update his layout address, country has to be verified but it's deprecated -->
+          {elseif $field_name eq "Country:name" || $field_name eq "country"}
+            <p class="required select form-group">
+              <label for="id_country">{l s='Country'} <sup>*</sup></label>
+              <select name="id_country" id="id_country" class="form-control">
+                <option value="">-</option>
+                {foreach from=$countries item=v}
+                  <option value="{$v.id_country}"{if (isset($smarty.post.id_country) AND $smarty.post.id_country == $v.id_country) OR (!isset($smarty.post.id_country) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name}</option>
+                {/foreach}
+              </select>
+            </p>
+          {elseif $field_name eq "State:name" || $field_name eq 'state'}
+            {assign var='stateExist' value=true}
+            <p class="required id_state select form-group">
+              <label for="id_state">{l s='State'} <sup>*</sup></label>
+              <select name="id_state" id="id_state" class="form-control">
+                <option value="">-</option>
+              </select>
+            </p>
+          {/if}
+        {/foreach}
+        {if $postCodeExist eq false}
+          <p class="required postcode form-group unvisible">
+            <label for="postcode">{l s='Zip/Postal Code'} <sup>*</sup></label>
+            <input type="text" class="validate form-control" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($smarty.post.postcode)}{$smarty.post.postcode}{/if}"/>
+          </p>
+        {/if}
+        {if $stateExist eq false}
+          <p class="required id_state select unvisible form-group">
+            <label for="id_state">{l s='State'} <sup>*</sup></label>
+            <select name="id_state" id="id_state" class="form-control">
+              <option value="">-</option>
+            </select>
+          </p>
+        {/if}
+        <p class="textarea form-group">
+          <label for="other">{l s='Additional information'}</label>
+          <textarea class="form-control" name="other" id="other" cols="26" rows="3">{if isset($smarty.post.other)}{$smarty.post.other}{/if}</textarea>
+        </p>
+        <p class="form-group">
+          <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+          <input type="text" class="form-control" name="phone" id="phone" value="{if isset($smarty.post.phone)}{$smarty.post.phone}{/if}" />
+        </p>
+        <p class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+          <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+          <input type="text" class="form-control" name="phone_mobile" id="phone_mobile" value="{if isset($smarty.post.phone_mobile)}{$smarty.post.phone_mobile}{/if}" />
+        </p>
+        {if isset($one_phone_at_least) && $one_phone_at_least}
+          {assign var="atLeastOneExists" value=true}
+          <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
+        {/if}
+        <p class="required form-group" id="address_alias">
+          <label for="alias">{l s='Assign an address alias for future reference.'} <sup>*</sup></label>
+          <input type="text" class="form-control" name="alias" id="alias" value="{if isset($smarty.post.alias)}{$smarty.post.alias}{else}{l s='My address'}{/if}" />
+        </p>
+      </div>
+      <div class="account_creation dni">
+        <h3 class="page-subheading">{l s='Tax identification'}</h3>
+        <p class="required form-group">
+          <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+          <input type="text" class="form-control" name="dni" id="dni" value="{if isset($smarty.post.dni)}{$smarty.post.dni}{/if}" />
+          <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+        </p>
+      </div>
+    {/if}
+    {$HOOK_CREATE_ACCOUNT_FORM}
+    <div class="submit clearfix">
+      <input type="hidden" name="email_create" value="1" />
+      <input type="hidden" name="is_new_customer" value="1" />
+      {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+      <button type="submit" name="submitAccount" id="submitAccount" class="btn btn-default button button-medium">
+        <span>{l s='Register'}<i class="icon-chevron-right right"></i></span>
+      </button>
+      <p class="pull-right required"><span><sup>*</sup>{l s='Required field'}</span></p>
+    </div>
+  </form>
 {/if}
 {strip}
-{if isset($smarty.post.id_state) && $smarty.post.id_state}
+  {if isset($smarty.post.id_state) && $smarty.post.id_state}
     {addJsDef idSelectedState=$smarty.post.id_state|intval}
-{elseif isset($address->id_state) && $address->id_state}
+  {elseif isset($address->id_state) && $address->id_state}
     {addJsDef idSelectedState=$address->id_state|intval}
-{else}
+  {else}
     {addJsDef idSelectedState=false}
-{/if}
-{if isset($smarty.post.id_state_invoice) && isset($smarty.post.id_state_invoice) && $smarty.post.id_state_invoice}
+  {/if}
+  {if isset($smarty.post.id_state_invoice) && isset($smarty.post.id_state_invoice) && $smarty.post.id_state_invoice}
     {addJsDef idSelectedStateInvoice=$smarty.post.id_state_invoice|intval}
-{else}
+  {else}
     {addJsDef idSelectedStateInvoice=false}
-{/if}
-{if isset($smarty.post.id_country) && $smarty.post.id_country}
+  {/if}
+  {if isset($smarty.post.id_country) && $smarty.post.id_country}
     {addJsDef idSelectedCountry=$smarty.post.id_country|intval}
-{elseif isset($address->id_country) && $address->id_country}
+  {elseif isset($address->id_country) && $address->id_country}
     {addJsDef idSelectedCountry=$address->id_country|intval}
-{else}
+  {else}
     {addJsDef idSelectedCountry=false}
-{/if}
-{if isset($smarty.post.id_country_invoice) && isset($smarty.post.id_country_invoice) && $smarty.post.id_country_invoice}
+  {/if}
+  {if isset($smarty.post.id_country_invoice) && isset($smarty.post.id_country_invoice) && $smarty.post.id_country_invoice}
     {addJsDef idSelectedCountryInvoice=$smarty.post.id_country_invoice|intval}
-{else}
+  {else}
     {addJsDef idSelectedCountryInvoice=false}
-{/if}
-{if isset($countries)}
+  {/if}
+  {if isset($countries)}
     {addJsDef countries=$countries}
-{/if}
-{if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
+  {/if}
+  {if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
     {addJsDef vatnumber_ajax_call=$vatnumber_ajax_call}
-{/if}
-{if isset($email_create) && $email_create}
+  {/if}
+  {if isset($email_create) && $email_create}
     {addJsDef email_create=$email_create|boolval}
-{else}
+  {else}
     {addJsDef email_create=false}
-{/if}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/best-sales.tpl
+++ b/themes/community-theme-16/best-sales.tpl
@@ -28,25 +28,25 @@
 <h1 class="page-heading product-listing">{l s='Top sellers'}</h1>
 
 {if $products}
-    <div class="content_sortPagiBar">
-        <div class="sortPagiBar clearfix">
-            {include file="./product-sort.tpl"}
-            {include file="./nbr-product-page.tpl"}
-        </div>
-        <div class="top-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {include file="$tpl_dir./pagination.tpl"}
-        </div>
+  <div class="content_sortPagiBar">
+    <div class="sortPagiBar clearfix">
+      {include file="./product-sort.tpl"}
+      {include file="./nbr-product-page.tpl"}
     </div>
-
-    {include file="./product-list.tpl" products=$products}
-
-    <div class="content_sortPagiBar">
-        <div class="bottom-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {include file="./pagination.tpl" paginationId='bottom'}
-        </div>
+    <div class="top-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {include file="$tpl_dir./pagination.tpl"}
     </div>
-    {else}
-    <p class="alert alert-warning">{l s='No top sellers for the moment.'}</p>
+  </div>
+
+  {include file="./product-list.tpl" products=$products}
+
+  <div class="content_sortPagiBar">
+    <div class="bottom-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {include file="./pagination.tpl" paginationId='bottom'}
+    </div>
+  </div>
+{else}
+  <p class="alert alert-warning">{l s='No top sellers for the moment.'}</p>
 {/if}

--- a/themes/community-theme-16/breadcrumb.tpl
+++ b/themes/community-theme-16/breadcrumb.tpl
@@ -26,24 +26,24 @@
 <!-- Breadcrumb -->
 {if isset($smarty.capture.path)}{assign var='path' value=$smarty.capture.path}{/if}
 <div class="breadcrumb clearfix">
-    <a class="home" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Return to Home'}"><i class="icon-home"></i></a>
-    {if isset($path) AND $path}
-        <span class="navigation-pipe"{if isset($category) && isset($category->id_category) && $category->id_category == (int)Configuration::get('PS_ROOT_CATEGORY')} style="display:none;"{/if}>{$navigationPipe|escape:'html':'UTF-8'}</span>
-        {if $path|strpos:'span' !== false}
-            <span class="navigation_page">{$path|@replace:'<a ': '<span itemscope itemtype="http://data-vocabulary.org/Breadcrumb"><a itemprop="url" '|@replace:'data-gg="">': '><span itemprop="title">'|@replace:'</a>': '</span></a></span>'}</span>
-        {else}
-            {$path}
-        {/if}
+  <a class="home" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Return to Home'}"><i class="icon-home"></i></a>
+  {if isset($path) AND $path}
+    <span class="navigation-pipe"{if isset($category) && isset($category->id_category) && $category->id_category == (int)Configuration::get('PS_ROOT_CATEGORY')} style="display:none;"{/if}>{$navigationPipe|escape:'html':'UTF-8'}</span>
+    {if $path|strpos:'span' !== false}
+      <span class="navigation_page">{$path|@replace:'<a ': '<span itemscope itemtype="http://data-vocabulary.org/Breadcrumb"><a itemprop="url" '|@replace:'data-gg="">': '><span itemprop="title">'|@replace:'</a>': '</span></a></span>'}</span>
+    {else}
+      {$path}
     {/if}
+  {/if}
 </div>
 {if isset($smarty.get.search_query) && isset($smarty.get.results) && $smarty.get.results > 1 && isset($smarty.server.HTTP_REFERER)}
-<div class="pull-right">
+  <div class="pull-right">
     <strong>
-        {capture}{if isset($smarty.get.HTTP_REFERER) && $smarty.get.HTTP_REFERER}{$smarty.get.HTTP_REFERER}{elseif isset($smarty.server.HTTP_REFERER) && $smarty.server.HTTP_REFERER}{$smarty.server.HTTP_REFERER}{/if}{/capture}
-        <a href="{$smarty.capture.default|escape:'html':'UTF-8'|secureReferrer|regex_replace:'/[\?|&]content_only=1/':''}" name="back">
-            <i class="icon-chevron-left left"></i> {l s='Back to Search results for "%s" (%d other results)' sprintf=[$smarty.get.search_query,$smarty.get.results]}
-        </a>
+      {capture}{if isset($smarty.get.HTTP_REFERER) && $smarty.get.HTTP_REFERER}{$smarty.get.HTTP_REFERER}{elseif isset($smarty.server.HTTP_REFERER) && $smarty.server.HTTP_REFERER}{$smarty.server.HTTP_REFERER}{/if}{/capture}
+      <a href="{$smarty.capture.default|escape:'html':'UTF-8'|secureReferrer|regex_replace:'/[\?|&]content_only=1/':''}" name="back">
+        <i class="icon-chevron-left left"></i> {l s='Back to Search results for "%s" (%d other results)' sprintf=[$smarty.get.search_query,$smarty.get.results]}
+      </a>
     </strong>
-</div>
+  </div>
 {/if}
 <!-- /Breadcrumb -->

--- a/themes/community-theme-16/category-cms-tree-branch.tpl
+++ b/themes/community-theme-16/category-cms-tree-branch.tpl
@@ -24,29 +24,29 @@
 *}
 
 <li {if isset($last) && $last == 'true'}class="last"{/if}>
-    <strong><a href="{$node.link|escape:'html':'UTF-8'}" title="{$node.name|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a></strong>
-    {if isset($node.children) && $node.children|@count > 0}
-        <ul>
-        {foreach from=$node.children item=child name=categoryCmsTreeBranch}
-            {if isset($child.children) && $child.children|@count > 0 || isset($child.cms) && $child.cms|@count > 0}
-                {if $smarty.foreach.categoryCmsTreeBranch.last && $node.cms|@count == 0}
-                    {include file="$tpl_dir./category-cms-tree-branch.tpl" node=$child last='true'}
-                {else}
-                    {include file="$tpl_dir./category-cms-tree-branch.tpl" node=$child}
-                {/if}
-            {/if}
-        {/foreach}
-        {if isset($node.cms) && $node.cms|@count > 0}
-            {foreach from=$node.cms item=cms name=cmsTreeBranch}
-                <li {if $smarty.foreach.cmsTreeBranch.last}class="last"{/if} ><a href="{$cms.link|escape:'html':'UTF-8'}" title="{$cms.meta_title|escape:'html':'UTF-8'}">{$cms.meta_title|escape:'html':'UTF-8'}</a></li>
-            {/foreach}
+  <strong><a href="{$node.link|escape:'html':'UTF-8'}" title="{$node.name|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a></strong>
+  {if isset($node.children) && $node.children|@count > 0}
+    <ul>
+      {foreach from=$node.children item=child name=categoryCmsTreeBranch}
+        {if isset($child.children) && $child.children|@count > 0 || isset($child.cms) && $child.cms|@count > 0}
+          {if $smarty.foreach.categoryCmsTreeBranch.last && $node.cms|@count == 0}
+            {include file="$tpl_dir./category-cms-tree-branch.tpl" node=$child last='true'}
+          {else}
+            {include file="$tpl_dir./category-cms-tree-branch.tpl" node=$child}
+          {/if}
         {/if}
-        </ul>
-    {elseif isset($node.cms) && $node.cms|@count > 0}
-        <ul>
+      {/foreach}
+      {if isset($node.cms) && $node.cms|@count > 0}
         {foreach from=$node.cms item=cms name=cmsTreeBranch}
-            <li {if $smarty.foreach.cmsTreeBranch.last}class="last"{/if} ><a href="{$cms.link|escape:'html':'UTF-8'}" title="{$cms.meta_title|escape:'html':'UTF-8'}">{$cms.meta_title|escape:'html':'UTF-8'}</a></li>
+          <li {if $smarty.foreach.cmsTreeBranch.last}class="last"{/if} ><a href="{$cms.link|escape:'html':'UTF-8'}" title="{$cms.meta_title|escape:'html':'UTF-8'}">{$cms.meta_title|escape:'html':'UTF-8'}</a></li>
         {/foreach}
-        </ul>
-    {/if}
+      {/if}
+    </ul>
+  {elseif isset($node.cms) && $node.cms|@count > 0}
+    <ul>
+      {foreach from=$node.cms item=cms name=cmsTreeBranch}
+        <li {if $smarty.foreach.cmsTreeBranch.last}class="last"{/if} ><a href="{$cms.link|escape:'html':'UTF-8'}" title="{$cms.meta_title|escape:'html':'UTF-8'}">{$cms.meta_title|escape:'html':'UTF-8'}</a></li>
+      {/foreach}
+    </ul>
+  {/if}
 </li>

--- a/themes/community-theme-16/category-count.tpl
+++ b/themes/community-theme-16/category-count.tpl
@@ -24,15 +24,15 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {strip}
-<span class="heading-counter">
+  <span class="heading-counter">
 {if (isset($category) && $category->id == 1) OR (isset($nb_products) && $nb_products == 0)}
-    {l s='There are no products in this category.'}
+  {l s='There are no products in this category.'}
 {else}
-    {if isset($nb_products) && $nb_products == 1}
-        {l s='There is 1 product.'}
-    {elseif isset($nb_products)}
-        {l s='There are %d products.' sprintf=$nb_products}
-    {/if}
+  {if isset($nb_products) && $nb_products == 1}
+    {l s='There is 1 product.'}
+  {elseif isset($nb_products)}
+    {l s='There are %d products.' sprintf=$nb_products}
+  {/if}
 {/if}
 </span>
 {/strip}

--- a/themes/community-theme-16/category-tree-branch.tpl
+++ b/themes/community-theme-16/category-tree-branch.tpl
@@ -24,16 +24,16 @@
 *}
 
 <li {if isset($last) && $last == 'true'}class="last"{/if}>
-    <a href="{$node.link|escape:'html':'UTF-8'}" {if isset($currentCategoryId) && $node.id == $currentCategoryId}class="selected"{/if} title="{$node.desc|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a>
-    {if $node.children|@count > 0}
-        <ul>
-        {foreach from=$node.children item=child name=categoryTreeBranch}
-            {if $smarty.foreach.categoryTreeBranch.last}
-                {include file="$tpl_dir./category-tree-branch.tpl" node=$child last='true'}
-            {else}
-                {include file="$tpl_dir./category-tree-branch.tpl" node=$child last='false'}
-            {/if}
-        {/foreach}
-        </ul>
-    {/if}
+  <a href="{$node.link|escape:'html':'UTF-8'}" {if isset($currentCategoryId) && $node.id == $currentCategoryId}class="selected"{/if} title="{$node.desc|escape:'html':'UTF-8'}">{$node.name|escape:'html':'UTF-8'}</a>
+  {if $node.children|@count > 0}
+    <ul>
+      {foreach from=$node.children item=child name=categoryTreeBranch}
+        {if $smarty.foreach.categoryTreeBranch.last}
+          {include file="$tpl_dir./category-tree-branch.tpl" node=$child last='true'}
+        {else}
+          {include file="$tpl_dir./category-tree-branch.tpl" node=$child last='false'}
+        {/if}
+      {/foreach}
+    </ul>
+  {/if}
 </li>

--- a/themes/community-theme-16/category.tpl
+++ b/themes/community-theme-16/category.tpl
@@ -24,99 +24,99 @@
 *}
 {include file="$tpl_dir./errors.tpl"}
 {if isset($category)}
-    {if $category->id AND $category->active}
-        {if $scenes || $category->description || $category->id_image}
-            <div class="content_scene_cat">
-                 {if $scenes}
-                    <div class="content_scene">
-                        <!-- Scenes -->
-                        {include file="$tpl_dir./scenes.tpl" scenes=$scenes}
-                        {if $category->description}
-                            <div class="cat_desc rte">
-                            {if Tools::strlen($category->description) > 350}
-                                <div id="category_description_short">{$description_short}</div>
-                                <div id="category_description_full" class="unvisible">{$category->description}</div>
-                                <a href="{$link->getCategoryLink($category->id_category, $category->link_rewrite)|escape:'html':'UTF-8'}" class="lnk_more">{l s='More'}</a>
-                            {else}
-                                <div>{$category->description}</div>
-                            {/if}
-                            </div>
-                        {/if}
-                    </div>
+  {if $category->id AND $category->active}
+    {if $scenes || $category->description || $category->id_image}
+      <div class="content_scene_cat">
+        {if $scenes}
+          <div class="content_scene">
+            <!-- Scenes -->
+            {include file="$tpl_dir./scenes.tpl" scenes=$scenes}
+            {if $category->description}
+              <div class="cat_desc rte">
+                {if Tools::strlen($category->description) > 350}
+                  <div id="category_description_short">{$description_short}</div>
+                  <div id="category_description_full" class="unvisible">{$category->description}</div>
+                  <a href="{$link->getCategoryLink($category->id_category, $category->link_rewrite)|escape:'html':'UTF-8'}" class="lnk_more">{l s='More'}</a>
                 {else}
-                    <!-- Category image -->
-                    <div class="content_scene_cat_bg"{if $category->id_image} style="background:url({$link->getCatImageLink($category->link_rewrite, $category->id_image, 'category_default')|escape:'html':'UTF-8'}) right center no-repeat; background-size:cover; min-height:{$categorySize.height}px;"{/if}>
-                        {if $category->description}
-                            <div class="cat_desc">
-                            <span class="category-name">
-                                {strip}
-                                    {$category->name|escape:'html':'UTF-8'}
-                                    {if isset($categoryNameComplement)}
-                                        {$categoryNameComplement|escape:'html':'UTF-8'}
-                                    {/if}
-                                {/strip}
-                            </span>
-                            {if Tools::strlen($category->description) > 350}
-                                <div id="category_description_short" class="rte">{$description_short}</div>
-                                <div id="category_description_full" class="unvisible rte">{$category->description}</div>
-                                <a href="{$link->getCategoryLink($category->id_category, $category->link_rewrite)|escape:'html':'UTF-8'}" class="lnk_more">{l s='More'}</a>
-                            {else}
-                                <div class="rte">{$category->description}</div>
-                            {/if}
-                            </div>
-                        {/if}
-                     </div>
-                  {/if}
-            </div>
+                  <div>{$category->description}</div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {else}
+          <!-- Category image -->
+          <div class="content_scene_cat_bg"{if $category->id_image} style="background:url({$link->getCatImageLink($category->link_rewrite, $category->id_image, 'category_default')|escape:'html':'UTF-8'}) right center no-repeat; background-size:cover; min-height:{$categorySize.height}px;"{/if}>
+            {if $category->description}
+              <div class="cat_desc">
+                <span class="category-name">
+                  {strip}
+                    {$category->name|escape:'html':'UTF-8'}
+                    {if isset($categoryNameComplement)}
+                      {$categoryNameComplement|escape:'html':'UTF-8'}
+                    {/if}
+                  {/strip}
+                </span>
+                {if Tools::strlen($category->description) > 350}
+                  <div id="category_description_short" class="rte">{$description_short}</div>
+                  <div id="category_description_full" class="unvisible rte">{$category->description}</div>
+                  <a href="{$link->getCategoryLink($category->id_category, $category->link_rewrite)|escape:'html':'UTF-8'}" class="lnk_more">{l s='More'}</a>
+                {else}
+                  <div class="rte">{$category->description}</div>
+                {/if}
+              </div>
+            {/if}
+          </div>
         {/if}
-        <h1 class="page-heading{if (isset($subcategories) && !$products) || (isset($subcategories) && $products) || !isset($subcategories) && $products} product-listing{/if}"><span class="cat-name">{$category->name|escape:'html':'UTF-8'}{if isset($categoryNameComplement)}&nbsp;{$categoryNameComplement|escape:'html':'UTF-8'}{/if}</span>{include file="$tpl_dir./category-count.tpl"}</h1>
-        {if isset($subcategories)}
-        {if (isset($display_subcategories) && $display_subcategories eq 1) || !isset($display_subcategories) }
+      </div>
+    {/if}
+    <h1 class="page-heading{if (isset($subcategories) && !$products) || (isset($subcategories) && $products) || !isset($subcategories) && $products} product-listing{/if}"><span class="cat-name">{$category->name|escape:'html':'UTF-8'}{if isset($categoryNameComplement)}&nbsp;{$categoryNameComplement|escape:'html':'UTF-8'}{/if}</span>{include file="$tpl_dir./category-count.tpl"}</h1>
+    {if isset($subcategories)}
+      {if (isset($display_subcategories) && $display_subcategories eq 1) || !isset($display_subcategories) }
         <!-- Subcategories -->
         <div id="subcategories">
-            <p class="subcategory-heading">{l s='Subcategories'}</p>
-            <ul class="clearfix">
+          <p class="subcategory-heading">{l s='Subcategories'}</p>
+          <ul class="clearfix">
             {foreach from=$subcategories item=subcategory}
-                <li>
-                    <div class="subcategory-image">
-                        <a href="{$link->getCategoryLink($subcategory.id_category, $subcategory.link_rewrite)|escape:'html':'UTF-8'}" title="{$subcategory.name|escape:'html':'UTF-8'}" class="img">
-                        {if $subcategory.id_image}
-                            <img class="replace-2x" src="{$link->getCatImageLink($subcategory.link_rewrite, $subcategory.id_image, 'medium_default')|escape:'html':'UTF-8'}" alt="{$subcategory.name|escape:'html':'UTF-8'}" width="{$mediumSize.width}" height="{$mediumSize.height}" />
-                        {else}
-                            <img class="replace-2x" src="{$img_cat_dir}{$lang_iso}-default-medium_default.jpg" alt="{$subcategory.name|escape:'html':'UTF-8'}" width="{$mediumSize.width}" height="{$mediumSize.height}" />
-                        {/if}
-                    </a>
-                    </div>
-                    <h5><a class="subcategory-name" href="{$link->getCategoryLink($subcategory.id_category, $subcategory.link_rewrite)|escape:'html':'UTF-8'}">{$subcategory.name|truncate:25:'...'|escape:'html':'UTF-8'}</a></h5>
-                    {if $subcategory.description}
-                        <div class="cat_desc">{$subcategory.description}</div>
+              <li>
+                <div class="subcategory-image">
+                  <a href="{$link->getCategoryLink($subcategory.id_category, $subcategory.link_rewrite)|escape:'html':'UTF-8'}" title="{$subcategory.name|escape:'html':'UTF-8'}" class="img">
+                    {if $subcategory.id_image}
+                      <img class="replace-2x" src="{$link->getCatImageLink($subcategory.link_rewrite, $subcategory.id_image, 'medium_default')|escape:'html':'UTF-8'}" alt="{$subcategory.name|escape:'html':'UTF-8'}" width="{$mediumSize.width}" height="{$mediumSize.height}" />
+                    {else}
+                      <img class="replace-2x" src="{$img_cat_dir}{$lang_iso}-default-medium_default.jpg" alt="{$subcategory.name|escape:'html':'UTF-8'}" width="{$mediumSize.width}" height="{$mediumSize.height}" />
                     {/if}
-                </li>
+                  </a>
+                </div>
+                <h5><a class="subcategory-name" href="{$link->getCategoryLink($subcategory.id_category, $subcategory.link_rewrite)|escape:'html':'UTF-8'}">{$subcategory.name|truncate:25:'...'|escape:'html':'UTF-8'}</a></h5>
+                {if $subcategory.description}
+                  <div class="cat_desc">{$subcategory.description}</div>
+                {/if}
+              </li>
             {/foreach}
-            </ul>
+          </ul>
         </div>
-        {/if}
-        {/if}
-        {if $products}
-            <div class="content_sortPagiBar clearfix">
-                <div class="sortPagiBar clearfix">
-                    {include file="./product-sort.tpl"}
-                    {include file="./nbr-product-page.tpl"}
-                </div>
-                <div class="top-pagination-content clearfix">
-                    {include file="./product-compare.tpl"}
-                    {include file="$tpl_dir./pagination.tpl"}
-                </div>
-            </div>
-            {include file="./product-list.tpl" products=$products}
-            <div class="content_sortPagiBar">
-                <div class="bottom-pagination-content clearfix">
-                    {include file="./product-compare.tpl" paginationId='bottom'}
-                    {include file="./pagination.tpl" paginationId='bottom'}
-                </div>
-            </div>
-        {/if}
-    {elseif $category->id}
-        <p class="alert alert-warning">{l s='This category is currently unavailable.'}</p>
+      {/if}
     {/if}
+    {if $products}
+      <div class="content_sortPagiBar clearfix">
+        <div class="sortPagiBar clearfix">
+          {include file="./product-sort.tpl"}
+          {include file="./nbr-product-page.tpl"}
+        </div>
+        <div class="top-pagination-content clearfix">
+          {include file="./product-compare.tpl"}
+          {include file="$tpl_dir./pagination.tpl"}
+        </div>
+      </div>
+      {include file="./product-list.tpl" products=$products}
+      <div class="content_sortPagiBar">
+        <div class="bottom-pagination-content clearfix">
+          {include file="./product-compare.tpl" paginationId='bottom'}
+          {include file="./pagination.tpl" paginationId='bottom'}
+        </div>
+      </div>
+    {/if}
+  {elseif $category->id}
+    <p class="alert alert-warning">{l s='This category is currently unavailable.'}</p>
+  {/if}
 {/if}

--- a/themes/community-theme-16/cms.tpl
+++ b/themes/community-theme-16/cms.tpl
@@ -23,60 +23,60 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($cms) && !isset($cms_category)}
-    {if !$cms->active}
-        <br />
-        <div id="admin-action-cms">
-            <p>
-                <span>{l s='This CMS page is not visible to your customers.'}</span>
-                <input type="hidden" id="admin-action-cms-id" value="{$cms->id}" />
-                <input type="submit" value="{l s='Publish'}" name="publish_button" class="button btn btn-default"/>
-                <input type="submit" value="{l s='Back'}" name="lnk_view" class="button btn btn-default"/>
-            </p>
-            <div class="clear" ></div>
-            <p id="admin-action-result"></p>
-        </div>
-    {/if}
-    <div class="rte{if $content_only} content_only{/if}">
-        {$cms->content}
+  {if !$cms->active}
+    <br />
+    <div id="admin-action-cms">
+      <p>
+        <span>{l s='This CMS page is not visible to your customers.'}</span>
+        <input type="hidden" id="admin-action-cms-id" value="{$cms->id}" />
+        <input type="submit" value="{l s='Publish'}" name="publish_button" class="button btn btn-default"/>
+        <input type="submit" value="{l s='Back'}" name="lnk_view" class="button btn btn-default"/>
+      </p>
+      <div class="clear" ></div>
+      <p id="admin-action-result"></p>
     </div>
+  {/if}
+  <div class="rte{if $content_only} content_only{/if}">
+    {$cms->content}
+  </div>
 {elseif isset($cms_category)}
-    <div class="block-cms">
-        <h1><a href="{if $cms_category->id eq 1}{$base_dir}{else}{$link->getCMSCategoryLink($cms_category->id, $cms_category->link_rewrite)}{/if}">{$cms_category->name|escape:'html':'UTF-8'}</a></h1>
-        {if $cms_category->description}
-            <p>{$cms_category->description|escape:'html':'UTF-8'}</p>
-        {/if}
-        {if isset($sub_category) && !empty($sub_category)}
-            <p class="title_block">{l s='List of sub categories in %s:' sprintf=$cms_category->name}</p>
-            <ul class="bullet list-group">
-                {foreach from=$sub_category item=subcategory}
-                    <li>
-                        <a class="list-group-item" href="{$link->getCMSCategoryLink($subcategory.id_cms_category, $subcategory.link_rewrite)|escape:'html':'UTF-8'}">{$subcategory.name|escape:'html':'UTF-8'}</a>
-                    </li>
-                {/foreach}
-            </ul>
-        {/if}
-        {if isset($cms_pages) && !empty($cms_pages)}
-        <p class="title_block">{l s='List of pages in %s:' sprintf=$cms_category->name}</p>
-            <ul class="bullet list-group">
-                {foreach from=$cms_pages item=cmspages}
-                    <li>
-                        <a class="list-group-item" href="{$link->getCMSLink($cmspages.id_cms, $cmspages.link_rewrite)|escape:'html':'UTF-8'}">{$cmspages.meta_title|escape:'html':'UTF-8'}</a>
-                    </li>
-                {/foreach}
-            </ul>
-        {/if}
-    </div>
+  <div class="block-cms">
+    <h1><a href="{if $cms_category->id eq 1}{$base_dir}{else}{$link->getCMSCategoryLink($cms_category->id, $cms_category->link_rewrite)}{/if}">{$cms_category->name|escape:'html':'UTF-8'}</a></h1>
+    {if $cms_category->description}
+      <p>{$cms_category->description|escape:'html':'UTF-8'}</p>
+    {/if}
+    {if isset($sub_category) && !empty($sub_category)}
+      <p class="title_block">{l s='List of sub categories in %s:' sprintf=$cms_category->name}</p>
+      <ul class="bullet list-group">
+        {foreach from=$sub_category item=subcategory}
+          <li>
+            <a class="list-group-item" href="{$link->getCMSCategoryLink($subcategory.id_cms_category, $subcategory.link_rewrite)|escape:'html':'UTF-8'}">{$subcategory.name|escape:'html':'UTF-8'}</a>
+          </li>
+        {/foreach}
+      </ul>
+    {/if}
+    {if isset($cms_pages) && !empty($cms_pages)}
+      <p class="title_block">{l s='List of pages in %s:' sprintf=$cms_category->name}</p>
+      <ul class="bullet list-group">
+        {foreach from=$cms_pages item=cmspages}
+          <li>
+            <a class="list-group-item" href="{$link->getCMSLink($cmspages.id_cms, $cmspages.link_rewrite)|escape:'html':'UTF-8'}">{$cmspages.meta_title|escape:'html':'UTF-8'}</a>
+          </li>
+        {/foreach}
+      </ul>
+    {/if}
+  </div>
 {else}
-    <div class="alert alert-danger">
-        {l s='This page does not exist.'}
-    </div>
+  <div class="alert alert-danger">
+    {l s='This page does not exist.'}
+  </div>
 {/if}
 <br />
 {strip}
-{if isset($smarty.get.ad) && $smarty.get.ad}
-{addJsDefL name=ad}{$base_dir|cat:$smarty.get.ad|escape:'html':'UTF-8'}{/addJsDefL}
-{/if}
-{if isset($smarty.get.adtoken) && $smarty.get.adtoken}
-{addJsDefL name=adtoken}{$smarty.get.adtoken|escape:'html':'UTF-8'}{/addJsDefL}
-{/if}
+  {if isset($smarty.get.ad) && $smarty.get.ad}
+    {addJsDefL name=ad}{$base_dir|cat:$smarty.get.ad|escape:'html':'UTF-8'}{/addJsDefL}
+  {/if}
+  {if isset($smarty.get.adtoken) && $smarty.get.adtoken}
+    {addJsDefL name=adtoken}{$smarty.get.adtoken|escape:'html':'UTF-8'}{/addJsDefL}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/contact-form.tpl
+++ b/themes/community-theme-16/contact-form.tpl
@@ -24,132 +24,132 @@
 *}
 {capture name=path}{l s='Contact'}{/capture}
 <h1 class="page-heading bottom-indent">
-    {l s='Customer service'} - {if isset($customerThread) && $customerThread}{l s='Your reply'}{else}{l s='Contact us'}{/if}
+  {l s='Customer service'} - {if isset($customerThread) && $customerThread}{l s='Your reply'}{else}{l s='Contact us'}{/if}
 </h1>
 {if isset($confirmation)}
-    <p class="alert alert-success">{l s='Your message has been successfully sent to our team.'}</p>
-    <ul class="footer_links clearfix">
-        <li>
-            <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-                <span>
-                    <i class="icon-chevron-left"></i>{l s='Home'}
-                </span>
-            </a>
-        </li>
-    </ul>
+  <p class="alert alert-success">{l s='Your message has been successfully sent to our team.'}</p>
+  <ul class="footer_links clearfix">
+    <li>
+      <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+        <span>
+          <i class="icon-chevron-left"></i>{l s='Home'}
+        </span>
+      </a>
+    </li>
+  </ul>
 {elseif isset($alreadySent)}
-    <p class="alert alert-warning">{l s='Your message has already been sent.'}</p>
-    <ul class="footer_links clearfix">
-        <li>
-            <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-                <span>
-                    <i class="icon-chevron-left"></i>{l s='Home'}
-                </span>
-            </a>
-        </li>
-    </ul>
+  <p class="alert alert-warning">{l s='Your message has already been sent.'}</p>
+  <ul class="footer_links clearfix">
+    <li>
+      <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+        <span>
+          <i class="icon-chevron-left"></i>{l s='Home'}
+        </span>
+      </a>
+    </li>
+  </ul>
 {else}
-    {include file="$tpl_dir./errors.tpl"}
-    <form action="{$request_uri}" method="post" class="contact-form-box" enctype="multipart/form-data">
-        <fieldset>
-            <h3 class="page-subheading">{l s='send a message'}</h3>
-            <div class="clearfix">
-                <div class="col-xs-12 col-md-3">
-                    <div class="form-group selector1">
-                        <label for="id_contact">{l s='Subject Heading'}</label>
-                    {if isset($customerThread.id_contact) && $customerThread.id_contact && $contacts|count}
-                            {assign var=flag value=true}
-                            {foreach from=$contacts item=contact}
-                                {if $contact.id_contact == $customerThread.id_contact}
-                                    <input type="text" class="form-control" id="contact_name" name="contact_name" value="{$contact.name|escape:'html':'UTF-8'}" readonly="readonly" />
-                                    <input type="hidden" name="id_contact" value="{$contact.id_contact|intval}" />
-                                    {$flag=false}
-                                {/if}
-                            {/foreach}
-                            {if $flag && isset($contacts.0.id_contact)}
-                                    <input type="text" class="form-control" id="contact_name" name="contact_name" value="{$contacts.0.name|escape:'html':'UTF-8'}" readonly="readonly" />
-                                    <input type="hidden" name="id_contact" value="{$contacts.0.id_contact|intval}" />
-                            {/if}
-                    </div>
-                    {else}
-                        <select id="id_contact" class="form-control" name="id_contact">
-                            <option value="0">{l s='-- Choose --'}</option>
-                            {foreach from=$contacts item=contact}
-                                <option value="{$contact.id_contact|intval}"{if isset($smarty.request.id_contact) && $smarty.request.id_contact == $contact.id_contact} selected="selected"{/if}>{$contact.name|escape:'html':'UTF-8'}</option>
-                            {/foreach}
-                        </select>
-                    </div>
-                        <p id="desc_contact0" class="desc_contact{if isset($smarty.request.id_contact)} unvisible{/if}">&nbsp;</p>
-                        {foreach from=$contacts item=contact}
-                            <p id="desc_contact{$contact.id_contact|intval}" class="desc_contact contact-title{if !isset($smarty.request.id_contact) || $smarty.request.id_contact|intval != $contact.id_contact|intval} unvisible{/if}">
-                                <i class="icon-comment-alt"></i>{$contact.description|escape:'html':'UTF-8'}
-                            </p>
-                        {/foreach}
-                    {/if}
-                    <p class="form-group">
-                        <label for="email">{l s='Email address'}</label>
-                        {if isset($customerThread.email)}
-                            <input class="form-control grey" type="text" id="email" name="from" value="{$customerThread.email|escape:'html':'UTF-8'}" readonly="readonly" />
-                        {else}
-                            <input class="form-control grey validate" type="text" id="email" name="from" data-validate="isEmail" value="{$email|escape:'html':'UTF-8'}" />
-                        {/if}
-                    </p>
-                    {if !$PS_CATALOG_MODE}
-                        {if (!isset($customerThread.id_order) || $customerThread.id_order > 0)}
-                            <div class="form-group selector1">
-                                <label>{l s='Order reference'}</label>
-                                {if !isset($customerThread.id_order) && isset($is_logged) && $is_logged}
-                                    <select name="id_order" class="form-control">
-                                        <option value="0">{l s='-- Choose --'}</option>
-                                        {foreach from=$orderList item=order}
-                                            <option value="{$order.value|intval}"{if $order.selected|intval} selected="selected"{/if}>{$order.label|escape:'html':'UTF-8'}</option>
-                                        {/foreach}
-                                    </select>
-                                {elseif !isset($customerThread.id_order) && empty($is_logged)}
-                                    <input class="form-control grey" type="text" name="id_order" id="id_order" value="{if isset($customerThread.id_order) && $customerThread.id_order|intval > 0}{$customerThread.id_order|intval}{else}{if isset($smarty.post.id_order) && !empty($smarty.post.id_order)}{$smarty.post.id_order|escape:'html':'UTF-8'}{/if}{/if}" />
-                                {elseif $customerThread.id_order|intval > 0}
-                                    <input class="form-control grey" type="text" name="id_order" id="id_order" value="{if isset($customerThread.reference) && $customerThread.reference}{$customerThread.reference|escape:'html':'UTF-8'}{else}{$customerThread.id_order|intval}{/if}" readonly="readonly" />
-                                {/if}
-                            </div>
-                        {/if}
-                        {if isset($is_logged) && $is_logged}
-                            <div class="form-group selector1">
-                                <label class="unvisible">{l s='Product'}</label>
-                                {if !isset($customerThread.id_product)}
-                                    {foreach from=$orderedProductList key=id_order item=products name=products}
-                                        <select name="id_product" id="{$id_order}_order_products" class="unvisible product_select form-control"{if !$smarty.foreach.products.first} style="display:none;"{/if}{if !$smarty.foreach.products.first} disabled="disabled"{/if}>
-                                            <option value="0">{l s='-- Choose --'}</option>
-                                            {foreach from=$products item=product}
-                                                <option value="{$product.value|intval}">{$product.label|escape:'html':'UTF-8'}</option>
-                                            {/foreach}
-                                        </select>
-                                    {/foreach}
-                                {elseif $customerThread.id_product > 0}
-                                    <input  type="hidden" name="id_product" id="id_product" value="{$customerThread.id_product|intval}" readonly="readonly" />
-                                {/if}
-                            </div>
-                        {/if}
-                    {/if}
-                    {if $fileupload == 1}
-                        <p class="form-group">
-                            <label for="fileUpload">{l s='Attach File'}</label>
-                            <input type="hidden" name="MAX_FILE_SIZE" value="{if isset($max_upload_size) && $max_upload_size}{$max_upload_size|intval}{else}2000000{/if}" />
-                            <input type="file" name="fileUpload" id="fileUpload" class="form-control" />
-                        </p>
-                    {/if}
-                </div>
-                <div class="col-xs-12 col-md-9">
-                    <div class="form-group">
-                        <label for="message">{l s='Message'}</label>
-                        <textarea class="form-control" id="message" name="message">{if isset($message)}{$message|escape:'html':'UTF-8'|stripslashes}{/if}</textarea>
-                    </div>
-                </div>
+  {include file="$tpl_dir./errors.tpl"}
+  <form action="{$request_uri}" method="post" class="contact-form-box" enctype="multipart/form-data">
+    <fieldset>
+      <h3 class="page-subheading">{l s='send a message'}</h3>
+      <div class="clearfix">
+        <div class="col-xs-12 col-md-3">
+          <div class="form-group selector1">
+            <label for="id_contact">{l s='Subject Heading'}</label>
+            {if isset($customerThread.id_contact) && $customerThread.id_contact && $contacts|count}
+            {assign var=flag value=true}
+            {foreach from=$contacts item=contact}
+              {if $contact.id_contact == $customerThread.id_contact}
+                <input type="text" class="form-control" id="contact_name" name="contact_name" value="{$contact.name|escape:'html':'UTF-8'}" readonly="readonly" />
+                <input type="hidden" name="id_contact" value="{$contact.id_contact|intval}" />
+                {$flag=false}
+              {/if}
+            {/foreach}
+            {if $flag && isset($contacts.0.id_contact)}
+              <input type="text" class="form-control" id="contact_name" name="contact_name" value="{$contacts.0.name|escape:'html':'UTF-8'}" readonly="readonly" />
+              <input type="hidden" name="id_contact" value="{$contacts.0.id_contact|intval}" />
+            {/if}
+          </div>
+          {else}
+          <select id="id_contact" class="form-control" name="id_contact">
+            <option value="0">{l s='-- Choose --'}</option>
+            {foreach from=$contacts item=contact}
+              <option value="{$contact.id_contact|intval}"{if isset($smarty.request.id_contact) && $smarty.request.id_contact == $contact.id_contact} selected="selected"{/if}>{$contact.name|escape:'html':'UTF-8'}</option>
+            {/foreach}
+          </select>
+        </div>
+        <p id="desc_contact0" class="desc_contact{if isset($smarty.request.id_contact)} unvisible{/if}">&nbsp;</p>
+        {foreach from=$contacts item=contact}
+          <p id="desc_contact{$contact.id_contact|intval}" class="desc_contact contact-title{if !isset($smarty.request.id_contact) || $smarty.request.id_contact|intval != $contact.id_contact|intval} unvisible{/if}">
+            <i class="icon-comment-alt"></i>{$contact.description|escape:'html':'UTF-8'}
+          </p>
+        {/foreach}
+        {/if}
+        <p class="form-group">
+          <label for="email">{l s='Email address'}</label>
+          {if isset($customerThread.email)}
+            <input class="form-control grey" type="text" id="email" name="from" value="{$customerThread.email|escape:'html':'UTF-8'}" readonly="readonly" />
+          {else}
+            <input class="form-control grey validate" type="text" id="email" name="from" data-validate="isEmail" value="{$email|escape:'html':'UTF-8'}" />
+          {/if}
+        </p>
+        {if !$PS_CATALOG_MODE}
+          {if (!isset($customerThread.id_order) || $customerThread.id_order > 0)}
+            <div class="form-group selector1">
+              <label>{l s='Order reference'}</label>
+              {if !isset($customerThread.id_order) && isset($is_logged) && $is_logged}
+                <select name="id_order" class="form-control">
+                  <option value="0">{l s='-- Choose --'}</option>
+                  {foreach from=$orderList item=order}
+                    <option value="{$order.value|intval}"{if $order.selected|intval} selected="selected"{/if}>{$order.label|escape:'html':'UTF-8'}</option>
+                  {/foreach}
+                </select>
+              {elseif !isset($customerThread.id_order) && empty($is_logged)}
+                <input class="form-control grey" type="text" name="id_order" id="id_order" value="{if isset($customerThread.id_order) && $customerThread.id_order|intval > 0}{$customerThread.id_order|intval}{else}{if isset($smarty.post.id_order) && !empty($smarty.post.id_order)}{$smarty.post.id_order|escape:'html':'UTF-8'}{/if}{/if}" />
+              {elseif $customerThread.id_order|intval > 0}
+                <input class="form-control grey" type="text" name="id_order" id="id_order" value="{if isset($customerThread.reference) && $customerThread.reference}{$customerThread.reference|escape:'html':'UTF-8'}{else}{$customerThread.id_order|intval}{/if}" readonly="readonly" />
+              {/if}
             </div>
-            <div class="submit">
-                <button type="submit" name="submitMessage" id="submitMessage" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
+          {/if}
+          {if isset($is_logged) && $is_logged}
+            <div class="form-group selector1">
+              <label class="unvisible">{l s='Product'}</label>
+              {if !isset($customerThread.id_product)}
+                {foreach from=$orderedProductList key=id_order item=products name=products}
+                  <select name="id_product" id="{$id_order}_order_products" class="unvisible product_select form-control"{if !$smarty.foreach.products.first} style="display:none;"{/if}{if !$smarty.foreach.products.first} disabled="disabled"{/if}>
+                    <option value="0">{l s='-- Choose --'}</option>
+                    {foreach from=$products item=product}
+                      <option value="{$product.value|intval}">{$product.label|escape:'html':'UTF-8'}</option>
+                    {/foreach}
+                  </select>
+                {/foreach}
+              {elseif $customerThread.id_product > 0}
+                <input  type="hidden" name="id_product" id="id_product" value="{$customerThread.id_product|intval}" readonly="readonly" />
+              {/if}
             </div>
-        </fieldset>
-    </form>
+          {/if}
+        {/if}
+        {if $fileupload == 1}
+          <p class="form-group">
+            <label for="fileUpload">{l s='Attach File'}</label>
+            <input type="hidden" name="MAX_FILE_SIZE" value="{if isset($max_upload_size) && $max_upload_size}{$max_upload_size|intval}{else}2000000{/if}" />
+            <input type="file" name="fileUpload" id="fileUpload" class="form-control" />
+          </p>
+        {/if}
+      </div>
+      <div class="col-xs-12 col-md-9">
+        <div class="form-group">
+          <label for="message">{l s='Message'}</label>
+          <textarea class="form-control" id="message" name="message">{if isset($message)}{$message|escape:'html':'UTF-8'|stripslashes}{/if}</textarea>
+        </div>
+      </div>
+      </div>
+      <div class="submit">
+        <button type="submit" name="submitMessage" id="submitMessage" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
+      </div>
+    </fieldset>
+  </form>
 {/if}
 {addJsDefL name='contact_fileDefaultHtml'}{l s='No file selected' js=1}{/addJsDefL}
 {addJsDefL name='contact_fileButtonHtml'}{l s='Choose File' js=1}{/addJsDefL}

--- a/themes/community-theme-16/discount.tpl
+++ b/themes/community-theme-16/discount.tpl
@@ -25,77 +25,77 @@
 {capture name=path}<a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">{l s='My account'}</a><span class="navigation-pipe">{$navigationPipe}</span><span class="navigation_page">{l s='My vouchers'}</span>{/capture}
 
 <h1 class="page-heading">
-    {l s='My vouchers'}
+  {l s='My vouchers'}
 </h1>
 
 {if isset($cart_rules) && count($cart_rules) && $nb_cart_rules}
-    <table class="discount table table-bordered footab">
-        <thead>
-            <tr>
-                <th data-sort-ignore="true" class="discount_code first_item">{l s='Code'}</th>
-                <th data-sort-ignore="true" class="discount_description item">{l s='Description'}</th>
-                <th class="discount_quantity item">{l s='Quantity'}</th>
-                <th data-sort-ignore="true" data-hide="phone,tablet" class="discount_value item">{l s='Value'}*</th>
-                <th data-hide="phone,tablet" class="discount_minimum item">{l s='Minimum'}</th>
-                <th data-sort-ignore="true" data-hide="phone,tablet" class="discount_cumulative item">{l s='Cumulative'}</th>
-                <th data-hide="phone" class="discount_expiration_date last_item">{l s='Expiration date'}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {foreach from=$cart_rules item=discountDetail name=myLoop}
-                <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
-                    <td class="discount_code">{$discountDetail.code}</td>
-                    <td class="discount_description">{$discountDetail.name}</td>
-                    <td data-value="{$discountDetail.quantity_for_user}" class="discount_quantity">{$discountDetail.quantity_for_user}</td>
-                    <td class="discount_value">
-                        {if $discountDetail.id_discount_type == 1}
-                            {$discountDetail.value|escape:'html':'UTF-8'}%
-                        {elseif $discountDetail.id_discount_type == 2}
-                            {convertPrice price=$discountDetail.value} ({if $discountDetail.reduction_tax == 1}{l s='Tax included'}{else}{l s='Tax excluded'}{/if})
-                        {elseif $discountDetail.id_discount_type == 3}
-                            {l s='Free shipping'}
-                        {else}
-                            -
-                        {/if}
-                    </td>
-                    <td class="discount_minimum" data-value="{if $discountDetail.minimal == 0}0{else}{$discountDetail.minimal}{/if}">
-                        {if $discountDetail.minimal == 0}
-                            {l s='None'}
-                        {else}
-                            {convertPrice price=$discountDetail.minimal}
-                        {/if}
-                    </td>
-                    <td class="discount_cumulative">
-                        {if $discountDetail.cumulable == 1}
-                            <i class="icon-ok icon"></i> {l s='Yes'}
-                        {else}
-                            <i class="icon-remove icon"></i> {l s='No'}
-                        {/if}
-                    </td>
-                    <td class="discount_expiration_date" data-value="{$discountDetail.date_to|regex_replace:"/[\-\:\ ]/":""}">
-                        {dateFormat date=$discountDetail.date_to}
-                    </td>
-                </tr>
-            {/foreach}
-        </tbody>
-    </table>
+  <table class="discount table table-bordered footab">
+    <thead>
+    <tr>
+      <th data-sort-ignore="true" class="discount_code first_item">{l s='Code'}</th>
+      <th data-sort-ignore="true" class="discount_description item">{l s='Description'}</th>
+      <th class="discount_quantity item">{l s='Quantity'}</th>
+      <th data-sort-ignore="true" data-hide="phone,tablet" class="discount_value item">{l s='Value'}*</th>
+      <th data-hide="phone,tablet" class="discount_minimum item">{l s='Minimum'}</th>
+      <th data-sort-ignore="true" data-hide="phone,tablet" class="discount_cumulative item">{l s='Cumulative'}</th>
+      <th data-hide="phone" class="discount_expiration_date last_item">{l s='Expiration date'}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {foreach from=$cart_rules item=discountDetail name=myLoop}
+      <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
+        <td class="discount_code">{$discountDetail.code}</td>
+        <td class="discount_description">{$discountDetail.name}</td>
+        <td data-value="{$discountDetail.quantity_for_user}" class="discount_quantity">{$discountDetail.quantity_for_user}</td>
+        <td class="discount_value">
+          {if $discountDetail.id_discount_type == 1}
+            {$discountDetail.value|escape:'html':'UTF-8'}%
+          {elseif $discountDetail.id_discount_type == 2}
+            {convertPrice price=$discountDetail.value} ({if $discountDetail.reduction_tax == 1}{l s='Tax included'}{else}{l s='Tax excluded'}{/if})
+          {elseif $discountDetail.id_discount_type == 3}
+            {l s='Free shipping'}
+          {else}
+            -
+          {/if}
+        </td>
+        <td class="discount_minimum" data-value="{if $discountDetail.minimal == 0}0{else}{$discountDetail.minimal}{/if}">
+          {if $discountDetail.minimal == 0}
+            {l s='None'}
+          {else}
+            {convertPrice price=$discountDetail.minimal}
+          {/if}
+        </td>
+        <td class="discount_cumulative">
+          {if $discountDetail.cumulable == 1}
+            <i class="icon-ok icon"></i> {l s='Yes'}
+          {else}
+            <i class="icon-remove icon"></i> {l s='No'}
+          {/if}
+        </td>
+        <td class="discount_expiration_date" data-value="{$discountDetail.date_to|regex_replace:"/[\-\:\ ]/":""}">
+          {dateFormat date=$discountDetail.date_to}
+        </td>
+      </tr>
+    {/foreach}
+    </tbody>
+  </table>
 {else}
-    <p class="alert alert-warning">{l s='You do not have any vouchers.'}</p>
+  <p class="alert alert-warning">{l s='You do not have any vouchers.'}</p>
 {/if}
 
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Back to your account'}
-            </span>
-        </a>
-    </li>
-    <li>
-        <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Home'}
-            </span>
-        </a>
-    </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Back to your account'}
+      </span>
+    </a>
+  </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Home'}
+      </span>
+    </a>
+  </li>
 </ul>

--- a/themes/community-theme-16/errors.tpl
+++ b/themes/community-theme-16/errors.tpl
@@ -24,15 +24,15 @@
 *}
 
 {if isset($errors) && $errors}
-    <div class="alert alert-danger">
-        <p>{if $errors|@count > 1}{l s='There are %d errors' sprintf=$errors|@count}{else}{l s='There is %d error' sprintf=$errors|@count}{/if}</p>
-        <ol>
-        {foreach from=$errors key=k item=error}
-            <li>{$error}</li>
-        {/foreach}
-        </ol>
-        {if isset($smarty.server.HTTP_REFERER) && !strstr($request_uri, 'authentication') && preg_replace('#^https?://[^/]+/#', '/', $smarty.server.HTTP_REFERER) != $request_uri}
-            <p class="lnk"><a class="alert-link" href="{$smarty.server.HTTP_REFERER|escape:'html':'UTF-8'|secureReferrer}" title="{l s='Back'}">&laquo; {l s='Back'}</a></p>
-        {/if}
-    </div>
+  <div class="alert alert-danger">
+    <p>{if $errors|@count > 1}{l s='There are %d errors' sprintf=$errors|@count}{else}{l s='There is %d error' sprintf=$errors|@count}{/if}</p>
+    <ol>
+      {foreach from=$errors key=k item=error}
+        <li>{$error}</li>
+      {/foreach}
+    </ol>
+    {if isset($smarty.server.HTTP_REFERER) && !strstr($request_uri, 'authentication') && preg_replace('#^https?://[^/]+/#', '/', $smarty.server.HTTP_REFERER) != $request_uri}
+      <p class="lnk"><a class="alert-link" href="{$smarty.server.HTTP_REFERER|escape:'html':'UTF-8'|secureReferrer}" title="{l s='Back'}">&laquo; {l s='Back'}</a></p>
+    {/if}
+  </div>
 {/if}

--- a/themes/community-theme-16/footer.tpl
+++ b/themes/community-theme-16/footer.tpl
@@ -23,23 +23,23 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !isset($content_only) || !$content_only}
-                    </div><!-- #center_column -->
-                    {if isset($right_column_size) && !empty($right_column_size)}
-                        <div id="right_column" class="col-xs-12 col-sm-{$right_column_size|intval} column">{$HOOK_RIGHT_COLUMN}</div>
-                    {/if}
-                    </div><!-- .row -->
-                </div><!-- #columns -->
-            </div><!-- .columns-container -->
-            {if isset($HOOK_FOOTER)}
-                <!-- Footer -->
-                <div class="footer-container">
-                    <footer id="footer"  class="container">
-                        <div class="row">{$HOOK_FOOTER}</div>
-                    </footer>
-                </div><!-- #footer -->
-            {/if}
-        </div><!-- #page -->
+        </div><!-- #center_column -->
+        {if isset($right_column_size) && !empty($right_column_size)}
+          <div id="right_column" class="col-xs-12 col-sm-{$right_column_size|intval} column">{$HOOK_RIGHT_COLUMN}</div>
+        {/if}
+      </div><!-- .row -->
+    </div><!-- #columns -->
+  </div><!-- .columns-container -->
+  {if isset($HOOK_FOOTER)}
+    <!-- Footer -->
+    <div class="footer-container">
+      <footer id="footer"  class="container">
+        <div class="row">{$HOOK_FOOTER}</div>
+      </footer>
+    </div><!-- #footer -->
+  {/if}
+  </div><!-- #page -->
 {/if}
 {include file="$tpl_dir./global.tpl"}
-    </body>
+</body>
 </html>

--- a/themes/community-theme-16/global.tpl
+++ b/themes/community-theme-16/global.tpl
@@ -23,33 +23,33 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {strip}
-{addJsDef isMobile=$mobile_device}
-{addJsDef baseDir=$content_dir}
-{addJsDef baseUri=$base_uri}
-{addJsDef static_token=$static_token}
-{addJsDef token=$token}
-{addJsDef priceDisplayPrecision=$priceDisplayPrecision*$currency->decimals}
-{addJsDef priceDisplayMethod=$priceDisplay}
-{addJsDef roundMode=$roundMode}
-{addJsDef currency=$currency}
-{addJsDef currencyRate=$currencyRate|floatval}
-{addJsDef currencySign=$currency->sign|html_entity_decode:2:"UTF-8"}
-{addJsDef currencyFormat=$currency->format|intval}
-{addJsDef currencyBlank=$currency->blank|intval}
-{addJsDef isLogged=$is_logged|intval}
-{addJsDef isGuest=$is_guest|intval}
-{addJsDef page_name=$page_name|escape:'html':'UTF-8'}
-{addJsDef contentOnly=$content_only|boolval}
-{if isset($cookie->id_lang)}
+  {addJsDef isMobile=$mobile_device}
+  {addJsDef baseDir=$content_dir}
+  {addJsDef baseUri=$base_uri}
+  {addJsDef static_token=$static_token}
+  {addJsDef token=$token}
+  {addJsDef priceDisplayPrecision=$priceDisplayPrecision*$currency->decimals}
+  {addJsDef priceDisplayMethod=$priceDisplay}
+  {addJsDef roundMode=$roundMode}
+  {addJsDef currency=$currency}
+  {addJsDef currencyRate=$currencyRate|floatval}
+  {addJsDef currencySign=$currency->sign|html_entity_decode:2:"UTF-8"}
+  {addJsDef currencyFormat=$currency->format|intval}
+  {addJsDef currencyBlank=$currency->blank|intval}
+  {addJsDef isLogged=$is_logged|intval}
+  {addJsDef isGuest=$is_guest|intval}
+  {addJsDef page_name=$page_name|escape:'html':'UTF-8'}
+  {addJsDef contentOnly=$content_only|boolval}
+  {if isset($cookie->id_lang)}
     {addJsDef id_lang=$cookie->id_lang|intval}
-{/if}
-{addJsDefL name=FancyboxI18nClose}{l s='Close'}{/addJsDefL}
-{addJsDefL name=FancyboxI18nNext}{l s='Next'}{/addJsDefL}
-{addJsDefL name=FancyboxI18nPrev}{l s='Previous'}{/addJsDefL}
-{addJsDef usingSecureMode=Tools::usingSecureMode()|boolval}
-{addJsDef ajaxsearch=Configuration::get('PS_SEARCH_AJAX')|boolval}
-{addJsDef instantsearch=Configuration::get('PS_INSTANT_SEARCH')|boolval}
-{addJsDef quickView=$quick_view|boolval}
-{addJsDef displayList=Configuration::get('PS_GRID_PRODUCT')|boolval}
-{addJsDef highDPI=Configuration::get('PS_HIGHT_DPI')|boolval}
+  {/if}
+  {addJsDefL name=FancyboxI18nClose}{l s='Close'}{/addJsDefL}
+  {addJsDefL name=FancyboxI18nNext}{l s='Next'}{/addJsDefL}
+  {addJsDefL name=FancyboxI18nPrev}{l s='Previous'}{/addJsDefL}
+  {addJsDef usingSecureMode=Tools::usingSecureMode()|boolval}
+  {addJsDef ajaxsearch=Configuration::get('PS_SEARCH_AJAX')|boolval}
+  {addJsDef instantsearch=Configuration::get('PS_INSTANT_SEARCH')|boolval}
+  {addJsDef quickView=$quick_view|boolval}
+  {addJsDef displayList=Configuration::get('PS_GRID_PRODUCT')|boolval}
+  {addJsDef highDPI=Configuration::get('PS_HIGHT_DPI')|boolval}
 {/strip}

--- a/themes/community-theme-16/guest-tracking.tpl
+++ b/themes/community-theme-16/guest-tracking.tpl
@@ -28,93 +28,93 @@
 <h1 class="page-heading">{l s='Guest Tracking'}</h1>
 
 {if isset($order_collection)}
-    {foreach $order_collection as $order}
-        {assign var=order_state value=$order->getCurrentState()}
-        {assign var=invoice value=$order->invoice}
-        {assign var=order_history value=$order->order_history}
-        {assign var=carrier value=$order->carrier}
-        {assign var=address_invoice value=$order->address_invoice}
-        {assign var=address_delivery value=$order->address_delivery}
-        {assign var=inv_adr_fields value=$order->inv_adr_fields}
-        {assign var=dlv_adr_fields value=$order->dlv_adr_fields}
-        {assign var=invoiceAddressFormatedValues value=$order->invoiceAddressFormatedValues}
-        {assign var=deliveryAddressFormatedValues value=$order->deliveryAddressFormatedValues}
-        {assign var=currency value=$order->currency}
-        {assign var=discounts value=$order->discounts}
-        {assign var=invoiceState value=$order->invoiceState}
-        {assign var=deliveryState value=$order->deliveryState}
-        {assign var=products value=$order->products}
-        {assign var=customizedDatas value=$order->customizedDatas}
-        {assign var=HOOK_ORDERDETAILDISPLAYED value=$order->hook_orderdetaildisplayed}
-        {if isset($order->total_old)}
-            {assign var=total_old value=$order->total_old}
-        {/if}
-        {if isset($order->followup)}
-            {assign var=followup value=$order->followup}
-        {/if}
+  {foreach $order_collection as $order}
+    {assign var=order_state value=$order->getCurrentState()}
+    {assign var=invoice value=$order->invoice}
+    {assign var=order_history value=$order->order_history}
+    {assign var=carrier value=$order->carrier}
+    {assign var=address_invoice value=$order->address_invoice}
+    {assign var=address_delivery value=$order->address_delivery}
+    {assign var=inv_adr_fields value=$order->inv_adr_fields}
+    {assign var=dlv_adr_fields value=$order->dlv_adr_fields}
+    {assign var=invoiceAddressFormatedValues value=$order->invoiceAddressFormatedValues}
+    {assign var=deliveryAddressFormatedValues value=$order->deliveryAddressFormatedValues}
+    {assign var=currency value=$order->currency}
+    {assign var=discounts value=$order->discounts}
+    {assign var=invoiceState value=$order->invoiceState}
+    {assign var=deliveryState value=$order->deliveryState}
+    {assign var=products value=$order->products}
+    {assign var=customizedDatas value=$order->customizedDatas}
+    {assign var=HOOK_ORDERDETAILDISPLAYED value=$order->hook_orderdetaildisplayed}
+    {if isset($order->total_old)}
+      {assign var=total_old value=$order->total_old}
+    {/if}
+    {if isset($order->followup)}
+      {assign var=followup value=$order->followup}
+    {/if}
 
-        <div id="block-history">
-            <div id="block-order-detail" class="std">
-            {include file="./order-detail.tpl"}
+    <div id="block-history">
+      <div id="block-order-detail" class="std">
+        {include file="./order-detail.tpl"}
+      </div>
+    </div>
+  {/foreach}
+
+  <h2 id="guestToCustomer" class="page-heading">{l s='For more advantages...'}</h2>
+
+  {include file="$tpl_dir./errors.tpl"}
+
+  {if isset($transformSuccess)}
+    <p class="alert alert-success">{l s='Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper. '} <a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}">{l s='Log in now.'}</a></p>
+  {else}
+    <form method="post" action="{$action|escape:'html':'UTF-8'}#guestToCustomer" class="std">
+      <fieldset class="description_box box">
+
+        <p><strong class="dark">{l s='Transform your guest account into a customer account and enjoy:'}</strong></p>
+        <ul>
+          <li> -{l s='Personalized and secure access'}</li>
+          <li> -{l s='Fast and easy checkout'}</li>
+          <li> -{l s='Easier merchandise return'}</li>
+        </ul>
+        <div class="row">
+          <div class="col-xs-12 col-sm-5 col-md-4 col-lg-3">
+            <div class="text form-group">
+              <label><strong class="dark">{l s='Set your password:'}</strong></label>
+              <input type="password" name="password" class="form-control" />
             </div>
+          </div>
         </div>
-    {/foreach}
 
-    <h2 id="guestToCustomer" class="page-heading">{l s='For more advantages...'}</h2>
+        <input type="hidden" name="id_order" value="{if isset($order->id)}{$order->id}{else}{if isset($smarty.get.id_order)}{$smarty.get.id_order|escape:'html':'UTF-8'}{else}{if isset($smarty.post.id_order)}{$smarty.post.id_order|escape:'html':'UTF-8'}{/if}{/if}{/if}" />
+        <input type="hidden" name="order_reference" value="{if isset($smarty.get.order_reference)}{$smarty.get.order_reference|escape:'html':'UTF-8'}{else}{if isset($smarty.post.order_reference)}{$smarty.post.order_reference|escape:'html':'UTF-8'}{/if}{/if}" />
+        <input type="hidden" name="email" value="{if isset($smarty.get.email)}{$smarty.get.email|escape:'html':'UTF-8'}{else}{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'}{/if}{/if}" />
 
-    {include file="$tpl_dir./errors.tpl"}
-
-    {if isset($transformSuccess)}
-        <p class="alert alert-success">{l s='Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper. '} <a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}">{l s='Log in now.'}</a></p>
-    {else}
-        <form method="post" action="{$action|escape:'html':'UTF-8'}#guestToCustomer" class="std">
-            <fieldset class="description_box box">
-
-                <p><strong class="dark">{l s='Transform your guest account into a customer account and enjoy:'}</strong></p>
-                <ul>
-                    <li> -{l s='Personalized and secure access'}</li>
-                    <li> -{l s='Fast and easy checkout'}</li>
-                    <li> -{l s='Easier merchandise return'}</li>
-                </ul>
-                <div class="row">
-                    <div class="col-xs-12 col-sm-5 col-md-4 col-lg-3">
-                        <div class="text form-group">
-                            <label><strong class="dark">{l s='Set your password:'}</strong></label>
-                            <input type="password" name="password" class="form-control" />
-                        </div>
-                    </div>
-                </div>
-
-                <input type="hidden" name="id_order" value="{if isset($order->id)}{$order->id}{else}{if isset($smarty.get.id_order)}{$smarty.get.id_order|escape:'html':'UTF-8'}{else}{if isset($smarty.post.id_order)}{$smarty.post.id_order|escape:'html':'UTF-8'}{/if}{/if}{/if}" />
-                <input type="hidden" name="order_reference" value="{if isset($smarty.get.order_reference)}{$smarty.get.order_reference|escape:'html':'UTF-8'}{else}{if isset($smarty.post.order_reference)}{$smarty.post.order_reference|escape:'html':'UTF-8'}{/if}{/if}" />
-                <input type="hidden" name="email" value="{if isset($smarty.get.email)}{$smarty.get.email|escape:'html':'UTF-8'}{else}{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'}{/if}{/if}" />
-
-                <p>
-                    <button type="submit" name="submitTransformGuestToCustomer" class="button button-medium btn btn-default"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
-                </p>
-            </fieldset>
-        </form>
-    {/if}
-{else}
-    {include file="$tpl_dir./errors.tpl"}
-    {if isset($show_login_link) && $show_login_link}
-        <p><img src="{$img_dir}icon/userinfo.gif" alt="{l s='Information'}" class="icon" /><a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">{l s='Click here to log in to your customer account.'}</a><br /><br /></p>
-    {/if}
-    <form method="post" action="{$action|escape:'html':'UTF-8'}" class="std" id="guestTracking">
-        <fieldset class="description_box box">
-            <h2 class="page-subheading">{l s='To track your order, please enter the following information:'}</h2>
-                    <div class="text form-group">
-                        <label>{l s='Order Reference:'} </label>
-                        <input class="form-control" type="text" name="order_reference" value="{if isset($smarty.get.id_order)}{$smarty.get.id_order|escape:'html':'UTF-8'}{else}{if isset($smarty.post.id_order)}{$smarty.post.id_order|escape:'html':'UTF-8'}{/if}{/if}" size="8" />
-                        <i>{l s='For example: QIIXJXNUI or QIIXJXNUI#1'}</i>
-                    </div>
-                    <div class="text form-group">
-                        <label>{l s='Email:'}</label>
-                        <input class="form-control" type="email" name="email" value="{if isset($smarty.get.email)}{$smarty.get.email|escape:'html':'UTF-8'}{else}{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'}{/if}{/if}" />
-                    </div>
-            <p>
-                <button type="submit" name="submitGuestTracking" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
-            </p>
-        </fieldset>
+        <p>
+          <button type="submit" name="submitTransformGuestToCustomer" class="button button-medium btn btn-default"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
+        </p>
+      </fieldset>
     </form>
+  {/if}
+{else}
+  {include file="$tpl_dir./errors.tpl"}
+  {if isset($show_login_link) && $show_login_link}
+    <p><img src="{$img_dir}icon/userinfo.gif" alt="{l s='Information'}" class="icon" /><a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">{l s='Click here to log in to your customer account.'}</a><br /><br /></p>
+  {/if}
+  <form method="post" action="{$action|escape:'html':'UTF-8'}" class="std" id="guestTracking">
+    <fieldset class="description_box box">
+      <h2 class="page-subheading">{l s='To track your order, please enter the following information:'}</h2>
+      <div class="text form-group">
+        <label>{l s='Order Reference:'} </label>
+        <input class="form-control" type="text" name="order_reference" value="{if isset($smarty.get.id_order)}{$smarty.get.id_order|escape:'html':'UTF-8'}{else}{if isset($smarty.post.id_order)}{$smarty.post.id_order|escape:'html':'UTF-8'}{/if}{/if}" size="8" />
+        <i>{l s='For example: QIIXJXNUI or QIIXJXNUI#1'}</i>
+      </div>
+      <div class="text form-group">
+        <label>{l s='Email:'}</label>
+        <input class="form-control" type="email" name="email" value="{if isset($smarty.get.email)}{$smarty.get.email|escape:'html':'UTF-8'}{else}{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'}{/if}{/if}" />
+      </div>
+      <p>
+        <button type="submit" name="submitGuestTracking" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
+      </p>
+    </fieldset>
+  </form>
 {/if}

--- a/themes/community-theme-16/header.tpl
+++ b/themes/community-theme-16/header.tpl
@@ -28,98 +28,98 @@
 <!--[if IE 8]><html class="no-js lt-ie9 ie8"{if isset($language_code) && $language_code} lang="{$language_code|escape:'html':'UTF-8'}"{/if}><![endif]-->
 <!--[if gt IE 8]> <html class="no-js ie9"{if isset($language_code) && $language_code} lang="{$language_code|escape:'html':'UTF-8'}"{/if}><![endif]-->
 <html{if isset($language_code) && $language_code} lang="{$language_code|escape:'html':'UTF-8'}"{/if}>
-    <head>
-        <meta charset="utf-8" />
-        <title>{$meta_title|escape:'html':'UTF-8'}</title>
-        {if isset($meta_description) AND $meta_description}
-            <meta name="description" content="{$meta_description|escape:'html':'UTF-8'}" />
-        {/if}
-        {if isset($meta_keywords) AND $meta_keywords}
-            <meta name="keywords" content="{$meta_keywords|escape:'html':'UTF-8'}" />
-        {/if}
-        <meta name="generator" content="PrestaShop" />
-        <meta name="robots" content="{if isset($nobots)}no{/if}index,{if isset($nofollow) && $nofollow}no{/if}follow" />
-        <meta name="viewport" content="width=device-width, minimum-scale=0.25, maximum-scale=1.6, initial-scale=1.0" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <link rel="icon" type="image/vnd.microsoft.icon" href="{$favicon_url}?{$img_update_time}" />
-        <link rel="shortcut icon" type="image/x-icon" href="{$favicon_url}?{$img_update_time}" />
-        {if isset($css_files)}
-            {foreach from=$css_files key=css_uri item=media}
-                <link rel="stylesheet" href="{$css_uri|escape:'html':'UTF-8'}" type="text/css" media="{$media|escape:'html':'UTF-8'}" />
-            {/foreach}
-        {/if}
-        {if isset($js_defer) && !$js_defer && isset($js_files) && isset($js_def)}
-            {$js_def}
-            {foreach from=$js_files item=js_uri}
-            <script type="text/javascript" src="{$js_uri|escape:'html':'UTF-8'}"></script>
-            {/foreach}
-        {/if}
-        {$HOOK_HEADER}
-        <link rel="stylesheet" href="http{if Tools::usingSecureMode()}s{/if}://fonts.googleapis.com/css?family=Open+Sans:300,600&amp;subset=latin,latin-ext" type="text/css" media="all" />
-        <!--[if IE 8]>
-        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-        <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-        <![endif]-->
-    </head>
-    <body{if isset($page_name)} id="{$page_name|escape:'html':'UTF-8'}"{/if} class="{if isset($page_name)}{$page_name|escape:'html':'UTF-8'}{/if}{if isset($body_classes) && $body_classes|@count} {implode value=$body_classes separator=' '}{/if}{if $hide_left_column} hide-left-column{else} show-left-column{/if}{if $hide_right_column} hide-right-column{else} show-right-column{/if}{if isset($content_only) && $content_only} content_only{/if} lang_{$lang_iso}">
-    {if !isset($content_only) || !$content_only}
-        {if isset($restricted_country_mode) && $restricted_country_mode}
-            <div id="restricted-country">
-                <p>{l s='You cannot place a new order from your country.'}{if isset($geolocation_country) && $geolocation_country} <span class="bold">{$geolocation_country|escape:'html':'UTF-8'}</span>{/if}</p>
+<head>
+  <meta charset="utf-8" />
+  <title>{$meta_title|escape:'html':'UTF-8'}</title>
+  {if isset($meta_description) AND $meta_description}
+    <meta name="description" content="{$meta_description|escape:'html':'UTF-8'}" />
+  {/if}
+  {if isset($meta_keywords) AND $meta_keywords}
+    <meta name="keywords" content="{$meta_keywords|escape:'html':'UTF-8'}" />
+  {/if}
+  <meta name="generator" content="PrestaShop" />
+  <meta name="robots" content="{if isset($nobots)}no{/if}index,{if isset($nofollow) && $nofollow}no{/if}follow" />
+  <meta name="viewport" content="width=device-width, minimum-scale=0.25, maximum-scale=1.6, initial-scale=1.0" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <link rel="icon" type="image/vnd.microsoft.icon" href="{$favicon_url}?{$img_update_time}" />
+  <link rel="shortcut icon" type="image/x-icon" href="{$favicon_url}?{$img_update_time}" />
+  {if isset($css_files)}
+    {foreach from=$css_files key=css_uri item=media}
+      <link rel="stylesheet" href="{$css_uri|escape:'html':'UTF-8'}" type="text/css" media="{$media|escape:'html':'UTF-8'}" />
+    {/foreach}
+  {/if}
+  {if isset($js_defer) && !$js_defer && isset($js_files) && isset($js_def)}
+    {$js_def}
+    {foreach from=$js_files item=js_uri}
+      <script type="text/javascript" src="{$js_uri|escape:'html':'UTF-8'}"></script>
+    {/foreach}
+  {/if}
+  {$HOOK_HEADER}
+  <link rel="stylesheet" href="http{if Tools::usingSecureMode()}s{/if}://fonts.googleapis.com/css?family=Open+Sans:300,600&amp;subset=latin,latin-ext" type="text/css" media="all" />
+  <!--[if IE 8]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body{if isset($page_name)} id="{$page_name|escape:'html':'UTF-8'}"{/if} class="{if isset($page_name)}{$page_name|escape:'html':'UTF-8'}{/if}{if isset($body_classes) && $body_classes|@count} {implode value=$body_classes separator=' '}{/if}{if $hide_left_column} hide-left-column{else} show-left-column{/if}{if $hide_right_column} hide-right-column{else} show-right-column{/if}{if isset($content_only) && $content_only} content_only{/if} lang_{$lang_iso}">
+{if !isset($content_only) || !$content_only}
+{if isset($restricted_country_mode) && $restricted_country_mode}
+  <div id="restricted-country">
+    <p>{l s='You cannot place a new order from your country.'}{if isset($geolocation_country) && $geolocation_country} <span class="bold">{$geolocation_country|escape:'html':'UTF-8'}</span>{/if}</p>
+  </div>
+{/if}
+<div id="page">
+  <div class="header-container">
+    <header id="header">
+      {capture name='displayBanner'}{hook h='displayBanner'}{/capture}
+      {if $smarty.capture.displayBanner}
+        <div class="banner">
+          <div class="container">
+            <div class="row">
+              {$smarty.capture.displayBanner}
             </div>
-        {/if}
-        <div id="page">
-            <div class="header-container">
-                <header id="header">
-                    {capture name='displayBanner'}{hook h='displayBanner'}{/capture}
-                    {if $smarty.capture.displayBanner}
-                        <div class="banner">
-                            <div class="container">
-                                <div class="row">
-                                    {$smarty.capture.displayBanner}
-                                </div>
-                            </div>
-                        </div>
-                    {/if}
-                    {capture name='displayNav'}{hook h='displayNav'}{/capture}
-                    {if $smarty.capture.displayNav}
-                        <div class="nav">
-                            <div class="container">
-                                <div class="row">
-                                    <nav>{$smarty.capture.displayNav}</nav>
-                                </div>
-                            </div>
-                        </div>
-                    {/if}
-                    <div>
-                        <div class="container">
-                            <div class="row">
-                                <div id="header_logo">
-                                    <a href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{$shop_name|escape:'html':'UTF-8'}">
-                                        <img class="logo img-responsive" src="{$logo_url}" alt="{$shop_name|escape:'html':'UTF-8'}"{if isset($logo_image_width) && $logo_image_width} width="{$logo_image_width}"{/if}{if isset($logo_image_height) && $logo_image_height} height="{$logo_image_height}"{/if}/>
-                                    </a>
-                                </div>
-                                {if isset($HOOK_TOP)}{$HOOK_TOP}{/if}
-                            </div>
-                        </div>
-                    </div>
-                </header>
+          </div>
+        </div>
+      {/if}
+      {capture name='displayNav'}{hook h='displayNav'}{/capture}
+      {if $smarty.capture.displayNav}
+        <div class="nav">
+          <div class="container">
+            <div class="row">
+              <nav>{$smarty.capture.displayNav}</nav>
             </div>
-            <div class="columns-container">
-                <div id="columns" class="container">
-                    {if $page_name !='index' && $page_name !='pagenotfound'}
-                        {include file="$tpl_dir./breadcrumb.tpl"}
-                    {/if}
-                    <div id="slider_row" class="row">
-                        {capture name='displayTopColumn'}{hook h='displayTopColumn'}{/capture}
-                        {if $smarty.capture.displayTopColumn}
-                            <div id="top_column" class="center_column col-xs-12 col-sm-12">{$smarty.capture.displayTopColumn}</div>
-                        {/if}
-                    </div>
-                    <div class="row">
-                        {if isset($left_column_size) && !empty($left_column_size)}
-                        <div id="left_column" class="column col-xs-12 col-sm-{$left_column_size|intval}">{$HOOK_LEFT_COLUMN}</div>
-                        {/if}
-                        {if isset($left_column_size) && isset($right_column_size)}{assign var='cols' value=(12 - $left_column_size - $right_column_size)}{else}{assign var='cols' value=12}{/if}
-                        <div id="center_column" class="center_column col-xs-12 col-sm-{$cols|intval}">
-    {/if}
+          </div>
+        </div>
+      {/if}
+      <div>
+        <div class="container">
+          <div class="row">
+            <div id="header_logo">
+              <a href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{$shop_name|escape:'html':'UTF-8'}">
+                <img class="logo img-responsive" src="{$logo_url}" alt="{$shop_name|escape:'html':'UTF-8'}"{if isset($logo_image_width) && $logo_image_width} width="{$logo_image_width}"{/if}{if isset($logo_image_height) && $logo_image_height} height="{$logo_image_height}"{/if}/>
+              </a>
+            </div>
+            {if isset($HOOK_TOP)}{$HOOK_TOP}{/if}
+          </div>
+        </div>
+      </div>
+    </header>
+  </div>
+  <div class="columns-container">
+    <div id="columns" class="container">
+      {if $page_name !='index' && $page_name !='pagenotfound'}
+        {include file="$tpl_dir./breadcrumb.tpl"}
+      {/if}
+      <div id="slider_row" class="row">
+        {capture name='displayTopColumn'}{hook h='displayTopColumn'}{/capture}
+        {if $smarty.capture.displayTopColumn}
+          <div id="top_column" class="center_column col-xs-12 col-sm-12">{$smarty.capture.displayTopColumn}</div>
+        {/if}
+      </div>
+      <div class="row">
+        {if isset($left_column_size) && !empty($left_column_size)}
+          <div id="left_column" class="column col-xs-12 col-sm-{$left_column_size|intval}">{$HOOK_LEFT_COLUMN}</div>
+        {/if}
+        {if isset($left_column_size) && isset($right_column_size)}{assign var='cols' value=(12 - $left_column_size - $right_column_size)}{else}{assign var='cols' value=12}{/if}
+        <div id="center_column" class="center_column col-xs-12 col-sm-{$cols|intval}">
+          {/if}

--- a/themes/community-theme-16/history.tpl
+++ b/themes/community-theme-16/history.tpl
@@ -23,104 +23,104 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {capture name=path}
-    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-        {l s='My account'}
-    </a>
-    <span class="navigation-pipe">{$navigationPipe}</span>
-    <span class="navigation_page">{l s='Order history'}</span>
+  <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+    {l s='My account'}
+  </a>
+  <span class="navigation-pipe">{$navigationPipe}</span>
+  <span class="navigation_page">{l s='Order history'}</span>
 {/capture}
 {include file="$tpl_dir./errors.tpl"}
 <h1 class="page-heading bottom-indent">{l s='Order history'}</h1>
 <p class="info-title">{l s='Here are the orders you\'ve placed since your account was created.'}</p>
 {if $slowValidation}
-    <p class="alert alert-warning">{l s='If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.'}</p>
+  <p class="alert alert-warning">{l s='If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.'}</p>
 {/if}
 <div class="block-center" id="block-history">
-    {if $orders && count($orders)}
-        <table id="order-list" class="table table-bordered footab">
-            <thead>
-                <tr>
-                    <th class="first_item" data-sort-ignore="true">{l s='Order reference'}</th>
-                    <th class="item">{l s='Date'}</th>
-                    <th data-hide="phone" class="item">{l s='Total price'}</th>
-                    <th data-sort-ignore="true" data-hide="phone,tablet" class="item">{l s='Payment'}</th>
-                    <th class="item">{l s='Status'}</th>
-                    <th data-sort-ignore="true" data-hide="phone,tablet" class="item">{l s='Invoice'}</th>
-                    <th data-sort-ignore="true" data-hide="phone,tablet" class="last_item">&nbsp;</th>
-                </tr>
-            </thead>
-            <tbody>
-                {foreach from=$orders item=order name=myLoop}
-                    <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
-                        <td class="history_link bold">
-                            {if isset($order.invoice) && $order.invoice && isset($order.virtual) && $order.virtual}
-                                <img class="icon" src="{$img_dir}icon/download_product.gif" alt="{l s='Products to download'}" title="{l s='Products to download'}" />
-                            {/if}
-                            <a class="color-myaccount" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true, NULL, "id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}');">
-                                {Order::getUniqReferenceOf($order.id_order)}
-                            </a>
-                        </td>
-                        <td data-value="{$order.date_add|regex_replace:"/[\-\:\ ]/":""}" class="history_date bold">
-                            {dateFormat date=$order.date_add full=0}
-                        </td>
-                        <td class="history_price" data-value="{$order.total_paid}">
-                            <span class="price">
-                                {displayPrice price=$order.total_paid currency=$order.id_currency no_utf8=false convert=false}
-                            </span>
-                        </td>
-                        <td class="history_method">{$order.payment|escape:'html':'UTF-8'}</td>
-                        <td{if isset($order.order_state)} data-value="{$order.id_order_state}"{/if} class="history_state">
-                            {if isset($order.order_state)}
-                                <span class="label{if isset($order.order_state_color) && Tools::getBrightness($order.order_state_color) > 128} dark{/if}"{if isset($order.order_state_color) && $order.order_state_color} style="background-color:{$order.order_state_color|escape:'html':'UTF-8'}; border-color:{$order.order_state_color|escape:'html':'UTF-8'};"{/if}>
-                                    {$order.order_state|escape:'html':'UTF-8'}
-                                </span>
-                            {/if}
-                        </td>
-                        <td class="history_invoice">
-                            {if (isset($order.invoice) && $order.invoice && isset($order.invoice_number) && $order.invoice_number) && isset($invoiceAllowed) && $invoiceAllowed == true}
-                                <a class="link-button" href="{$link->getPageLink('pdf-invoice', true, NULL, "id_order={$order.id_order}")|escape:'html':'UTF-8'}" title="{l s='Invoice'}" target="_blank">
-                                    <i class="icon-file-text large"></i>{l s='PDF'}
-                                </a>
-                            {else}
-                                -
-                            {/if}
-                        </td>
-                        <td class="history_detail">
-                            <a class="btn btn-default button button-small" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true, NULL, "id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}');">
-                                <span>
-                                    {l s='Details'}<i class="icon-chevron-right right"></i>
-                                </span>
-                            </a>
-                            {if isset($opc) && $opc}
-                                <a class="link-button" href="{$link->getPageLink('order-opc', true, NULL, "submitReorder&id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}" title="{l s='Reorder'}">
-                            {else}
-                                <a class="link-button" href="{$link->getPageLink('order', true, NULL, "submitReorder&id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}" title="{l s='Reorder'}">
-                            {/if}
-                                {if isset($reorderingAllowed) && $reorderingAllowed}
-                                    <i class="icon-refresh"></i>{l s='Reorder'}
-                                {/if}
-                            </a>
-                        </td>
-                    </tr>
-                {/foreach}
-            </tbody>
-        </table>
-        <div id="block-order-detail" class="unvisible">&nbsp;</div>
-    {else}
-        <p class="alert alert-warning">{l s='You have not placed any orders.'}</p>
-    {/if}
+  {if $orders && count($orders)}
+    <table id="order-list" class="table table-bordered footab">
+      <thead>
+      <tr>
+        <th class="first_item" data-sort-ignore="true">{l s='Order reference'}</th>
+        <th class="item">{l s='Date'}</th>
+        <th data-hide="phone" class="item">{l s='Total price'}</th>
+        <th data-sort-ignore="true" data-hide="phone,tablet" class="item">{l s='Payment'}</th>
+        <th class="item">{l s='Status'}</th>
+        <th data-sort-ignore="true" data-hide="phone,tablet" class="item">{l s='Invoice'}</th>
+        <th data-sort-ignore="true" data-hide="phone,tablet" class="last_item">&nbsp;</th>
+      </tr>
+      </thead>
+      <tbody>
+      {foreach from=$orders item=order name=myLoop}
+        <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
+          <td class="history_link bold">
+            {if isset($order.invoice) && $order.invoice && isset($order.virtual) && $order.virtual}
+              <img class="icon" src="{$img_dir}icon/download_product.gif" alt="{l s='Products to download'}" title="{l s='Products to download'}" />
+            {/if}
+            <a class="color-myaccount" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true, NULL, "id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}');">
+              {Order::getUniqReferenceOf($order.id_order)}
+            </a>
+          </td>
+          <td data-value="{$order.date_add|regex_replace:"/[\-\:\ ]/":""}" class="history_date bold">
+            {dateFormat date=$order.date_add full=0}
+          </td>
+          <td class="history_price" data-value="{$order.total_paid}">
+            <span class="price">
+              {displayPrice price=$order.total_paid currency=$order.id_currency no_utf8=false convert=false}
+            </span>
+          </td>
+          <td class="history_method">{$order.payment|escape:'html':'UTF-8'}</td>
+          <td{if isset($order.order_state)} data-value="{$order.id_order_state}"{/if} class="history_state">
+            {if isset($order.order_state)}
+              <span class="label{if isset($order.order_state_color) && Tools::getBrightness($order.order_state_color) > 128} dark{/if}"{if isset($order.order_state_color) && $order.order_state_color} style="background-color:{$order.order_state_color|escape:'html':'UTF-8'}; border-color:{$order.order_state_color|escape:'html':'UTF-8'};"{/if}>
+                {$order.order_state|escape:'html':'UTF-8'}
+              </span>
+            {/if}
+          </td>
+          <td class="history_invoice">
+            {if (isset($order.invoice) && $order.invoice && isset($order.invoice_number) && $order.invoice_number) && isset($invoiceAllowed) && $invoiceAllowed == true}
+              <a class="link-button" href="{$link->getPageLink('pdf-invoice', true, NULL, "id_order={$order.id_order}")|escape:'html':'UTF-8'}" title="{l s='Invoice'}" target="_blank">
+                <i class="icon-file-text large"></i>{l s='PDF'}
+              </a>
+            {else}
+              -
+            {/if}
+          </td>
+          <td class="history_detail">
+            <a class="btn btn-default button button-small" href="javascript:showOrder(1, {$order.id_order|intval}, '{$link->getPageLink('order-detail', true, NULL, "id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}');">
+              <span>
+                {l s='Details'}<i class="icon-chevron-right right"></i>
+              </span>
+            </a>
+            {if isset($opc) && $opc}
+            <a class="link-button" href="{$link->getPageLink('order-opc', true, NULL, "submitReorder&id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}" title="{l s='Reorder'}">
+              {else}
+              <a class="link-button" href="{$link->getPageLink('order', true, NULL, "submitReorder&id_order={$order.id_order|intval}")|escape:'html':'UTF-8'}" title="{l s='Reorder'}">
+                {/if}
+                {if isset($reorderingAllowed) && $reorderingAllowed}
+                  <i class="icon-refresh"></i>{l s='Reorder'}
+                {/if}
+              </a>
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    </table>
+    <div id="block-order-detail" class="unvisible">&nbsp;</div>
+  {else}
+    <p class="alert alert-warning">{l s='You have not placed any orders.'}</p>
+  {/if}
 </div>
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Back to Your Account'}
-            </span>
-        </a>
-    </li>
-    <li>
-        <a class="btn btn-default button button-small" href="{$base_dir}">
-            <span><i class="icon-chevron-left"></i> {l s='Home'}</span>
-        </a>
-    </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Back to Your Account'}
+      </span>
+    </a>
+  </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$base_dir}">
+      <span><i class="icon-chevron-left"></i> {l s='Home'}</span>
+    </a>
+  </li>
 </ul>

--- a/themes/community-theme-16/identity.tpl
+++ b/themes/community-theme-16/identity.tpl
@@ -24,197 +24,197 @@
 *}
 
 {capture name=path}
-    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-        {l s='My account'}
-    </a>
-    <span class="navigation-pipe">
-        {$navigationPipe}
-    </span>
-    <span class="navigation_page">
-        {l s='Your personal information'}
-    </span>
+  <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+    {l s='My account'}
+  </a>
+  <span class="navigation-pipe">
+     {$navigationPipe}
+  </span>
+  <span class="navigation_page">
+     {l s='Your personal information'}
+  </span>
 {/capture}
 <div class="box">
-    <h1 class="page-subheading">
-        {l s='Your personal information'}
-    </h1>
+  <h1 class="page-subheading">
+    {l s='Your personal information'}
+  </h1>
 
-    {include file="$tpl_dir./errors.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
 
-    {if isset($confirmation) && $confirmation}
-        <p class="alert alert-success">
-            {l s='Your personal information has been successfully updated.'}
-            {if isset($pwd_changed)}<br />{l s='Your password has been sent to your email:'} {$email}{/if}
-        </p>
-    {else}
-        <p class="info-title">
-            {l s='Please be sure to update your personal information if it has changed.'}
-        </p>
-        <p class="required">
-            <sup>*</sup>{l s='Required field'}
-        </p>
-        <form action="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" method="post" class="std">
-            <fieldset>
-                <div class="clearfix">
-                    <label>{l s='Social title'}</label>
-                    <br />
-                    {foreach from=$genders key=k item=gender}
-                        <div class="radio-inline">
-                            <label for="id_gender{$gender->id}" class="top">
-                            <input type="radio" name="id_gender" id="id_gender{$gender->id}" value="{$gender->id|intval}" {if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id}checked="checked"{/if} />
-                            {$gender->name}</label>
-                        </div>
-                    {/foreach}
-                </div>
-                <div class="required form-group">
-                    <label for="firstname" class="required">
-                        {l s='First name'}
-                    </label>
-                    <input class="is_required validate form-control" data-validate="isName" type="text" id="firstname" name="firstname" value="{$smarty.post.firstname}" />
-                </div>
-                <div class="required form-group">
-                    <label for="lastname" class="required">
-                        {l s='Last name'}
-                    </label>
-                    <input class="is_required validate form-control" data-validate="isName" type="text" name="lastname" id="lastname" value="{$smarty.post.lastname}" />
-                </div>
-                <div class="required form-group">
-                    <label for="email" class="required">
-                        {l s='E-mail address'}
-                    </label>
-                    <input class="is_required validate form-control" data-validate="isEmail" type="email" name="email" id="email" value="{$smarty.post.email}" />
-                </div>
-                <div class="form-group">
-                    <label>
-                        {l s='Date of Birth'}
-                    </label>
-                    <div class="row">
-                        <div class="col-xs-4">
-                            <select name="days" id="days" class="form-control">
-                                <option value="">-</option>
-                                {foreach from=$days item=v}
-                                    <option value="{$v}" {if ($sl_day == $v)}selected="selected"{/if}>{$v}&nbsp;&nbsp;</option>
-                                {/foreach}
-                            </select>
-                        </div>
-                        <div class="col-xs-4">
-                            {*
-                                {l s='January'}
-                                {l s='February'}
-                                {l s='March'}
-                                {l s='April'}
-                                {l s='May'}
-                                {l s='June'}
-                                {l s='July'}
-                                {l s='August'}
-                                {l s='September'}
-                                {l s='October'}
-                                {l s='November'}
-                                {l s='December'}
-                            *}
-                            <select id="months" name="months" class="form-control">
-                                <option value="">-</option>
-                                {foreach from=$months key=k item=v}
-                                    <option value="{$k}" {if ($sl_month == $k)}selected="selected"{/if}>{l s=$v}&nbsp;</option>
-                                {/foreach}
-                            </select>
-                        </div>
-                        <div class="col-xs-4">
-                            <select id="years" name="years" class="form-control">
-                                <option value="">-</option>
-                                {foreach from=$years item=v}
-                                    <option value="{$v}" {if ($sl_year == $v)}selected="selected"{/if}>{$v}&nbsp;&nbsp;</option>
-                                {/foreach}
-                            </select>
-                        </div>
-                    </div>
-                </div>
-                <div class="required form-group">
-                    <label for="old_passwd" class="required">
-                        {l s='Current Password'}
-                    </label>
-                    <input class="is_required validate form-control" type="password" data-validate="isPasswd" name="old_passwd" id="old_passwd" />
-                </div>
-                <div class="password form-group">
-                    <label for="passwd">
-                        {l s='New Password'}
-                    </label>
-                    <input class="is_required validate form-control" type="password" data-validate="isPasswd" name="passwd" id="passwd" />
-                </div>
-                <div class="password form-group">
-                    <label for="confirmation">
-                        {l s='Confirmation'}
-                    </label>
-                    <input class="is_required validate form-control" type="password" data-validate="isPasswd" name="confirmation" id="confirmation" />
-                </div>
-                {if isset($newsletter) && $newsletter}
-                    <div class="checkbox">
-                        <label for="newsletter">
-                            <input type="checkbox" id="newsletter" name="newsletter" value="1" {if isset($smarty.post.newsletter) && $smarty.post.newsletter == 1} checked="checked"{/if}/>
-                            {l s='Sign up for our newsletter!'}
-                            {if isset($required_fields) && array_key_exists('newsletter', $field_required)}
-                              <sup> *</sup>
-                            {/if}
-                        </label>
-                    </div>
-                {/if}
-                {if isset($optin) && $optin}
-                    <div class="checkbox">
-                        <label for="optin">
-                            <input type="checkbox" name="optin" id="optin" value="1" {if isset($smarty.post.optin) && $smarty.post.optin == 1} checked="checked"{/if}/>
-                            {l s='Receive special offers from our partners!'}
-                            {if isset($required_fields) && array_key_exists('optin', $field_required)}
-                              <sup> *</sup>
-                            {/if}
-                        </label>
-                    </div>
-                {/if}
-            {if $b2b_enable}
-                <h1 class="page-subheading">
-                    {l s='Your company information'}
-                </h1>
-                <div class="form-group">
-                    <label for="">{l s='Company'}</label>
-                    <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
-                </div>
-                <div class="form-group">
-                    <label for="siret">{l s='SIRET'}</label>
-                    <input type="text" class="form-control" id="siret" name="siret" value="{if isset($smarty.post.siret)}{$smarty.post.siret}{/if}" />
-                </div>
-                <div class="form-group">
-                    <label for="ape">{l s='APE'}</label>
-                    <input type="text" class="form-control" id="ape" name="ape" value="{if isset($smarty.post.ape)}{$smarty.post.ape}{/if}" />
-                </div>
-                <div class="form-group">
-                    <label for="website">{l s='Website'}</label>
-                    <input type="text" class="form-control" id="website" name="website" value="{if isset($smarty.post.website)}{$smarty.post.website}{/if}" />
-                </div>
-            {/if}
-                {if isset($HOOK_CUSTOMER_IDENTITY_FORM)}
-            {$HOOK_CUSTOMER_IDENTITY_FORM}
+  {if isset($confirmation) && $confirmation}
+    <p class="alert alert-success">
+      {l s='Your personal information has been successfully updated.'}
+      {if isset($pwd_changed)}<br />{l s='Your password has been sent to your email:'} {$email}{/if}
+    </p>
+  {else}
+    <p class="info-title">
+      {l s='Please be sure to update your personal information if it has changed.'}
+    </p>
+    <p class="required">
+      <sup>*</sup>{l s='Required field'}
+    </p>
+    <form action="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" method="post" class="std">
+      <fieldset>
+        <div class="clearfix">
+          <label>{l s='Social title'}</label>
+          <br />
+          {foreach from=$genders key=k item=gender}
+            <div class="radio-inline">
+              <label for="id_gender{$gender->id}" class="top">
+                <input type="radio" name="id_gender" id="id_gender{$gender->id}" value="{$gender->id|intval}" {if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id}checked="checked"{/if} />
+                {$gender->name}</label>
+            </div>
+          {/foreach}
+        </div>
+        <div class="required form-group">
+          <label for="firstname" class="required">
+            {l s='First name'}
+          </label>
+          <input class="is_required validate form-control" data-validate="isName" type="text" id="firstname" name="firstname" value="{$smarty.post.firstname}" />
+        </div>
+        <div class="required form-group">
+          <label for="lastname" class="required">
+            {l s='Last name'}
+          </label>
+          <input class="is_required validate form-control" data-validate="isName" type="text" name="lastname" id="lastname" value="{$smarty.post.lastname}" />
+        </div>
+        <div class="required form-group">
+          <label for="email" class="required">
+            {l s='E-mail address'}
+          </label>
+          <input class="is_required validate form-control" data-validate="isEmail" type="email" name="email" id="email" value="{$smarty.post.email}" />
+        </div>
+        <div class="form-group">
+          <label>
+            {l s='Date of Birth'}
+          </label>
+          <div class="row">
+            <div class="col-xs-4">
+              <select name="days" id="days" class="form-control">
+                <option value="">-</option>
+                {foreach from=$days item=v}
+                  <option value="{$v}" {if ($sl_day == $v)}selected="selected"{/if}>{$v}&nbsp;&nbsp;</option>
+                {/foreach}
+              </select>
+            </div>
+            <div class="col-xs-4">
+              {*
+                  {l s='January'}
+                  {l s='February'}
+                  {l s='March'}
+                  {l s='April'}
+                  {l s='May'}
+                  {l s='June'}
+                  {l s='July'}
+                  {l s='August'}
+                  {l s='September'}
+                  {l s='October'}
+                  {l s='November'}
+                  {l s='December'}
+              *}
+              <select id="months" name="months" class="form-control">
+                <option value="">-</option>
+                {foreach from=$months key=k item=v}
+                  <option value="{$k}" {if ($sl_month == $k)}selected="selected"{/if}>{l s=$v}&nbsp;</option>
+                {/foreach}
+              </select>
+            </div>
+            <div class="col-xs-4">
+              <select id="years" name="years" class="form-control">
+                <option value="">-</option>
+                {foreach from=$years item=v}
+                  <option value="{$v}" {if ($sl_year == $v)}selected="selected"{/if}>{$v}&nbsp;&nbsp;</option>
+                {/foreach}
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="required form-group">
+          <label for="old_passwd" class="required">
+            {l s='Current Password'}
+          </label>
+          <input class="is_required validate form-control" type="password" data-validate="isPasswd" name="old_passwd" id="old_passwd" />
+        </div>
+        <div class="password form-group">
+          <label for="passwd">
+            {l s='New Password'}
+          </label>
+          <input class="is_required validate form-control" type="password" data-validate="isPasswd" name="passwd" id="passwd" />
+        </div>
+        <div class="password form-group">
+          <label for="confirmation">
+            {l s='Confirmation'}
+          </label>
+          <input class="is_required validate form-control" type="password" data-validate="isPasswd" name="confirmation" id="confirmation" />
+        </div>
+        {if isset($newsletter) && $newsletter}
+          <div class="checkbox">
+            <label for="newsletter">
+              <input type="checkbox" id="newsletter" name="newsletter" value="1" {if isset($smarty.post.newsletter) && $smarty.post.newsletter == 1} checked="checked"{/if}/>
+              {l s='Sign up for our newsletter!'}
+              {if isset($required_fields) && array_key_exists('newsletter', $field_required)}
+                <sup> *</sup>
+              {/if}
+            </label>
+          </div>
         {/if}
-                <div class="form-group">
-                    <button type="submit" name="submitIdentity" class="btn btn-default button button-medium">
-                        <span>{l s='Save'}<i class="icon-chevron-right right"></i></span>
-                    </button>
-                </div>
-            </fieldset>
-        </form> <!-- .std -->
-    {/if}
+        {if isset($optin) && $optin}
+          <div class="checkbox">
+            <label for="optin">
+              <input type="checkbox" name="optin" id="optin" value="1" {if isset($smarty.post.optin) && $smarty.post.optin == 1} checked="checked"{/if}/>
+              {l s='Receive special offers from our partners!'}
+              {if isset($required_fields) && array_key_exists('optin', $field_required)}
+                <sup> *</sup>
+              {/if}
+            </label>
+          </div>
+        {/if}
+        {if $b2b_enable}
+          <h1 class="page-subheading">
+            {l s='Your company information'}
+          </h1>
+          <div class="form-group">
+            <label for="">{l s='Company'}</label>
+            <input type="text" class="form-control" id="company" name="company" value="{if isset($smarty.post.company)}{$smarty.post.company}{/if}" />
+          </div>
+          <div class="form-group">
+            <label for="siret">{l s='SIRET'}</label>
+            <input type="text" class="form-control" id="siret" name="siret" value="{if isset($smarty.post.siret)}{$smarty.post.siret}{/if}" />
+          </div>
+          <div class="form-group">
+            <label for="ape">{l s='APE'}</label>
+            <input type="text" class="form-control" id="ape" name="ape" value="{if isset($smarty.post.ape)}{$smarty.post.ape}{/if}" />
+          </div>
+          <div class="form-group">
+            <label for="website">{l s='Website'}</label>
+            <input type="text" class="form-control" id="website" name="website" value="{if isset($smarty.post.website)}{$smarty.post.website}{/if}" />
+          </div>
+        {/if}
+        {if isset($HOOK_CUSTOMER_IDENTITY_FORM)}
+          {$HOOK_CUSTOMER_IDENTITY_FORM}
+        {/if}
+        <div class="form-group">
+          <button type="submit" name="submitIdentity" class="btn btn-default button button-medium">
+            <span>{l s='Save'}<i class="icon-chevron-right right"></i></span>
+          </button>
+        </div>
+      </fieldset>
+    </form> <!-- .std -->
+  {/if}
 </div>
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)}">
-            <span>
-                <i class="icon-chevron-left"></i>{l s='Back to your account'}
-            </span>
-        </a>
-    </li>
-    <li>
-        <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-            <span>
-                <i class="icon-chevron-left"></i>{l s='Home'}
-            </span>
-        </a>
-    </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)}">
+      <span>
+        <i class="icon-chevron-left"></i>{l s='Back to your account'}
+      </span>
+    </a>
+  </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+      <span>
+        <i class="icon-chevron-left"></i>{l s='Home'}
+      </span>
+    </a>
+  </li>
 </ul>

--- a/themes/community-theme-16/index.tpl
+++ b/themes/community-theme-16/index.tpl
@@ -23,13 +23,13 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($HOOK_HOME_TAB_CONTENT) && $HOOK_HOME_TAB_CONTENT|trim}
-    {if isset($HOOK_HOME_TAB) && $HOOK_HOME_TAB|trim}
-        <ul id="home-page-tabs" class="nav nav-tabs clearfix">
-            {$HOOK_HOME_TAB}
-        </ul>
-    {/if}
-    <div class="tab-content">{$HOOK_HOME_TAB_CONTENT}</div>
+  {if isset($HOOK_HOME_TAB) && $HOOK_HOME_TAB|trim}
+    <ul id="home-page-tabs" class="nav nav-tabs clearfix">
+      {$HOOK_HOME_TAB}
+    </ul>
+  {/if}
+  <div class="tab-content">{$HOOK_HOME_TAB_CONTENT}</div>
 {/if}
 {if isset($HOOK_HOME) && $HOOK_HOME|trim}
-    <div class="clearfix">{$HOOK_HOME}</div>
+  <div class="clearfix">{$HOOK_HOME}</div>
 {/if}

--- a/themes/community-theme-16/maintenance.tpl
+++ b/themes/community-theme-16/maintenance.tpl
@@ -26,32 +26,32 @@
 <!DOCTYPE html>
 <html lang="{$language_code|escape:'html':'UTF-8'}">
 <head>
-    <meta charset="utf-8">
-    <title>{$meta_title|escape:'html':'UTF-8'}</title>
-{if isset($meta_description)}
+  <meta charset="utf-8">
+  <title>{$meta_title|escape:'html':'UTF-8'}</title>
+  {if isset($meta_description)}
     <meta name="description" content="{$meta_description|escape:'html':'UTF-8'}">
-{/if}
-{if isset($meta_keywords)}
+  {/if}
+  {if isset($meta_keywords)}
     <meta name="keywords" content="{$meta_keywords|escape:'html':'UTF-8'}">
-{/if}
-    <meta name="robots" content="{if isset($nobots)}no{/if}index,follow">
-    <link rel="shortcut icon" href="{$favicon_url}">
-        <link href="{$css_dir}maintenance.css" rel="stylesheet">
-        <link href='//fonts.googleapis.com/css?family=Open+Sans:600' rel='stylesheet'>
+  {/if}
+  <meta name="robots" content="{if isset($nobots)}no{/if}index,follow">
+  <link rel="shortcut icon" href="{$favicon_url}">
+  <link href="{$css_dir}maintenance.css" rel="stylesheet">
+  <link href='//fonts.googleapis.com/css?family=Open+Sans:600' rel='stylesheet'>
 </head>
 <body>
-        <div class="container">
-            <div id="maintenance">
-                <div class="logo"><img src="{$logo_url}" {if $logo_image_width}width="{$logo_image_width}"{/if} {if $logo_image_height}height="{$logo_image_height}"{/if} alt="logo" /></div>
-                    {$HOOK_MAINTENANCE}
-                    <div id="message">
-                            <h1 class="maintenance-heading">{l s='We\'ll be back soon.'}</h1>
-                            {l s='We are currently updating our shop and will be back really soon.'}
-                            <br />
-                            {l s='Thanks for your patience.'}
-                    </div>
-                </div>
-            </div>
-        </div>
+<div class="container">
+  <div id="maintenance">
+    <div class="logo"><img src="{$logo_url}" {if $logo_image_width}width="{$logo_image_width}"{/if} {if $logo_image_height}height="{$logo_image_height}"{/if} alt="logo" /></div>
+    {$HOOK_MAINTENANCE}
+    <div id="message">
+      <h1 class="maintenance-heading">{l s='We\'ll be back soon.'}</h1>
+      {l s='We are currently updating our shop and will be back really soon.'}
+      <br />
+      {l s='Thanks for your patience.'}
+    </div>
+  </div>
+</div>
+</div>
 </body>
 </html>

--- a/themes/community-theme-16/manufacturer-list.tpl
+++ b/themes/community-theme-16/manufacturer-list.tpl
@@ -26,134 +26,134 @@
 {capture name=path}{l s='Manufacturers:'}{/capture}
 
 <h1 class="page-heading product-listing">
-    {l s='Brands'}
-    {strip}
-        <span class="heading-counter">
-            {if $nbManufacturers == 0}{l s='There are no manufacturers.'}
-            {else}
-                {if $nbManufacturers == 1}
-                    {l s='There is 1 brand'}
-                {else}
-                    {l s='There are %d brands' sprintf=$nbManufacturers}
-                {/if}
-            {/if}
-        </span>
-    {/strip}
+  {l s='Brands'}
+  {strip}
+    <span class="heading-counter">
+      {if $nbManufacturers == 0}{l s='There are no manufacturers.'}
+      {else}
+        {if $nbManufacturers == 1}
+          {l s='There is 1 brand'}
+        {else}
+          {l s='There are %d brands' sprintf=$nbManufacturers}
+        {/if}
+      {/if}
+    </span>
+  {/strip}
 </h1>
 {if isset($errors) AND $errors}
-    {include file="$tpl_dir./errors.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
 {else}
-    {if $nbManufacturers > 0}
-        <div class="content_sortPagiBar">
-            <div class="sortPagiBar clearfix">
-                {if isset($manufacturer) && isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                    <ul class="display hidden-xs">
-                        <li class="display-title">
-                            {l s='View:'}
-                        </li>
-                        <li id="grid">
-                            <a rel="nofollow" href="#" title="{l s='Grid'}">
-                                <i class="icon-th-large"></i>{l s='Grid'}
-                            </a>
-                        </li>
-                        <li id="list">
-                            <a rel="nofollow" href="#" title="{l s='List'}">
-                                <i class="icon-th-list"></i>{l s='List'}
-                            </a>
-                        </li>
-                    </ul>
-                {/if}
-                {include file="./nbr-product-page.tpl"}
+  {if $nbManufacturers > 0}
+    <div class="content_sortPagiBar">
+      <div class="sortPagiBar clearfix">
+        {if isset($manufacturer) && isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+          <ul class="display hidden-xs">
+            <li class="display-title">
+              {l s='View:'}
+            </li>
+            <li id="grid">
+              <a rel="nofollow" href="#" title="{l s='Grid'}">
+                <i class="icon-th-large"></i>{l s='Grid'}
+              </a>
+            </li>
+            <li id="list">
+              <a rel="nofollow" href="#" title="{l s='List'}">
+                <i class="icon-th-list"></i>{l s='List'}
+              </a>
+            </li>
+          </ul>
+        {/if}
+        {include file="./nbr-product-page.tpl"}
+      </div>
+      <div class="top-pagination-content clearfix bottom-line">
+        {include file="$tpl_dir./pagination.tpl" no_follow=1}
+      </div>
+    </div> <!-- .content_sortPagiBar -->
+
+    {assign var='nbItemsPerLine' value=3}
+    {assign var='nbItemsPerLineTablet' value=2}
+    {assign var='nbLi' value=$manufacturers|@count}
+    {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
+    {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
+
+    <ul id="manufacturers_list" class="list row">
+      {foreach from=$manufacturers item=manufacturer name=manufacturers}
+        {math equation="(total%perLine)" total=$smarty.foreach.manufacturers.total perLine=$nbItemsPerLine assign=totModulo}
+        {math equation="(total%perLineT)" total=$smarty.foreach.manufacturers.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
+        {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
+        {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
+        <li class="{if $smarty.foreach.manufacturers.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.manufacturers.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.manufacturers.iteration > ($smarty.foreach.manufacturers.total - $totModulo)}last-line{/if} {if $smarty.foreach.manufacturers.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.manufacturers.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.manufacturers.iteration > ($smarty.foreach.manufacturers.total - $totModuloTablet)}last-tablet-line{/if}{if $smarty.foreach.manufacturers.last} item-last{/if} col-xs-12">
+          <div class="mansup-container">
+            <div class="row">
+              <div class="left-side col-xs-12 col-sm-3">
+                <div class="logo">
+                  {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                  <a
+                    class="lnk_img"
+                    href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}"
+                    title="{$manufacturer.name|escape:'html':'UTF-8'}" >
+                    {/if}
+                    <img src="{$img_manu_dir}{$manufacturer.image|escape:'html':'UTF-8'}-medium_default.jpg" alt="" />
+                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                  </a>
+                  {/if}
+                </div> <!-- .logo -->
+              </div> <!-- .left-side -->
+
+              <div class="middle-side col-xs-12 col-sm-5">
+                <h3>
+                  {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                  <a
+                    class="product-name"
+                    href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">
+                    {/if}
+                    {$manufacturer.name|truncate:60:'...'|escape:'html':'UTF-8'}
+                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                  </a>
+                  {/if}
+                </h3>
+                <div class="description rte">
+                  {$manufacturer.short_description}
+                </div>
+              </div> <!-- .middle-side -->
+
+              <div class="right-side col-xs-12 col-sm-4">
+                <div class="right-side-content">
+                  <p class="product-counter">
+                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                    <a href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">
+                      {/if}
+                      {if isset($manufacturer.nb_products) && $manufacturer.nb_products == 1}
+                        {l s='%d product' sprintf=$manufacturer.nb_products|intval}
+                      {else}
+                        {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                          {l s='%d products' sprintf=$manufacturer.nb_products|intval}
+                        {/if}
+                      {/if}
+                      {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                    </a>
+                    {/if}
+                  </p>
+                  {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
+                    <a
+                      class="btn btn-default button exclusive-medium"
+                      href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">
+                      <span>
+                        {l s='view products'} <i class="icon-chevron-right right"></i>
+                      </span>
+                    </a>
+                  {/if}
+                </div>
+              </div> <!-- .right-side -->
             </div>
-            <div class="top-pagination-content clearfix bottom-line">
-                {include file="$tpl_dir./pagination.tpl" no_follow=1}
-            </div>
-        </div> <!-- .content_sortPagiBar -->
-
-        {assign var='nbItemsPerLine' value=3}
-        {assign var='nbItemsPerLineTablet' value=2}
-        {assign var='nbLi' value=$manufacturers|@count}
-        {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
-        {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
-
-        <ul id="manufacturers_list" class="list row">
-            {foreach from=$manufacturers item=manufacturer name=manufacturers}
-                {math equation="(total%perLine)" total=$smarty.foreach.manufacturers.total perLine=$nbItemsPerLine assign=totModulo}
-                {math equation="(total%perLineT)" total=$smarty.foreach.manufacturers.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
-                {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
-                {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
-                <li class="{if $smarty.foreach.manufacturers.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.manufacturers.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.manufacturers.iteration > ($smarty.foreach.manufacturers.total - $totModulo)}last-line{/if} {if $smarty.foreach.manufacturers.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.manufacturers.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.manufacturers.iteration > ($smarty.foreach.manufacturers.total - $totModuloTablet)}last-tablet-line{/if}{if $smarty.foreach.manufacturers.last} item-last{/if} col-xs-12">
-                    <div class="mansup-container">
-                        <div class="row">
-                            <div class="left-side col-xs-12 col-sm-3">
-                                <div class="logo">
-                                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                        <a
-                                        class="lnk_img"
-                                        href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}"
-                                        title="{$manufacturer.name|escape:'html':'UTF-8'}" >
-                                    {/if}
-                                        <img src="{$img_manu_dir}{$manufacturer.image|escape:'html':'UTF-8'}-medium_default.jpg" alt="" />
-                                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                        </a>
-                                    {/if}
-                                </div> <!-- .logo -->
-                            </div> <!-- .left-side -->
-
-                            <div class="middle-side col-xs-12 col-sm-5">
-                                <h3>
-                                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                        <a
-                                        class="product-name"
-                                        href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">
-                                    {/if}
-                                        {$manufacturer.name|truncate:60:'...'|escape:'html':'UTF-8'}
-                                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                        </a>
-                                    {/if}
-                                </h3>
-                                <div class="description rte">
-                                    {$manufacturer.short_description}
-                                </div>
-                            </div> <!-- .middle-side -->
-
-                            <div class="right-side col-xs-12 col-sm-4">
-                                <div class="right-side-content">
-                                    <p class="product-counter">
-                                        {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                            <a href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">
-                                        {/if}
-                                        {if isset($manufacturer.nb_products) && $manufacturer.nb_products == 1}
-                                            {l s='%d product' sprintf=$manufacturer.nb_products|intval}
-                                        {else}
-                                          {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                            {l s='%d products' sprintf=$manufacturer.nb_products|intval}
-                                          {/if}
-                                        {/if}
-                                        {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                            </a>
-                                        {/if}
-                                    </p>
-                                    {if isset($manufacturer.nb_products) && $manufacturer.nb_products > 0}
-                                        <a
-                                        class="btn btn-default button exclusive-medium"
-                                        href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">
-                                            <span>
-                                                {l s='view products'} <i class="icon-chevron-right right"></i>
-                                            </span>
-                                        </a>
-                                    {/if}
-                                </div>
-                            </div> <!-- .right-side -->
-                        </div>
-                    </div>
-                </li>
-            {/foreach}
-        </ul>
-        <div class="content_sortPagiBar">
-            <div class="bottom-pagination-content clearfix">
-                {include file="$tpl_dir./pagination.tpl" no_follow=1 paginationId='bottom'}
-            </div>
-        </div>
-    {/if}
+          </div>
+        </li>
+      {/foreach}
+    </ul>
+    <div class="content_sortPagiBar">
+      <div class="bottom-pagination-content clearfix">
+        {include file="$tpl_dir./pagination.tpl" no_follow=1 paginationId='bottom'}
+      </div>
+    </div>
+  {/if}
 {/if}

--- a/themes/community-theme-16/manufacturer.tpl
+++ b/themes/community-theme-16/manufacturer.tpl
@@ -27,52 +27,52 @@
 {include file="$tpl_dir./errors.tpl"}
 
 {if !isset($errors) OR !sizeof($errors)}
-    <h1 class="page-heading product-listing">
-        {l s='List of products by manufacturer'}&nbsp;{$manufacturer->name|escape:'html':'UTF-8'}
-    </h1>
-    {if !empty($manufacturer->description) || !empty($manufacturer->short_description)}
-        <div class="description_box rte">
-            {if !empty($manufacturer->short_description)}
-                <div class="short_desc">
-                    {$manufacturer->short_description}
-                </div>
-                <div class="hide_desc">
-                    {$manufacturer->description}
-                </div>
-                {if !empty($manufacturer->description)}
-                    <a href="#" class="lnk_more" onclick="$(this).prev().slideDown('slow'); $(this).hide();$(this).prev().prev().hide(); return false;">
-                        {l s='More'}
-                    </a>
-                {/if}
-            {else}
-                <div>
-                    {$manufacturer->description}
-                </div>
-            {/if}
+  <h1 class="page-heading product-listing">
+    {l s='List of products by manufacturer'}&nbsp;{$manufacturer->name|escape:'html':'UTF-8'}
+  </h1>
+  {if !empty($manufacturer->description) || !empty($manufacturer->short_description)}
+    <div class="description_box rte">
+      {if !empty($manufacturer->short_description)}
+        <div class="short_desc">
+          {$manufacturer->short_description}
         </div>
-    {/if}
-
-    {if $products}
-        <div class="content_sortPagiBar">
-            <div class="sortPagiBar clearfix">
-                {include file="./product-sort.tpl"}
-                {include file="./nbr-product-page.tpl"}
-            </div>
-            <div class="top-pagination-content clearfix">
-                {include file="./product-compare.tpl"}
-                {include file="$tpl_dir./pagination.tpl" no_follow=1}
-            </div>
+        <div class="hide_desc">
+          {$manufacturer->description}
         </div>
-
-        {include file="./product-list.tpl" products=$products}
-
-        <div class="content_sortPagiBar">
-            <div class="bottom-pagination-content clearfix">
-                {include file="./product-compare.tpl"}
-                {include file="./pagination.tpl" no_follow=1 paginationId='bottom'}
-            </div>
+        {if !empty($manufacturer->description)}
+          <a href="#" class="lnk_more" onclick="$(this).prev().slideDown('slow'); $(this).hide();$(this).prev().prev().hide(); return false;">
+            {l s='More'}
+          </a>
+        {/if}
+      {else}
+        <div>
+          {$manufacturer->description}
         </div>
-    {else}
-        <p class="alert alert-warning">{l s='No products for this manufacturer.'}</p>
-    {/if}
+      {/if}
+    </div>
+  {/if}
+
+  {if $products}
+    <div class="content_sortPagiBar">
+      <div class="sortPagiBar clearfix">
+        {include file="./product-sort.tpl"}
+        {include file="./nbr-product-page.tpl"}
+      </div>
+      <div class="top-pagination-content clearfix">
+        {include file="./product-compare.tpl"}
+        {include file="$tpl_dir./pagination.tpl" no_follow=1}
+      </div>
+    </div>
+
+    {include file="./product-list.tpl" products=$products}
+
+    <div class="content_sortPagiBar">
+      <div class="bottom-pagination-content clearfix">
+        {include file="./product-compare.tpl"}
+        {include file="./pagination.tpl" no_follow=1 paginationId='bottom'}
+      </div>
+    </div>
+  {else}
+    <p class="alert alert-warning">{l s='No products for this manufacturer.'}</p>
+  {/if}
 {/if}

--- a/themes/community-theme-16/modules/bankwire/views/templates/front/payment_execution.tpl
+++ b/themes/community-theme-16/modules/bankwire/views/templates/front/payment_execution.tpl
@@ -24,70 +24,70 @@
 *}
 
 {capture name=path}
-    <a href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}" title="{l s='Go back to the Checkout' mod='bankwire'}">{l s='Checkout' mod='bankwire'}</a><span class="navigation-pipe">{$navigationPipe}</span>{l s='Bank-wire payment' mod='bankwire'}
+  <a href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}" title="{l s='Go back to the Checkout' mod='bankwire'}">{l s='Checkout' mod='bankwire'}</a><span class="navigation-pipe">{$navigationPipe}</span>{l s='Bank-wire payment' mod='bankwire'}
 {/capture}
 
 <h1 class="page-heading">
-    {l s='Order summary' mod='bankwire'}
+  {l s='Order summary' mod='bankwire'}
 </h1>
 
 {assign var='current_step' value='payment'}
 {include file="$tpl_dir./order-steps.tpl"}
 
 {if $nbProducts <= 0}
-    <p class="alert alert-warning">
-        {l s='Your shopping cart is empty.' mod='bankwire'}
-    </p>
+  <p class="alert alert-warning">
+    {l s='Your shopping cart is empty.' mod='bankwire'}
+  </p>
 {else}
-    <form action="{$link->getModuleLink('bankwire', 'validation', [], true)|escape:'html':'UTF-8'}" method="post">
-        <div class="box cheque-box">
-            <h3 class="page-subheading">
-                {l s='Bank-wire payment' mod='bankwire'}
-            </h3>
-            <p class="cheque-indent">
-                <strong class="dark">
-                    {l s='You have chosen to pay by bank wire.' mod='bankwire'} {l s='Here is a short summary of your order:' mod='bankwire'}
-                </strong>
-            </p>
-            <p>
-                - {l s='The total amount of your order is' mod='bankwire'}
-                <span id="amount" class="price">{displayPrice price=$total}</span>
-                {if $use_taxes == 1}
-                    {l s='(tax incl.)' mod='bankwire'}
-                {/if}
-            </p>
-            <p>
-                -
-                {if $currencies|@count > 1}
-                    {l s='We allow several currencies to be sent via bank wire.' mod='bankwire'}
-                    <div class="form-group">
-                        <label>{l s='Choose one of the following:' mod='bankwire'}</label>
-                        <select id="currency_payment" class="form-control" name="currency_payment">
-                            {foreach from=$currencies item=currency}
-                                <option value="{$currency.id_currency}" {if $currency.id_currency == $cust_currency}selected="selected"{/if}>
-                                    {$currency.name}
-                                </option>
-                            {/foreach}
-                        </select>
-                    </div>
-                {else}
-                    {l s='We allow the following currency to be sent via bank wire:' mod='bankwire'}&nbsp;<b>{$currencies.0.name}</b>
-                    <input type="hidden" name="currency_payment" value="{$currencies.0.id_currency}" />
-                {/if}
-            </p>
-            <p>
-                - {l s='Bank wire account information will be displayed on the next page.' mod='bankwire'}
-                <br />
-                - {l s='Please confirm your order by clicking "I confirm my order".' mod='bankwire'}
-            </p>
-        </div><!-- .cheque-box -->
-        <p class="cart_navigation clearfix" id="cart_navigation">
-            <a class="button-exclusive btn btn-default" href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}">
-                <i class="icon-chevron-left"></i>{l s='Other payment methods' mod='bankwire'}
-            </a>
-            <button class="button btn btn-default button-medium" type="submit">
-                <span>{l s='I confirm my order' mod='bankwire'}<i class="icon-chevron-right right"></i></span>
-            </button>
-        </p>
-    </form>
+  <form action="{$link->getModuleLink('bankwire', 'validation', [], true)|escape:'html':'UTF-8'}" method="post">
+    <div class="box cheque-box">
+      <h3 class="page-subheading">
+        {l s='Bank-wire payment' mod='bankwire'}
+      </h3>
+      <p class="cheque-indent">
+        <strong class="dark">
+          {l s='You have chosen to pay by bank wire.' mod='bankwire'} {l s='Here is a short summary of your order:' mod='bankwire'}
+        </strong>
+      </p>
+      <p>
+        - {l s='The total amount of your order is' mod='bankwire'}
+        <span id="amount" class="price">{displayPrice price=$total}</span>
+        {if $use_taxes == 1}
+          {l s='(tax incl.)' mod='bankwire'}
+        {/if}
+      </p>
+      <p>
+        -
+        {if $currencies|@count > 1}
+          {l s='We allow several currencies to be sent via bank wire.' mod='bankwire'}
+          <div class="form-group">
+            <label>{l s='Choose one of the following:' mod='bankwire'}</label>
+            <select id="currency_payment" class="form-control" name="currency_payment">
+              {foreach from=$currencies item=currency}
+                <option value="{$currency.id_currency}" {if $currency.id_currency == $cust_currency}selected="selected"{/if}>
+                  {$currency.name}
+                </option>
+              {/foreach}
+            </select>
+          </div>
+        {else}
+          {l s='We allow the following currency to be sent via bank wire:' mod='bankwire'}&nbsp;<b>{$currencies.0.name}</b>
+          <input type="hidden" name="currency_payment" value="{$currencies.0.id_currency}" />
+        {/if}
+      </p>
+      <p>
+        - {l s='Bank wire account information will be displayed on the next page.' mod='bankwire'}
+        <br />
+        - {l s='Please confirm your order by clicking "I confirm my order".' mod='bankwire'}
+      </p>
+    </div><!-- .cheque-box -->
+    <p class="cart_navigation clearfix" id="cart_navigation">
+      <a class="button-exclusive btn btn-default" href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}">
+        <i class="icon-chevron-left"></i>{l s='Other payment methods' mod='bankwire'}
+      </a>
+      <button class="button btn btn-default button-medium" type="submit">
+        <span>{l s='I confirm my order' mod='bankwire'}<i class="icon-chevron-right right"></i></span>
+      </button>
+    </p>
+  </form>
 {/if}

--- a/themes/community-theme-16/modules/bankwire/views/templates/hook/payment.tpl
+++ b/themes/community-theme-16/modules/bankwire/views/templates/hook/payment.tpl
@@ -23,11 +23,11 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="row">
-    <div class="col-xs-12">
-        <p class="payment_module">
-            <a class="bankwire" href="{$link->getModuleLink('bankwire', 'payment')|escape:'html':'UTF-8'}" title="{l s='Pay by bank wire' mod='bankwire'}">
-                {l s='Pay by bank wire' mod='bankwire'} <span>{l s='(order processing will be longer)' mod='bankwire'}</span>
-            </a>
-        </p>
-    </div>
+  <div class="col-xs-12">
+    <p class="payment_module">
+      <a class="bankwire" href="{$link->getModuleLink('bankwire', 'payment')|escape:'html':'UTF-8'}" title="{l s='Pay by bank wire' mod='bankwire'}">
+        {l s='Pay by bank wire' mod='bankwire'} <span>{l s='(order processing will be longer)' mod='bankwire'}</span>
+      </a>
+    </p>
+  </div>
 </div>

--- a/themes/community-theme-16/modules/bankwire/views/templates/hook/payment_return.tpl
+++ b/themes/community-theme-16/modules/bankwire/views/templates/hook/payment_return.tpl
@@ -24,24 +24,24 @@
 *}
 
 {if $status == 'ok'}
-    <p class="alert alert-success">{l s='Your order on %s is complete.' sprintf=$shop_name mod='cheque'}</p>
-    <div class="box">
-        {l s='Please send us a bank wire with' mod='bankwire'}
-        <br />- {l s='Amount' mod='bankwire'} <span class="price"><strong>{$total_to_pay}</strong></span>
-        <br />- {l s='Name of account owner' mod='bankwire'}  <strong>{if $bankwireOwner}{$bankwireOwner}{else}___________{/if}</strong>
-        <br />- {l s='Include these details' mod='bankwire'}  <strong>{if $bankwireDetails}{$bankwireDetails}{else}___________{/if}</strong>
-        <br />- {l s='Bank name' mod='bankwire'}  <strong>{if $bankwireAddress}{$bankwireAddress}{else}___________{/if}</strong>
-        {if !isset($reference)}
-            <br />- {l s='Do not forget to insert your order number #%d in the subject of your bank wire.' sprintf=$id_order mod='bankwire'}
-        {else}
-            <br />- {l s='Do not forget to insert your order reference %s in the subject of your bank wire.' sprintf=$reference mod='bankwire'}
-        {/if}<br />{l s='An email has been sent with this information.' mod='bankwire'}
-        <br /> <strong>{l s='Your order will be sent as soon as we receive payment.' mod='bankwire'}</strong>
-        <br />{l s='If you have questions, comments or concerns, please contact our' mod='bankwire'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='expert customer support team' mod='bankwire'}</a>.
-    </div>
+  <p class="alert alert-success">{l s='Your order on %s is complete.' sprintf=$shop_name mod='cheque'}</p>
+  <div class="box">
+    {l s='Please send us a bank wire with' mod='bankwire'}
+    <br />- {l s='Amount' mod='bankwire'} <span class="price"><strong>{$total_to_pay}</strong></span>
+    <br />- {l s='Name of account owner' mod='bankwire'}  <strong>{if $bankwireOwner}{$bankwireOwner}{else}___________{/if}</strong>
+    <br />- {l s='Include these details' mod='bankwire'}  <strong>{if $bankwireDetails}{$bankwireDetails}{else}___________{/if}</strong>
+    <br />- {l s='Bank name' mod='bankwire'}  <strong>{if $bankwireAddress}{$bankwireAddress}{else}___________{/if}</strong>
+    {if !isset($reference)}
+  <br />- {l s='Do not forget to insert your order number #%d in the subject of your bank wire.' sprintf=$id_order mod='bankwire'}
+    {else}
+  <br />- {l s='Do not forget to insert your order reference %s in the subject of your bank wire.' sprintf=$reference mod='bankwire'}
+    {/if}<br />{l s='An email has been sent with this information.' mod='bankwire'}
+    <br /> <strong>{l s='Your order will be sent as soon as we receive payment.' mod='bankwire'}</strong>
+    <br />{l s='If you have questions, comments or concerns, please contact our' mod='bankwire'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='expert customer support team' mod='bankwire'}</a>.
+  </div>
 {else}
-    <p class="alert alert-warning">
-        {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our' mod='bankwire'}
-        <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer service department.' mod='bankwire'}</a>.
-    </p>
+  <p class="alert alert-warning">
+    {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our' mod='bankwire'}
+    <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer service department.' mod='bankwire'}</a>.
+  </p>
 {/if}

--- a/themes/community-theme-16/modules/blockbestsellers/blockbestsellers.tpl
+++ b/themes/community-theme-16/modules/blockbestsellers/blockbestsellers.tpl
@@ -26,40 +26,40 @@
 
 <!-- MODULE Block best sellers -->
 <div id="best-sellers_block_right" class="block products_block">
-    <h4 class="title_block">
-        <a href="{$link->getPageLink('best-sales')|escape:'html'}" title="{l s='View a top sellers products' mod='blockbestsellers'}">{l s='Top sellers' mod='blockbestsellers'}</a>
-    </h4>
-    <div class="block_content">
+  <h4 class="title_block">
+    <a href="{$link->getPageLink('best-sales')|escape:'html'}" title="{l s='View a top sellers products' mod='blockbestsellers'}">{l s='Top sellers' mod='blockbestsellers'}</a>
+  </h4>
+  <div class="block_content">
     {if $best_sellers && $best_sellers|@count > 0}
-        <ul class="block_content products-block">
-            {foreach from=$best_sellers item=product name=myLoop}
-            <li class="clearfix">
-                <a href="{$product.link|escape:'html'}" title="{$product.legend|escape:'html':'UTF-8'}" class="products-block-image content_img clearfix">
-                    <img class="replace-2x img-responsive" src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html'}" alt="{$product.legend|escape:'html':'UTF-8'}" />
+      <ul class="block_content products-block">
+        {foreach from=$best_sellers item=product name=myLoop}
+          <li class="clearfix">
+            <a href="{$product.link|escape:'html'}" title="{$product.legend|escape:'html':'UTF-8'}" class="products-block-image content_img clearfix">
+              <img class="replace-2x img-responsive" src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html'}" alt="{$product.legend|escape:'html':'UTF-8'}" />
+            </a>
+            <div class="product-content">
+              <h5>
+                <a class="product-name" href="{$product.link|escape:'html'}" title="{$product.legend|escape:'html':'UTF-8'}">
+                  {$product.name|strip_tags:'UTF-8'|escape:'html':'UTF-8'}
                 </a>
-                <div class="product-content">
-                    <h5>
-                        <a class="product-name" href="{$product.link|escape:'html'}" title="{$product.legend|escape:'html':'UTF-8'}">
-                            {$product.name|strip_tags:'UTF-8'|escape:'html':'UTF-8'}
-                        </a>
-                    </h5>
-                    <p class="product-description">{$product.description_short|strip_tags:'UTF-8'|truncate:75:'...'}</p>
-                    {if !$PS_CATALOG_MODE}
-                        <div class="price-box">
-                            <span class="price">{$product.price}</span>
-                            {hook h="displayProductPriceBlock" product=$product type="price"}
-                        </div>
-                    {/if}
+              </h5>
+              <p class="product-description">{$product.description_short|strip_tags:'UTF-8'|truncate:75:'...'}</p>
+              {if !$PS_CATALOG_MODE}
+                <div class="price-box">
+                  <span class="price">{$product.price}</span>
+                  {hook h="displayProductPriceBlock" product=$product type="price"}
                 </div>
-            </li>
+              {/if}
+            </div>
+          </li>
         {/foreach}
-        </ul>
-        <div class="lnk">
-            <a href="{$link->getPageLink('best-sales')|escape:'html'}" title="{l s='All best sellers' mod='blockbestsellers'}"  class="btn btn-default button button-small"><span>{l s='All best sellers' mod='blockbestsellers'}<i class="icon-chevron-right right"></i></span></a>
-        </div>
+      </ul>
+      <div class="lnk">
+        <a href="{$link->getPageLink('best-sales')|escape:'html'}" title="{l s='All best sellers' mod='blockbestsellers'}"  class="btn btn-default button button-small"><span>{l s='All best sellers' mod='blockbestsellers'}<i class="icon-chevron-right right"></i></span></a>
+      </div>
     {else}
-        <p>{l s='No best sellers at this time' mod='blockbestsellers'}</p>
+      <p>{l s='No best sellers at this time' mod='blockbestsellers'}</p>
     {/if}
-    </div>
+  </div>
 </div>
 <!-- /MODULE Block best sellers -->

--- a/themes/community-theme-16/modules/blockcart/blockcart-json.tpl
+++ b/themes/community-theme-16/modules/blockcart/blockcart-json.tpl
@@ -25,76 +25,76 @@
 {ldelim}
 "products": [
 {if $products}
-{foreach from=$products item=product name='products'}
-{assign var='productId' value=$product.id_product}
-{assign var='productAttributeId' value=$product.id_product_attribute}
+  {foreach from=$products item=product name='products'}
+    {assign var='productId' value=$product.id_product}
+    {assign var='productAttributeId' value=$product.id_product_attribute}
     {ldelim}
-        "id": {$product.id_product|intval},
-        "link": {$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute)|json_encode},
-        "quantity": {$product.cart_quantity|intval},
-        "image": {$link->getImageLink($product.link_rewrite, $product.id_image, 'home_default')|json_encode},
-        "image_cart": {$link->getImageLink($product.link_rewrite, $product.id_image, 'cart_default')|json_encode},
-        "priceByLine": {if $priceDisplay == $smarty.const.PS_TAX_EXC}{displayWtPrice|json_encode p=$product.total}{else}{displayWtPrice|json_encode p=$product.total_wt}{/if},
-        "name": {$product.name|trim|html_entity_decode:2:'UTF-8'|json_encode},
-        "price": {if $priceDisplay == $smarty.const.PS_TAX_EXC}{displayWtPrice|json_encode p=$product.total}{else}{displayWtPrice|json_encode p=$product.total_wt}{/if},
-        "price_float": {$product.total|floatval|json_encode},
-        "idCombination": {if isset($product.attributes_small)}{$productAttributeId|intval}{else}0{/if},
-        "idAddressDelivery": {if isset($product.id_address_delivery)}{$product.id_address_delivery|intval}{else}0{/if},
-        "is_gift": {if isset($product.is_gift) && $product.is_gift}true{else}false{/if},
-{if isset($product.attributes_small)}
-        "hasAttributes": true,
-        "attributes": {$product.attributes_small|json_encode},
-{else}
-        "hasAttributes": false,
-{/if}
-        "hasCustomizedDatas": {if isset($customizedDatas.$productId.$productAttributeId)}true{else}false{/if},
-        "customizedDatas": [
-        {if isset($customizedDatas.$productId.$productAttributeId[$product.id_address_delivery])}
-        {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization' name='customizedDatas'}{ldelim}
-{* This empty line was made in purpose (product addition debug), please leave it here *}
-            "customizationId": {$id_customization|intval},
-            "quantity": {$customization.quantity|intval},
-            "datas": [
-                {foreach from=$customization.datas key='type' item='datas' name='customization'}
-                {ldelim}
-                    "type": {$type|json_encode},
-                    "datas": [
-                    {foreach from=$datas key='index' item='data' name='datas'}
-                        {ldelim}
-                        "index": {$index|intval},
-                        "value": {Tools::nl2br($data.value)|json_encode},
-                        "truncatedValue": {Tools::nl2br($data.value|truncate:28:'...')|json_encode}
-                        {rdelim}{if !$smarty.foreach.datas.last},{/if}
-                    {/foreach}]
-                {rdelim}{if !$smarty.foreach.customization.last},{/if}
-                {/foreach}
-            ]
-        {rdelim}{if !$smarty.foreach.customizedDatas.last},{/if}
+    "id": {$product.id_product|intval},
+    "link": {$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute)|json_encode},
+    "quantity": {$product.cart_quantity|intval},
+    "image": {$link->getImageLink($product.link_rewrite, $product.id_image, 'home_default')|json_encode},
+    "image_cart": {$link->getImageLink($product.link_rewrite, $product.id_image, 'cart_default')|json_encode},
+    "priceByLine": {if $priceDisplay == $smarty.const.PS_TAX_EXC}{displayWtPrice|json_encode p=$product.total}{else}{displayWtPrice|json_encode p=$product.total_wt}{/if},
+    "name": {$product.name|trim|html_entity_decode:2:'UTF-8'|json_encode},
+    "price": {if $priceDisplay == $smarty.const.PS_TAX_EXC}{displayWtPrice|json_encode p=$product.total}{else}{displayWtPrice|json_encode p=$product.total_wt}{/if},
+    "price_float": {$product.total|floatval|json_encode},
+    "idCombination": {if isset($product.attributes_small)}{$productAttributeId|intval}{else}0{/if},
+    "idAddressDelivery": {if isset($product.id_address_delivery)}{$product.id_address_delivery|intval}{else}0{/if},
+    "is_gift": {if isset($product.is_gift) && $product.is_gift}true{else}false{/if},
+    {if isset($product.attributes_small)}
+      "hasAttributes": true,
+      "attributes": {$product.attributes_small|json_encode},
+    {else}
+      "hasAttributes": false,
+    {/if}
+    "hasCustomizedDatas": {if isset($customizedDatas.$productId.$productAttributeId)}true{else}false{/if},
+    "customizedDatas": [
+    {if isset($customizedDatas.$productId.$productAttributeId[$product.id_address_delivery])}
+      {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization' name='customizedDatas'}{ldelim}
+        {* This empty line was made in purpose (product addition debug), please leave it here *}
+        "customizationId": {$id_customization|intval},
+        "quantity": {$customization.quantity|intval},
+        "datas": [
+        {foreach from=$customization.datas key='type' item='datas' name='customization'}
+          {ldelim}
+          "type": {$type|json_encode},
+          "datas": [
+          {foreach from=$datas key='index' item='data' name='datas'}
+            {ldelim}
+            "index": {$index|intval},
+            "value": {Tools::nl2br($data.value)|json_encode},
+            "truncatedValue": {Tools::nl2br($data.value|truncate:28:'...')|json_encode}
+          {rdelim}{if !$smarty.foreach.datas.last},{/if}
+          {/foreach}]
+        {rdelim}{if !$smarty.foreach.customization.last},{/if}
         {/foreach}
-        {/if}
         ]
-    {rdelim}{if !$smarty.foreach.products.last},{/if}
-{/foreach}{/if}
+      {rdelim}{if !$smarty.foreach.customizedDatas.last},{/if}
+      {/foreach}
+    {/if}
+    ]
+  {rdelim}{if !$smarty.foreach.products.last},{/if}
+  {/foreach}{/if}
 ],
 "discounts": [
 {if $discounts}{foreach from=$discounts item=discount name='discounts'}
-    {ldelim}
-        "id": {$discount.id_discount|intval},
-        "name": {$discount.name|trim|truncate:18:'...'|json_encode},
-        "description": {$discount.description|json_encode},
-        "nameDescription": {$discount.name|cat:' : '|cat:$discount.description|trim|truncate:18:'...'|json_encode},
-        "code": {$discount.code|json_encode},
-        "link": {$link->getPageLink("$order_process", true, NULL, "deleteDiscount={$discount.id_discount}")|json_encode},
-        "price": {if $priceDisplay == 1}{convertPrice|json_encode price=$discount.value_tax_exc}{else}{convertPrice|json_encode price=$discount.value_real}{/if},
-        "price_float": {if $priceDisplay == 1}{$discount.value_tax_exc|json_encode}{else}{$discount.value_real|json_encode}{/if}
-    {rdelim}
-    {if !$smarty.foreach.discounts.last},{/if}
+  {ldelim}
+  "id": {$discount.id_discount|intval},
+  "name": {$discount.name|trim|truncate:18:'...'|json_encode},
+  "description": {$discount.description|json_encode},
+  "nameDescription": {$discount.name|cat:' : '|cat:$discount.description|trim|truncate:18:'...'|json_encode},
+  "code": {$discount.code|json_encode},
+  "link": {$link->getPageLink("$order_process", true, NULL, "deleteDiscount={$discount.id_discount}")|json_encode},
+  "price": {if $priceDisplay == 1}{convertPrice|json_encode price=$discount.value_tax_exc}{else}{convertPrice|json_encode price=$discount.value_real}{/if},
+  "price_float": {if $priceDisplay == 1}{$discount.value_tax_exc|json_encode}{else}{$discount.value_real|json_encode}{/if}
+{rdelim}
+  {if !$smarty.foreach.discounts.last},{/if}
 {/foreach}{/if}
 ],
 "shippingCost": {$shipping_cost|json_encode},
 "shippingCostFloat": {$shipping_cost_float|json_encode},
 {if isset($tax_cost)}
-"taxCost": {$tax_cost|json_encode},
+  "taxCost": {$tax_cost|json_encode},
 {/if}
 "wrappingCost": {$wrapping_cost|json_encode},
 "nbTotalProducts": {$nb_total_products|intval},
@@ -105,14 +105,14 @@
 "free_ship": {(!$shipping_cost_float && !count($cart->getDeliveryAddressesWithoutCarriers(true, $errors_back)))|json_encode},
 "isVirtualCart": {$cart->isVirtualCart()|json_encode},
 {if isset($errors) && $errors}
-"hasError" : true,
-"errors" : [
-{foreach from=$errors key=k item=error name='errors'}
+  "hasError" : true,
+  "errors" : [
+  {foreach from=$errors key=k item=error name='errors'}
     {$error|json_encode}
     {if !$smarty.foreach.errors.last},{/if}
-{/foreach}
-]
+  {/foreach}
+  ]
 {else}
-"hasError" : false
+  "hasError" : false
 {/if}
 {rdelim}

--- a/themes/community-theme-16/modules/blockcart/blockcart.tpl
+++ b/themes/community-theme-16/modules/blockcart/blockcart.tpl
@@ -25,328 +25,328 @@
 <!-- MODULE Block cart -->
 {if isset($blockcart_top) && $blockcart_top}
 <div class="col-sm-4 clearfix{if $PS_CATALOG_MODE} header_user_catalog{/if}">
-{/if}
-    <div class="shopping_cart">
-        <a href="{$link->getPageLink($order_process, true)|escape:'html':'UTF-8'}" title="{l s='View my shopping cart' mod='blockcart'}" rel="nofollow">
-            <b>{l s='Cart' mod='blockcart'}</b>
-            <span class="ajax_cart_quantity{if $cart_qties == 0} unvisible{/if}">{$cart_qties}</span>
-            <span class="ajax_cart_product_txt{if $cart_qties != 1} unvisible{/if}">{l s='Product' mod='blockcart'}</span>
-            <span class="ajax_cart_product_txt_s{if $cart_qties < 2} unvisible{/if}">{l s='Products' mod='blockcart'}</span>
-            <span class="ajax_cart_total{if $cart_qties == 0} unvisible{/if}">
-                {if $cart_qties > 0}
-                    {if $priceDisplay == 1}
-                        {assign var='blockcart_cart_flag' value='Cart::BOTH_WITHOUT_SHIPPING'|constant}
-                        {convertPrice price=$cart->getOrderTotal(false, $blockcart_cart_flag)}
-                    {else}
-                        {assign var='blockcart_cart_flag' value='Cart::BOTH_WITHOUT_SHIPPING'|constant}
-                        {convertPrice price=$cart->getOrderTotal(true, $blockcart_cart_flag)}
-                    {/if}
-                {/if}
-            </span>
-            <span class="ajax_cart_no_product{if $cart_qties > 0} unvisible{/if}">{l s='(empty)' mod='blockcart'}</span>
-            {if $ajax_allowed && isset($blockcart_top) && !$blockcart_top}
-                <span class="block_cart_expand{if !isset($colapseExpandStatus) || (isset($colapseExpandStatus) && $colapseExpandStatus eq 'expanded')} unvisible{/if}">&nbsp;</span>
-                <span class="block_cart_collapse{if isset($colapseExpandStatus) && $colapseExpandStatus eq 'collapsed'} unvisible{/if}">&nbsp;</span>
-            {/if}
-        </a>
-        {if !$PS_CATALOG_MODE}
-            <div class="cart_block block exclusive">
-                <div class="block_content">
-                    <!-- block list of products -->
-                    <div class="cart_block_list{if isset($blockcart_top) && !$blockcart_top}{if isset($colapseExpandStatus) && $colapseExpandStatus eq 'expanded' || !$ajax_allowed || !isset($colapseExpandStatus)} expanded{else} collapsed unvisible{/if}{/if}">
-                        {if $products}
-                            <dl class="products">
-                                {foreach from=$products item='product' name='myLoop'}
-                                    {assign var='productId' value=$product.id_product}
-                                    {assign var='productAttributeId' value=$product.id_product_attribute}
-                                    <dt data-id="cart_block_product_{$product.id_product|intval}_{if $product.id_product_attribute}{$product.id_product_attribute|intval}{else}0{/if}_{if $product.id_address_delivery}{$product.id_address_delivery|intval}{else}0{/if}" class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if}">
-                                        <a class="cart-images" href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'cart_default')}" alt="{$product.name|escape:'html':'UTF-8'}" /></a>
-                                        <div class="cart-info">
-                                            <div class="product-name">
-                                                <span class="quantity-formated"><span class="quantity">{$product.cart_quantity}</span>&nbsp;x&nbsp;</span><a class="cart_block_product_name" href="{$link->getProductLink($product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}">{$product.name|truncate:13:'...'|escape:'html':'UTF-8'}</a>
-                                            </div>
-                                            {if isset($product.attributes_small)}
-                                                <div class="product-atributes">
-                                                    <a href="{$link->getProductLink($product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockcart'}">{$product.attributes_small}</a>
-                                                </div>
-                                            {/if}
-                                            <span class="price">
-                                                {if !isset($product.is_gift) || !$product.is_gift}
-                                                    {if $priceDisplay == $smarty.const.PS_TAX_EXC}{displayWtPrice p="`$product.total`"}{else}{displayWtPrice p="`$product.total_wt`"}{/if}
-                                                    <div class="hookDisplayProductPriceBlock-price">
-                                                        {hook h="displayProductPriceBlock" product=$product type="price" from="blockcart"}
-                                                    </div>
-                                                {else}
-                                                    {l s='Free!' mod='blockcart'}
-                                                {/if}
-                                            </span>
-                                        </div>
-                                        <span class="remove_link">
-                                            {if !isset($customizedDatas.$productId.$productAttributeId) && (!isset($product.is_gift) || !$product.is_gift)}
-                                                <a class="ajax_cart_block_remove_link" href="{$link->getPageLink('cart', true, NULL, "delete=1&id_product={$product.id_product|intval}&ipa={$product.id_product_attribute|intval}&id_address_delivery={$product.id_address_delivery|intval}&token={$static_token}")|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='remove this product from my cart' mod='blockcart'}">&nbsp;</a>
-                                            {/if}
-                                        </span>
-                                    </dt>
-                                    {if isset($product.attributes_small)}
-                                        <dd data-id="cart_block_combination_of_{$product.id_product|intval}{if $product.id_product_attribute}_{$product.id_product_attribute|intval}{/if}_{$product.id_address_delivery|intval}" class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if}">
-                                    {/if}
-                                    <!-- Customizable datas -->
-                                    {if isset($customizedDatas.$productId.$productAttributeId[$product.id_address_delivery])}
-                                        {if !isset($product.attributes_small)}
-                                            <dd data-id="cart_block_combination_of_{$product.id_product|intval}_{if $product.id_product_attribute}{$product.id_product_attribute|intval}{else}0{/if}_{if $product.id_address_delivery}{$product.id_address_delivery|intval}{else}0{/if}" class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if}">
-                                        {/if}
-                                        <ul class="cart_block_customizations" data-id="customization_{$productId}_{$productAttributeId}">
-                                            {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization' name='customizations'}
-                                                <li name="customization">
-                                                    <div data-id="deleteCustomizableProduct_{$id_customization|intval}_{$product.id_product|intval}_{$product.id_product_attribute|intval}_{$product.id_address_delivery|intval}" class="deleteCustomizableProduct">
-                                                        <a class="ajax_cart_block_remove_link" href="{$link->getPageLink('cart', true, NULL, "delete=1&id_product={$product.id_product|intval}&ipa={$product.id_product_attribute|intval}&id_customization={$id_customization|intval}&token={$static_token}")|escape:'html':'UTF-8'}" rel="nofollow">&nbsp;</a>
-                                                    </div>
-                                                    {if isset($customization.datas.$CUSTOMIZE_TEXTFIELD.0)}
-                                                        {$customization.datas.$CUSTOMIZE_TEXTFIELD.0.value|replace:"<br />":" "|truncate:28:'...'|escape:'html':'UTF-8'}
-                                                    {else}
-                                                        {l s='Customization #%d:' sprintf=$id_customization|intval mod='blockcart'}
-                                                    {/if}
-                                                </li>
-                                            {/foreach}
-                                        </ul>
-                                        {if !isset($product.attributes_small)}</dd>{/if}
-                                    {/if}
-                                    {if isset($product.attributes_small)}</dd>{/if}
-                                {/foreach}
-                            </dl>
-                        {/if}
-                        <p class="cart_block_no_products{if $products} unvisible{/if}">
-                            {l s='No products' mod='blockcart'}
-                        </p>
-                        {if $discounts|@count > 0}
-                            <table class="vouchers{if $discounts|@count == 0} unvisible{/if}">
-                                {foreach from=$discounts item=discount}
-                                    {if $discount.value_real > 0}
-                                        <tr class="bloc_cart_voucher" data-id="bloc_cart_voucher_{$discount.id_discount|intval}">
-                                            <td class="quantity">1x</td>
-                                            <td class="name" title="{$discount.description}">
-                                                {$discount.name|truncate:18:'...'|escape:'html':'UTF-8'}
-                                            </td>
-                                            <td class="price">
-                                                -{if $priceDisplay == 1}{convertPrice price=$discount.value_tax_exc}{else}{convertPrice price=$discount.value_real}{/if}
-                                            </td>
-                                            <td class="delete">
-                                                {if strlen($discount.code)}
-                                                    <a class="delete_voucher" href="{$link->getPageLink("$order_process", true)}?deleteDiscount={$discount.id_discount|intval}" title="{l s='Delete' mod='blockcart'}" rel="nofollow">
-                                                        <i class="icon-remove-sign"></i>
-                                                    </a>
-                                                {/if}
-                                            </td>
-                                        </tr>
-                                    {/if}
-                                {/foreach}
-                            </table>
-                        {/if}
-                        {assign var='free_ship' value=count($cart->getDeliveryAddressesWithoutCarriers(true, $errors))}
-                        <div class="cart-prices">
-                            <div class="cart-prices-line first-line">
-                                <span class="price cart_block_shipping_cost ajax_cart_shipping_cost{if !($page_name == 'order-opc') && $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery || $free_ship)} unvisible{/if}">
-                                    {if $shipping_cost_float == 0}
-                                         {if !($page_name == 'order-opc') && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
-                                    {else}
-                                        {$shipping_cost}
-                                    {/if}
-                                </span>
-                                <span{if !($page_name == 'order-opc') && $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery || $free_ship)} class="unvisible"{/if}>
-                                    {l s='Shipping' mod='blockcart'}
-                                </span>
-                            </div>
-                            {if $show_wrapping}
-                                <div class="cart-prices-line">
-                                    {assign var='cart_flag' value='Cart::ONLY_WRAPPING'|constant}
-                                    <span class="price cart_block_wrapping_cost">
-                                        {if $priceDisplay == 1}
-                                            {convertPrice price=$cart->getOrderTotal(false, $cart_flag)}{else}{convertPrice price=$cart->getOrderTotal(true, $cart_flag)}
-                                        {/if}
-                                    </span>
-                                    <span>
-                                        {l s='Wrapping' mod='blockcart'}
-                                    </span>
-                               </div>
-                            {/if}
-                            {if $show_tax && isset($tax_cost)}
-                                <div class="cart-prices-line">
-                                    <span class="price cart_block_tax_cost ajax_cart_tax_cost">{$tax_cost}</span>
-                                    <span>{l s='Tax' mod='blockcart'}</span>
-                                </div>
-                            {/if}
-                            <div class="cart-prices-line last-line">
-                                <span class="price cart_block_total ajax_block_cart_total">{$total}</span>
-                                <span>{l s='Total' mod='blockcart'}</span>
-                            </div>
-                            {if $use_taxes && $display_tax_label && $show_tax}
-                                <p>
-                                {if $priceDisplay == 0}
-                                    {l s='Prices are tax included' mod='blockcart'}
-                                {elseif $priceDisplay == 1}
-                                    {l s='Prices are tax excluded' mod='blockcart'}
-                                {/if}
-                                </p>
-                            {/if}
-                        </div>
-                        <p class="cart-buttons">
-                            <a id="button_order_cart" class="btn btn-default button button-small" href="{$link->getPageLink("$order_process", true)|escape:"html":"UTF-8"}" title="{l s='Check out' mod='blockcart'}" rel="nofollow">
-                                <span>
-                                    {l s='Check out' mod='blockcart'}<i class="icon-chevron-right right"></i>
-                                </span>
-                            </a>
-                        </p>
-                    </div>
-                </div>
-            </div><!-- .cart_block -->
+  {/if}
+  <div class="shopping_cart">
+    <a href="{$link->getPageLink($order_process, true)|escape:'html':'UTF-8'}" title="{l s='View my shopping cart' mod='blockcart'}" rel="nofollow">
+      <b>{l s='Cart' mod='blockcart'}</b>
+      <span class="ajax_cart_quantity{if $cart_qties == 0} unvisible{/if}">{$cart_qties}</span>
+      <span class="ajax_cart_product_txt{if $cart_qties != 1} unvisible{/if}">{l s='Product' mod='blockcart'}</span>
+      <span class="ajax_cart_product_txt_s{if $cart_qties < 2} unvisible{/if}">{l s='Products' mod='blockcart'}</span>
+      <span class="ajax_cart_total{if $cart_qties == 0} unvisible{/if}">
+        {if $cart_qties > 0}
+          {if $priceDisplay == 1}
+            {assign var='blockcart_cart_flag' value='Cart::BOTH_WITHOUT_SHIPPING'|constant}
+            {convertPrice price=$cart->getOrderTotal(false, $blockcart_cart_flag)}
+          {else}
+            {assign var='blockcart_cart_flag' value='Cart::BOTH_WITHOUT_SHIPPING'|constant}
+            {convertPrice price=$cart->getOrderTotal(true, $blockcart_cart_flag)}
+          {/if}
         {/if}
-    </div>
-{if isset($blockcart_top) && $blockcart_top}
+      </span>
+      <span class="ajax_cart_no_product{if $cart_qties > 0} unvisible{/if}">{l s='(empty)' mod='blockcart'}</span>
+      {if $ajax_allowed && isset($blockcart_top) && !$blockcart_top}
+        <span class="block_cart_expand{if !isset($colapseExpandStatus) || (isset($colapseExpandStatus) && $colapseExpandStatus eq 'expanded')} unvisible{/if}">&nbsp;</span>
+        <span class="block_cart_collapse{if isset($colapseExpandStatus) && $colapseExpandStatus eq 'collapsed'} unvisible{/if}">&nbsp;</span>
+      {/if}
+    </a>
+    {if !$PS_CATALOG_MODE}
+      <div class="cart_block block exclusive">
+        <div class="block_content">
+          <!-- block list of products -->
+          <div class="cart_block_list{if isset($blockcart_top) && !$blockcart_top}{if isset($colapseExpandStatus) && $colapseExpandStatus eq 'expanded' || !$ajax_allowed || !isset($colapseExpandStatus)} expanded{else} collapsed unvisible{/if}{/if}">
+            {if $products}
+              <dl class="products">
+                {foreach from=$products item='product' name='myLoop'}
+                  {assign var='productId' value=$product.id_product}
+                  {assign var='productAttributeId' value=$product.id_product_attribute}
+                  <dt data-id="cart_block_product_{$product.id_product|intval}_{if $product.id_product_attribute}{$product.id_product_attribute|intval}{else}0{/if}_{if $product.id_address_delivery}{$product.id_address_delivery|intval}{else}0{/if}" class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if}">
+                    <a class="cart-images" href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'cart_default')}" alt="{$product.name|escape:'html':'UTF-8'}" /></a>
+                    <div class="cart-info">
+                      <div class="product-name">
+                        <span class="quantity-formated"><span class="quantity">{$product.cart_quantity}</span>&nbsp;x&nbsp;</span><a class="cart_block_product_name" href="{$link->getProductLink($product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}">{$product.name|truncate:13:'...'|escape:'html':'UTF-8'}</a>
+                      </div>
+                      {if isset($product.attributes_small)}
+                        <div class="product-atributes">
+                          <a href="{$link->getProductLink($product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockcart'}">{$product.attributes_small}</a>
+                        </div>
+                      {/if}
+                      <span class="price">
+                        {if !isset($product.is_gift) || !$product.is_gift}
+                          {if $priceDisplay == $smarty.const.PS_TAX_EXC}{displayWtPrice p="`$product.total`"}{else}{displayWtPrice p="`$product.total_wt`"}{/if}
+                          <div class="hookDisplayProductPriceBlock-price">
+                            {hook h="displayProductPriceBlock" product=$product type="price" from="blockcart"}
+                          </div>
+                        {else}
+                          {l s='Free!' mod='blockcart'}
+                        {/if}
+                      </span>
+                    </div>
+                    <span class="remove_link">
+                      {if !isset($customizedDatas.$productId.$productAttributeId) && (!isset($product.is_gift) || !$product.is_gift)}
+                        <a class="ajax_cart_block_remove_link" href="{$link->getPageLink('cart', true, NULL, "delete=1&id_product={$product.id_product|intval}&ipa={$product.id_product_attribute|intval}&id_address_delivery={$product.id_address_delivery|intval}&token={$static_token}")|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='remove this product from my cart' mod='blockcart'}">&nbsp;</a>
+                      {/if}
+                    </span>
+                  </dt>
+                  {if isset($product.attributes_small)}
+                    <dd data-id="cart_block_combination_of_{$product.id_product|intval}{if $product.id_product_attribute}_{$product.id_product_attribute|intval}{/if}_{$product.id_address_delivery|intval}" class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if}">
+                  {/if}
+                  <!-- Customizable datas -->
+                  {if isset($customizedDatas.$productId.$productAttributeId[$product.id_address_delivery])}
+                    {if !isset($product.attributes_small)}
+                      <dd data-id="cart_block_combination_of_{$product.id_product|intval}_{if $product.id_product_attribute}{$product.id_product_attribute|intval}{else}0{/if}_{if $product.id_address_delivery}{$product.id_address_delivery|intval}{else}0{/if}" class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if}">
+                    {/if}
+                    <ul class="cart_block_customizations" data-id="customization_{$productId}_{$productAttributeId}">
+                      {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization' name='customizations'}
+                        <li name="customization">
+                          <div data-id="deleteCustomizableProduct_{$id_customization|intval}_{$product.id_product|intval}_{$product.id_product_attribute|intval}_{$product.id_address_delivery|intval}" class="deleteCustomizableProduct">
+                            <a class="ajax_cart_block_remove_link" href="{$link->getPageLink('cart', true, NULL, "delete=1&id_product={$product.id_product|intval}&ipa={$product.id_product_attribute|intval}&id_customization={$id_customization|intval}&token={$static_token}")|escape:'html':'UTF-8'}" rel="nofollow">&nbsp;</a>
+                          </div>
+                          {if isset($customization.datas.$CUSTOMIZE_TEXTFIELD.0)}
+                            {$customization.datas.$CUSTOMIZE_TEXTFIELD.0.value|replace:"<br />":" "|truncate:28:'...'|escape:'html':'UTF-8'}
+                          {else}
+                            {l s='Customization #%d:' sprintf=$id_customization|intval mod='blockcart'}
+                          {/if}
+                        </li>
+                      {/foreach}
+                    </ul>
+                    {if !isset($product.attributes_small)}</dd>{/if}
+                  {/if}
+                  {if isset($product.attributes_small)}</dd>{/if}
+                {/foreach}
+              </dl>
+            {/if}
+            <p class="cart_block_no_products{if $products} unvisible{/if}">
+              {l s='No products' mod='blockcart'}
+            </p>
+            {if $discounts|@count > 0}
+              <table class="vouchers{if $discounts|@count == 0} unvisible{/if}">
+                {foreach from=$discounts item=discount}
+                  {if $discount.value_real > 0}
+                    <tr class="bloc_cart_voucher" data-id="bloc_cart_voucher_{$discount.id_discount|intval}">
+                      <td class="quantity">1x</td>
+                      <td class="name" title="{$discount.description}">
+                        {$discount.name|truncate:18:'...'|escape:'html':'UTF-8'}
+                      </td>
+                      <td class="price">
+                        -{if $priceDisplay == 1}{convertPrice price=$discount.value_tax_exc}{else}{convertPrice price=$discount.value_real}{/if}
+                      </td>
+                      <td class="delete">
+                        {if strlen($discount.code)}
+                          <a class="delete_voucher" href="{$link->getPageLink("$order_process", true)}?deleteDiscount={$discount.id_discount|intval}" title="{l s='Delete' mod='blockcart'}" rel="nofollow">
+                            <i class="icon-remove-sign"></i>
+                          </a>
+                        {/if}
+                      </td>
+                    </tr>
+                  {/if}
+                {/foreach}
+              </table>
+            {/if}
+            {assign var='free_ship' value=count($cart->getDeliveryAddressesWithoutCarriers(true, $errors))}
+            <div class="cart-prices">
+              <div class="cart-prices-line first-line">
+                <span class="price cart_block_shipping_cost ajax_cart_shipping_cost{if !($page_name == 'order-opc') && $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery || $free_ship)} unvisible{/if}">
+                  {if $shipping_cost_float == 0}
+                    {if !($page_name == 'order-opc') && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
+                  {else}
+                    {$shipping_cost}
+                  {/if}
+                </span>
+                <span{if !($page_name == 'order-opc') && $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery || $free_ship)} class="unvisible"{/if}>
+                  {l s='Shipping' mod='blockcart'}
+                </span>
+              </div>
+              {if $show_wrapping}
+                <div class="cart-prices-line">
+                  {assign var='cart_flag' value='Cart::ONLY_WRAPPING'|constant}
+                  <span class="price cart_block_wrapping_cost">
+                    {if $priceDisplay == 1}
+                      {convertPrice price=$cart->getOrderTotal(false, $cart_flag)}{else}{convertPrice price=$cart->getOrderTotal(true, $cart_flag)}
+                    {/if}
+                  </span>
+                  <span>
+                    {l s='Wrapping' mod='blockcart'}
+                  </span>
+                </div>
+              {/if}
+              {if $show_tax && isset($tax_cost)}
+                <div class="cart-prices-line">
+                  <span class="price cart_block_tax_cost ajax_cart_tax_cost">{$tax_cost}</span>
+                  <span>{l s='Tax' mod='blockcart'}</span>
+                </div>
+              {/if}
+              <div class="cart-prices-line last-line">
+                <span class="price cart_block_total ajax_block_cart_total">{$total}</span>
+                <span>{l s='Total' mod='blockcart'}</span>
+              </div>
+              {if $use_taxes && $display_tax_label && $show_tax}
+                <p>
+                  {if $priceDisplay == 0}
+                    {l s='Prices are tax included' mod='blockcart'}
+                  {elseif $priceDisplay == 1}
+                    {l s='Prices are tax excluded' mod='blockcart'}
+                  {/if}
+                </p>
+              {/if}
+            </div>
+            <p class="cart-buttons">
+              <a id="button_order_cart" class="btn btn-default button button-small" href="{$link->getPageLink("$order_process", true)|escape:"html":"UTF-8"}" title="{l s='Check out' mod='blockcart'}" rel="nofollow">
+              <span>
+                {l s='Check out' mod='blockcart'}<i class="icon-chevron-right right"></i>
+              </span>
+              </a>
+            </p>
+          </div>
+        </div>
+      </div><!-- .cart_block -->
+    {/if}
+  </div>
+  {if isset($blockcart_top) && $blockcart_top}
 </div>
 {/if}
 {counter name=active_overlay assign=active_overlay}
 {if !$PS_CATALOG_MODE && $active_overlay == 1}
-    <div id="layer_cart">
-        <div class="clearfix">
-            <div class="layer_cart_product col-xs-12 col-md-6">
-                <span class="cross" title="{l s='Close window' mod='blockcart'}"></span>
-                <span class="title">
-                    <i class="icon-check"></i>{l s='Product successfully added to your shopping cart' mod='blockcart'}
-                </span>
-                <div class="product-image-container layer_cart_img">
-                </div>
-                <div class="layer_cart_product_info">
-                    <span id="layer_cart_product_title" class="product-name"></span>
-                    <span id="layer_cart_product_attributes"></span>
-                    <div>
-                        <strong class="dark">{l s='Quantity' mod='blockcart'}</strong>
-                        <span id="layer_cart_product_quantity"></span>
-                    </div>
-                    <div>
-                        <strong class="dark">{l s='Total' mod='blockcart'}</strong>
-                        <span id="layer_cart_product_price"></span>
-                    </div>
-                </div>
-            </div>
-            <div class="layer_cart_cart col-xs-12 col-md-6">
-                <span class="title">
-                    <!-- Plural Case [both cases are needed because page may be updated in Javascript] -->
-                    <span class="ajax_cart_product_txt_s {if $cart_qties < 2} unvisible{/if}">
-                        {l s='There are [1]%d[/1] items in your cart.' mod='blockcart' sprintf=[$cart_qties] tags=['<span class="ajax_cart_quantity">']}
-                    </span>
-                    <!-- Singular Case [both cases are needed because page may be updated in Javascript] -->
-                    <span class="ajax_cart_product_txt {if $cart_qties > 1} unvisible{/if}">
-                        {l s='There is 1 item in your cart.' mod='blockcart'}
-                    </span>
-                </span>
-                <div class="layer_cart_row">
-                    <strong class="dark">
-                        {l s='Total products' mod='blockcart'}
-                        {if $use_taxes && $display_tax_label && $show_tax}
-                            {if $priceDisplay == 1}
-                                {l s='(tax excl.)' mod='blockcart'}
-                            {else}
-                                {l s='(tax incl.)' mod='blockcart'}
-                            {/if}
-                        {/if}
-                    </strong>
-                    <span class="ajax_block_products_total">
-                        {if $cart_qties > 0}
-                            {convertPrice price=$cart->getOrderTotal(false, Cart::ONLY_PRODUCTS)}
-                        {/if}
-                    </span>
-                </div>
-
-                {if $show_wrapping}
-                    <div class="layer_cart_row">
-                        <strong class="dark">
-                            {l s='Wrapping' mod='blockcart'}
-                            {if $use_taxes && $display_tax_label && $show_tax}
-                                {if $priceDisplay == 1}
-                                    {l s='(tax excl.)' mod='blockcart'}
-                                {else}
-                                    {l s='(tax incl.)' mod='blockcart'}
-                                {/if}
-                            {/if}
-                        </strong>
-                        <span class="price cart_block_wrapping_cost">
-                            {if $priceDisplay == 1}
-                                {convertPrice price=$cart->getOrderTotal(false, Cart::ONLY_WRAPPING)}
-                            {else}
-                                {convertPrice price=$cart->getOrderTotal(true, Cart::ONLY_WRAPPING)}
-                            {/if}
-                        </span>
-                    </div>
-                {/if}
-                <div class="layer_cart_row">
-                    <strong class="dark{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
-                        {l s='Total shipping' mod='blockcart'}&nbsp;{if $use_taxes && $display_tax_label && $show_tax}{if $priceDisplay == 1}{l s='(tax excl.)' mod='blockcart'}{else}{l s='(tax incl.)' mod='blockcart'}{/if}{/if}
-                    </strong>
-                    <span class="ajax_cart_shipping_cost{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
-                        {if $shipping_cost_float == 0}
-                             {if (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
-                        {else}
-                            {$shipping_cost}
-                        {/if}
-                    </span>
-                </div>
-                {if $show_tax && isset($tax_cost)}
-                    <div class="layer_cart_row">
-                        <strong class="dark">{l s='Tax' mod='blockcart'}</strong>
-                        <span class="price cart_block_tax_cost ajax_cart_tax_cost">{$tax_cost}</span>
-                    </div>
-                {/if}
-                <div class="layer_cart_row">
-                    <strong class="dark">
-                        {l s='Total' mod='blockcart'}
-                        {if $use_taxes && $display_tax_label && $show_tax}
-                            {if $priceDisplay == 1}
-                                {l s='(tax excl.)' mod='blockcart'}
-                            {else}
-                                {l s='(tax incl.)' mod='blockcart'}
-                            {/if}
-                        {/if}
-                    </strong>
-                    <span class="ajax_block_cart_total">
-                        {if $cart_qties > 0}
-                            {if $priceDisplay == 1}
-                                {convertPrice price=$cart->getOrderTotal(false)}
-                            {else}
-                                {convertPrice price=$cart->getOrderTotal(true)}
-                            {/if}
-                        {/if}
-                    </span>
-                </div>
-                <div class="button-container">
-                    <span class="continue btn btn-default button exclusive-medium" title="{l s='Continue shopping' mod='blockcart'}">
-                        <span>
-                            <i class="icon-chevron-left left"></i>{l s='Continue shopping' mod='blockcart'}
-                        </span>
-                    </span>
-                    <a class="btn btn-default button button-medium" href="{$link->getPageLink("$order_process", true)|escape:"html":"UTF-8"}" title="{l s='Proceed to checkout' mod='blockcart'}" rel="nofollow">
-                        <span>
-                            {l s='Proceed to checkout' mod='blockcart'}<i class="icon-chevron-right right"></i>
-                        </span>
-                    </a>
-                </div>
-            </div>
+  <div id="layer_cart">
+    <div class="clearfix">
+      <div class="layer_cart_product col-xs-12 col-md-6">
+        <span class="cross" title="{l s='Close window' mod='blockcart'}"></span>
+          <span class="title">
+            <i class="icon-check"></i>{l s='Product successfully added to your shopping cart' mod='blockcart'}
+          </span>
+        <div class="product-image-container layer_cart_img">
         </div>
-        <div class="crossseling"></div>
-    </div> <!-- #layer_cart -->
-    <div class="layer_cart_overlay"></div>
+        <div class="layer_cart_product_info">
+          <span id="layer_cart_product_title" class="product-name"></span>
+          <span id="layer_cart_product_attributes"></span>
+          <div>
+            <strong class="dark">{l s='Quantity' mod='blockcart'}</strong>
+            <span id="layer_cart_product_quantity"></span>
+          </div>
+          <div>
+            <strong class="dark">{l s='Total' mod='blockcart'}</strong>
+            <span id="layer_cart_product_price"></span>
+          </div>
+        </div>
+      </div>
+      <div class="layer_cart_cart col-xs-12 col-md-6">
+        <span class="title">
+          <!-- Plural Case [both cases are needed because page may be updated in Javascript] -->
+          <span class="ajax_cart_product_txt_s {if $cart_qties < 2} unvisible{/if}">
+              {l s='There are [1]%d[/1] items in your cart.' mod='blockcart' sprintf=[$cart_qties] tags=['<span class="ajax_cart_quantity">']}
+          </span>
+          <!-- Singular Case [both cases are needed because page may be updated in Javascript] -->
+          <span class="ajax_cart_product_txt {if $cart_qties > 1} unvisible{/if}">
+              {l s='There is 1 item in your cart.' mod='blockcart'}
+          </span>
+        </span>
+        <div class="layer_cart_row">
+          <strong class="dark">
+            {l s='Total products' mod='blockcart'}
+            {if $use_taxes && $display_tax_label && $show_tax}
+              {if $priceDisplay == 1}
+                {l s='(tax excl.)' mod='blockcart'}
+              {else}
+                {l s='(tax incl.)' mod='blockcart'}
+              {/if}
+            {/if}
+          </strong>
+          <span class="ajax_block_products_total">
+            {if $cart_qties > 0}
+              {convertPrice price=$cart->getOrderTotal(false, Cart::ONLY_PRODUCTS)}
+            {/if}
+          </span>
+        </div>
+
+        {if $show_wrapping}
+          <div class="layer_cart_row">
+            <strong class="dark">
+              {l s='Wrapping' mod='blockcart'}
+              {if $use_taxes && $display_tax_label && $show_tax}
+                {if $priceDisplay == 1}
+                  {l s='(tax excl.)' mod='blockcart'}
+                {else}
+                  {l s='(tax incl.)' mod='blockcart'}
+                {/if}
+              {/if}
+            </strong>
+            <span class="price cart_block_wrapping_cost">
+              {if $priceDisplay == 1}
+                {convertPrice price=$cart->getOrderTotal(false, Cart::ONLY_WRAPPING)}
+              {else}
+                {convertPrice price=$cart->getOrderTotal(true, Cart::ONLY_WRAPPING)}
+              {/if}
+            </span>
+          </div>
+        {/if}
+        <div class="layer_cart_row">
+          <strong class="dark{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
+            {l s='Total shipping' mod='blockcart'}&nbsp;{if $use_taxes && $display_tax_label && $show_tax}{if $priceDisplay == 1}{l s='(tax excl.)' mod='blockcart'}{else}{l s='(tax incl.)' mod='blockcart'}{/if}{/if}
+          </strong>
+          <span class="ajax_cart_shipping_cost{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
+            {if $shipping_cost_float == 0}
+              {if (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
+            {else}
+              {$shipping_cost}
+            {/if}
+          </span>
+        </div>
+        {if $show_tax && isset($tax_cost)}
+          <div class="layer_cart_row">
+            <strong class="dark">{l s='Tax' mod='blockcart'}</strong>
+            <span class="price cart_block_tax_cost ajax_cart_tax_cost">{$tax_cost}</span>
+          </div>
+        {/if}
+        <div class="layer_cart_row">
+          <strong class="dark">
+            {l s='Total' mod='blockcart'}
+            {if $use_taxes && $display_tax_label && $show_tax}
+              {if $priceDisplay == 1}
+                {l s='(tax excl.)' mod='blockcart'}
+              {else}
+                {l s='(tax incl.)' mod='blockcart'}
+              {/if}
+            {/if}
+          </strong>
+          <span class="ajax_block_cart_total">
+            {if $cart_qties > 0}
+              {if $priceDisplay == 1}
+                {convertPrice price=$cart->getOrderTotal(false)}
+              {else}
+                {convertPrice price=$cart->getOrderTotal(true)}
+              {/if}
+            {/if}
+          </span>
+        </div>
+        <div class="button-container">
+          <span class="continue btn btn-default button exclusive-medium" title="{l s='Continue shopping' mod='blockcart'}">
+            <span>
+                <i class="icon-chevron-left left"></i>{l s='Continue shopping' mod='blockcart'}
+            </span>
+          </span>
+          <a class="btn btn-default button button-medium" href="{$link->getPageLink("$order_process", true)|escape:"html":"UTF-8"}" title="{l s='Proceed to checkout' mod='blockcart'}" rel="nofollow">
+            <span>
+              {l s='Proceed to checkout' mod='blockcart'}<i class="icon-chevron-right right"></i>
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="crossseling"></div>
+  </div> <!-- #layer_cart -->
+  <div class="layer_cart_overlay"></div>
 {/if}
 {strip}
-{addJsDef CUSTOMIZE_TEXTFIELD=$CUSTOMIZE_TEXTFIELD}
-{addJsDef img_dir=$img_dir|escape:'quotes':'UTF-8'}
-{addJsDef generated_date=$smarty.now|intval}
-{addJsDef ajax_allowed=$ajax_allowed|boolval}
-{addJsDef hasDeliveryAddress=(isset($cart->id_address_delivery) && $cart->id_address_delivery)}
+  {addJsDef CUSTOMIZE_TEXTFIELD=$CUSTOMIZE_TEXTFIELD}
+  {addJsDef img_dir=$img_dir|escape:'quotes':'UTF-8'}
+  {addJsDef generated_date=$smarty.now|intval}
+  {addJsDef ajax_allowed=$ajax_allowed|boolval}
+  {addJsDef hasDeliveryAddress=(isset($cart->id_address_delivery) && $cart->id_address_delivery)}
 
-{addJsDefL name=customizationIdMessage}{l s='Customization #' mod='blockcart' js=1}{/addJsDefL}
-{addJsDefL name=removingLinkText}{l s='remove this product from my cart' mod='blockcart' js=1}{/addJsDefL}
-{addJsDefL name=freeShippingTranslation}{l s='Free shipping!' mod='blockcart' js=1}{/addJsDefL}
-{addJsDefL name=freeProductTranslation}{l s='Free!' mod='blockcart' js=1}{/addJsDefL}
-{addJsDefL name=delete_txt}{l s='Delete' mod='blockcart' js=1}{/addJsDefL}
-{addJsDefL name=toBeDetermined}{l s='To be determined' mod='blockcart' js=1}{/addJsDefL}
+  {addJsDefL name=customizationIdMessage}{l s='Customization #' mod='blockcart' js=1}{/addJsDefL}
+  {addJsDefL name=removingLinkText}{l s='remove this product from my cart' mod='blockcart' js=1}{/addJsDefL}
+  {addJsDefL name=freeShippingTranslation}{l s='Free shipping!' mod='blockcart' js=1}{/addJsDefL}
+  {addJsDefL name=freeProductTranslation}{l s='Free!' mod='blockcart' js=1}{/addJsDefL}
+  {addJsDefL name=delete_txt}{l s='Delete' mod='blockcart' js=1}{/addJsDefL}
+  {addJsDefL name=toBeDetermined}{l s='To be determined' mod='blockcart' js=1}{/addJsDefL}
 {/strip}
 <!-- /MODULE Block cart -->

--- a/themes/community-theme-16/modules/blockcart/crossselling.tpl
+++ b/themes/community-theme-16/modules/blockcart/crossselling.tpl
@@ -23,30 +23,30 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($orderProducts) && count($orderProducts) > 0}
-    <div class="crossseling-content">
-        <h2>{l s='Customers who bought this product also bought:' mod='blockcart'}</h2>
-        <div id="blockcart_list">
-            <ul id="blockcart_caroucel">
-                {foreach from=$orderProducts item='orderProduct' name=orderProduct}
-                    <li>
-                        <div class="product-image-container">
-                            <a href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}" class="lnk_img">
-                                <img class="img-responsive" src="{$orderProduct.image}" alt="{$orderProduct.name|htmlspecialchars}" />
-                            </a>
-                        </div>
-                        <p class="product-name">
-                            <a href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}">
-                                {$orderProduct.name|truncate:15:'...'|escape:'html':'UTF-8'}
-                            </a>
-                        </p>
-                        {if $orderProduct.show_price == 1 AND !isset($restricted_country_mode) AND !$PS_CATALOG_MODE}
-                            <span class="price_display">
-                                <span class="price">{convertPrice price=$orderProduct.displayed_price}</span>
-                            </span>
-                        {/if}
-                    </li>
-                {/foreach}
-            </ul>
-        </div>
+  <div class="crossseling-content">
+    <h2>{l s='Customers who bought this product also bought:' mod='blockcart'}</h2>
+    <div id="blockcart_list">
+      <ul id="blockcart_caroucel">
+        {foreach from=$orderProducts item='orderProduct' name=orderProduct}
+          <li>
+            <div class="product-image-container">
+              <a href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}" class="lnk_img">
+                <img class="img-responsive" src="{$orderProduct.image}" alt="{$orderProduct.name|htmlspecialchars}" />
+              </a>
+            </div>
+            <p class="product-name">
+              <a href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}">
+                {$orderProduct.name|truncate:15:'...'|escape:'html':'UTF-8'}
+              </a>
+            </p>
+            {if $orderProduct.show_price == 1 AND !isset($restricted_country_mode) AND !$PS_CATALOG_MODE}
+              <span class="price_display">
+                <span class="price">{convertPrice price=$orderProduct.displayed_price}</span>
+              </span>
+            {/if}
+          </li>
+        {/foreach}
+      </ul>
     </div>
+  </div>
 {/if}

--- a/themes/community-theme-16/modules/blockcategories/blockcategories.tpl
+++ b/themes/community-theme-16/modules/blockcategories/blockcategories.tpl
@@ -23,26 +23,26 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if $blockCategTree && $blockCategTree.children|@count}
-<!-- Block categories module -->
-<div id="categories_block_left" class="block">
+  <!-- Block categories module -->
+  <div id="categories_block_left" class="block">
     <h2 class="title_block">
-        {if isset($currentCategory)}
-            {$currentCategory->name|escape}
-        {else}
-            {l s='Categories' mod='blockcategories'}
-        {/if}
+      {if isset($currentCategory)}
+        {$currentCategory->name|escape}
+      {else}
+        {l s='Categories' mod='blockcategories'}
+      {/if}
     </h2>
     <div class="block_content">
-        <ul class="tree {if $isDhtml}dhtml{/if}">
-            {foreach from=$blockCategTree.children item=child name=blockCategTree}
-                {if $smarty.foreach.blockCategTree.last}
-                    {include file="$branche_tpl_path" node=$child last='true'}
-                {else}
-                    {include file="$branche_tpl_path" node=$child}
-                {/if}
-            {/foreach}
-        </ul>
+      <ul class="tree {if $isDhtml}dhtml{/if}">
+        {foreach from=$blockCategTree.children item=child name=blockCategTree}
+          {if $smarty.foreach.blockCategTree.last}
+            {include file="$branche_tpl_path" node=$child last='true'}
+          {else}
+            {include file="$branche_tpl_path" node=$child}
+          {/if}
+        {/foreach}
+      </ul>
     </div>
-</div>
-<!-- /Block categories module -->
+  </div>
+  <!-- /Block categories module -->
 {/if}

--- a/themes/community-theme-16/modules/blockcategories/blockcategories_footer.tpl
+++ b/themes/community-theme-16/modules/blockcategories/blockcategories_footer.tpl
@@ -25,29 +25,29 @@
 
 <!-- Block categories module -->
 <section class="blockcategories_footer footer-block col-xs-12 col-sm-2">
-    <h4>{l s='Categories' mod='blockcategories'}</h4>
-    <div class="category_footer toggle-footer">
-        <div class="list">
-            <ul class="tree {if $isDhtml}dhtml{/if}">
-            {foreach from=$blockCategTree.children item=child name=blockCategTree}
-                {if $smarty.foreach.blockCategTree.last}
-                    {include file="$branche_tpl_path" node=$child last='true'}
-                {else}
-                    {include file="$branche_tpl_path" node=$child}
-                {/if}
+  <h4>{l s='Categories' mod='blockcategories'}</h4>
+  <div class="category_footer toggle-footer">
+    <div class="list">
+      <ul class="tree {if $isDhtml}dhtml{/if}">
+        {foreach from=$blockCategTree.children item=child name=blockCategTree}
+        {if $smarty.foreach.blockCategTree.last}
+          {include file="$branche_tpl_path" node=$child last='true'}
+        {else}
+          {include file="$branche_tpl_path" node=$child}
+        {/if}
 
-                {if ($smarty.foreach.blockCategTree.iteration mod $numberColumn) == 0 AND !$smarty.foreach.blockCategTree.last}
-            </ul>
-        </div>
-    </div> <!-- .category_footer -->
+        {if ($smarty.foreach.blockCategTree.iteration mod $numberColumn) == 0 AND !$smarty.foreach.blockCategTree.last}
+      </ul>
+    </div>
+  </div> <!-- .category_footer -->
 
-    <div class="category_footer">
-        <div class="list">
-            <ul class="tree {if $isDhtml}dhtml{/if}">
-                {/if}
-            {/foreach}
-            </ul>
-        </div>
-    </div> <!-- .category_footer -->
+  <div class="category_footer">
+    <div class="list">
+      <ul class="tree {if $isDhtml}dhtml{/if}">
+        {/if}
+        {/foreach}
+      </ul>
+    </div>
+  </div> <!-- .category_footer -->
 </section>
 <!-- /Block categories module -->

--- a/themes/community-theme-16/modules/blockcategories/category-tree-branch.tpl
+++ b/themes/community-theme-16/modules/blockcategories/category-tree-branch.tpl
@@ -24,19 +24,19 @@
 *}
 
 <li {if isset($last) && $last == 'true'}class="last"{/if}>
-    <a
+  <a
     href="{$node.link|escape:'html':'UTF-8'}"{if isset($currentCategoryId) && $node.id == $currentCategoryId} class="selected"{/if} title="{$node.desc|strip_tags|trim|escape:'html':'UTF-8'}">
-        {$node.name|escape:'html':'UTF-8'}
-    </a>
-    {if $node.children|@count > 0}
-        <ul>
-            {foreach from=$node.children item=child name=categoryTreeBranch}
-                {if $smarty.foreach.categoryTreeBranch.last}
-                    {include file="$branche_tpl_path" node=$child last='true'}
-                {else}
-                    {include file="$branche_tpl_path" node=$child last='false'}
-                {/if}
-            {/foreach}
-        </ul>
-    {/if}
+    {$node.name|escape:'html':'UTF-8'}
+  </a>
+  {if $node.children|@count > 0}
+    <ul>
+      {foreach from=$node.children item=child name=categoryTreeBranch}
+        {if $smarty.foreach.categoryTreeBranch.last}
+          {include file="$branche_tpl_path" node=$child last='true'}
+        {else}
+          {include file="$branche_tpl_path" node=$child last='false'}
+        {/if}
+      {/foreach}
+    </ul>
+  {/if}
 </li>

--- a/themes/community-theme-16/modules/blockcms/blockcms.tpl
+++ b/themes/community-theme-16/modules/blockcms/blockcms.tpl
@@ -24,111 +24,111 @@
 *}
 
 {if $block == 1}
-    <!-- Block CMS module -->
-    {foreach from=$cms_titles key=cms_key item=cms_title}
-        <section id="informations_block_left_{$cms_key}" class="block informations_block_left">
-            <p class="title_block">
-                <a href="{$cms_title.category_link|escape:'html':'UTF-8'}">
-                    {if !empty($cms_title.name)}{$cms_title.name}{else}{$cms_title.category_name}{/if}
+  <!-- Block CMS module -->
+  {foreach from=$cms_titles key=cms_key item=cms_title}
+    <section id="informations_block_left_{$cms_key}" class="block informations_block_left">
+      <p class="title_block">
+        <a href="{$cms_title.category_link|escape:'html':'UTF-8'}">
+          {if !empty($cms_title.name)}{$cms_title.name}{else}{$cms_title.category_name}{/if}
+        </a>
+      </p>
+      <div class="block_content list-block">
+        <ul>
+          {foreach from=$cms_title.categories item=cms_page}
+            {if isset($cms_page.link)}
+              <li class="bullet">
+                <a href="{$cms_page.link|escape:'html':'UTF-8'}" title="{$cms_page.name|escape:'html':'UTF-8'}">
+                  {$cms_page.name|escape:'html':'UTF-8'}
                 </a>
-            </p>
-            <div class="block_content list-block">
-                <ul>
-                    {foreach from=$cms_title.categories item=cms_page}
-                        {if isset($cms_page.link)}
-                            <li class="bullet">
-                                <a href="{$cms_page.link|escape:'html':'UTF-8'}" title="{$cms_page.name|escape:'html':'UTF-8'}">
-                                    {$cms_page.name|escape:'html':'UTF-8'}
-                                </a>
-                            </li>
-                        {/if}
-                    {/foreach}
-                    {foreach from=$cms_title.cms item=cms_page}
-                        {if isset($cms_page.link)}
-                            <li>
-                                <a href="{$cms_page.link|escape:'html':'UTF-8'}" title="{$cms_page.meta_title|escape:'html':'UTF-8'}">
-                                    {$cms_page.meta_title|escape:'html':'UTF-8'}
-                                </a>
-                            </li>
-                        {/if}
-                    {/foreach}
-                    {if $cms_title.display_store}
-                        <li>
-                            <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockcms'}">
-                                {l s='Our stores' mod='blockcms'}
-                            </a>
-                        </li>
-                    {/if}
-                </ul>
-            </div>
-        </section>
-    {/foreach}
-    <!-- /Block CMS module -->
-{else}
-    <!-- Block CMS module footer -->
-    <section class="footer-block col-xs-12 col-sm-2" id="block_various_links_footer">
-        <h4>{l s='Information' mod='blockcms'}</h4>
-        <ul class="toggle-footer">
-            {if isset($show_price_drop) && $show_price_drop && !$PS_CATALOG_MODE}
-                <li class="item">
-                    <a href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}" title="{l s='Specials' mod='blockcms'}">
-                        {l s='Specials' mod='blockcms'}
-                    </a>
-                </li>
+              </li>
             {/if}
-            {if isset($show_new_products) && $show_new_products}
-            <li class="item">
-                <a href="{$link->getPageLink('new-products')|escape:'html':'UTF-8'}" title="{l s='New products' mod='blockcms'}">
-                    {l s='New products' mod='blockcms'}
+          {/foreach}
+          {foreach from=$cms_title.cms item=cms_page}
+            {if isset($cms_page.link)}
+              <li>
+                <a href="{$cms_page.link|escape:'html':'UTF-8'}" title="{$cms_page.meta_title|escape:'html':'UTF-8'}">
+                  {$cms_page.meta_title|escape:'html':'UTF-8'}
                 </a>
-            </li>
+              </li>
             {/if}
-            {if isset($show_best_sales) && $show_best_sales && !$PS_CATALOG_MODE}
-                <li class="item">
-                    <a href="{$link->getPageLink('best-sales')|escape:'html':'UTF-8'}" title="{l s='Top sellers' mod='blockcms'}">
-                        {l s='Top sellers' mod='blockcms'}
-                    </a>
-                </li>
-            {/if}
-            {if isset($display_stores_footer) && $display_stores_footer}
-                <li class="item">
-                    <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockcms'}">
-                        {l s='Our stores' mod='blockcms'}
-                    </a>
-                </li>
-            {/if}
-            {if isset($show_contact) && $show_contact}
-            <li class="item">
-                <a href="{$link->getPageLink($contact_url, true)|escape:'html':'UTF-8'}" title="{l s='Contact us' mod='blockcms'}">
-                    {l s='Contact us' mod='blockcms'}
-                </a>
-            </li>
-            {/if}
-            {foreach from=$cmslinks item=cmslink}
-                {if $cmslink.meta_title != ''}
-                    <li class="item">
-                        <a href="{$cmslink.link|escape:'html':'UTF-8'}" title="{$cmslink.meta_title|escape:'html':'UTF-8'}">
-                            {$cmslink.meta_title|escape:'html':'UTF-8'}
-                        </a>
-                    </li>
-                {/if}
-            {/foreach}
-            {if isset($show_sitemap) && $show_sitemap}
+          {/foreach}
+          {if $cms_title.display_store}
             <li>
-                <a href="{$link->getPageLink('sitemap')|escape:'html':'UTF-8'}" title="{l s='Sitemap' mod='blockcms'}">
-                    {l s='Sitemap' mod='blockcms'}
-                </a>
+              <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockcms'}">
+                {l s='Our stores' mod='blockcms'}
+              </a>
             </li>
-            {/if}
+          {/if}
         </ul>
-        {$footer_text}
+      </div>
     </section>
-    {if $display_poweredby}
+  {/foreach}
+  <!-- /Block CMS module -->
+{else}
+  <!-- Block CMS module footer -->
+  <section class="footer-block col-xs-12 col-sm-2" id="block_various_links_footer">
+    <h4>{l s='Information' mod='blockcms'}</h4>
+    <ul class="toggle-footer">
+      {if isset($show_price_drop) && $show_price_drop && !$PS_CATALOG_MODE}
+        <li class="item">
+          <a href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}" title="{l s='Specials' mod='blockcms'}">
+            {l s='Specials' mod='blockcms'}
+          </a>
+        </li>
+      {/if}
+      {if isset($show_new_products) && $show_new_products}
+        <li class="item">
+          <a href="{$link->getPageLink('new-products')|escape:'html':'UTF-8'}" title="{l s='New products' mod='blockcms'}">
+            {l s='New products' mod='blockcms'}
+          </a>
+        </li>
+      {/if}
+      {if isset($show_best_sales) && $show_best_sales && !$PS_CATALOG_MODE}
+        <li class="item">
+          <a href="{$link->getPageLink('best-sales')|escape:'html':'UTF-8'}" title="{l s='Top sellers' mod='blockcms'}">
+            {l s='Top sellers' mod='blockcms'}
+          </a>
+        </li>
+      {/if}
+      {if isset($display_stores_footer) && $display_stores_footer}
+        <li class="item">
+          <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockcms'}">
+            {l s='Our stores' mod='blockcms'}
+          </a>
+        </li>
+      {/if}
+      {if isset($show_contact) && $show_contact}
+        <li class="item">
+          <a href="{$link->getPageLink($contact_url, true)|escape:'html':'UTF-8'}" title="{l s='Contact us' mod='blockcms'}">
+            {l s='Contact us' mod='blockcms'}
+          </a>
+        </li>
+      {/if}
+      {foreach from=$cmslinks item=cmslink}
+        {if $cmslink.meta_title != ''}
+          <li class="item">
+            <a href="{$cmslink.link|escape:'html':'UTF-8'}" title="{$cmslink.meta_title|escape:'html':'UTF-8'}">
+              {$cmslink.meta_title|escape:'html':'UTF-8'}
+            </a>
+          </li>
+        {/if}
+      {/foreach}
+      {if isset($show_sitemap) && $show_sitemap}
+        <li>
+          <a href="{$link->getPageLink('sitemap')|escape:'html':'UTF-8'}" title="{l s='Sitemap' mod='blockcms'}">
+            {l s='Sitemap' mod='blockcms'}
+          </a>
+        </li>
+      {/if}
+    </ul>
+    {$footer_text}
+  </section>
+  {if $display_poweredby}
     <section class="bottom-footer col-xs-12">
-        <div>
-            {l s='[1] %3$s %2$s - Ecommerce software by %1$s [/1]' mod='blockcms' sprintf=['PrestaShop™', 'Y'|date, '©'] tags=['<a class="_blank" href="http://www.prestashop.com">'] nocache}
-        </div>
+      <div>
+        {l s='[1] %3$s %2$s - Ecommerce software by %1$s [/1]' mod='blockcms' sprintf=['PrestaShop™', 'Y'|date, '©'] tags=['<a class="_blank" href="http://www.prestashop.com">'] nocache}
+      </div>
     </section>
-    {/if}
-    <!-- /Block CMS module footer -->
+  {/if}
+  <!-- /Block CMS module footer -->
 {/if}

--- a/themes/community-theme-16/modules/blockcontact/blockcontact.tpl
+++ b/themes/community-theme-16/modules/blockcontact/blockcontact.tpl
@@ -24,22 +24,22 @@
 *}
 
 <div id="contact_block" class="block">
-    <h4 class="title_block">
-        {l s='Contact Us' mod='blockcontact'}
-    </h4>
-    <div class="block_content clearfix">
-        <p>
-            {l s='Our support hotline is available 24/7.' mod='blockcontact'}
-        </p>
-        {if $telnumber != ''}
-            <p class="tel">
-                <span class="label">{l s='Phone:' mod='blockcontact'}</span>{$telnumber|escape:'html':'UTF-8'}
-            </p>
-        {/if}
-        {if $email != ''}
-            <a href="mailto:{$email|escape:'html':'UTF-8'}" title="{l s='Contact our expert support team!' mod='blockcontact'}">
-                {l s='Contact our expert support team!' mod='blockcontact'}
-            </a>
-        {/if}
-    </div>
+  <h4 class="title_block">
+    {l s='Contact Us' mod='blockcontact'}
+  </h4>
+  <div class="block_content clearfix">
+    <p>
+      {l s='Our support hotline is available 24/7.' mod='blockcontact'}
+    </p>
+    {if $telnumber != ''}
+      <p class="tel">
+        <span class="label">{l s='Phone:' mod='blockcontact'}</span>{$telnumber|escape:'html':'UTF-8'}
+      </p>
+    {/if}
+    {if $email != ''}
+      <a href="mailto:{$email|escape:'html':'UTF-8'}" title="{l s='Contact our expert support team!' mod='blockcontact'}">
+        {l s='Contact our expert support team!' mod='blockcontact'}
+      </a>
+    {/if}
+  </div>
 </div>

--- a/themes/community-theme-16/modules/blockcontact/nav.tpl
+++ b/themes/community-theme-16/modules/blockcontact/nav.tpl
@@ -23,10 +23,10 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div id="contact-link" {if isset($is_logged) && $is_logged} class="is_logged"{/if}>
-    <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}" title="{l s='Contact us' mod='blockcontact'}">{l s='Contact us' mod='blockcontact'}</a>
+  <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}" title="{l s='Contact us' mod='blockcontact'}">{l s='Contact us' mod='blockcontact'}</a>
 </div>
 {if $telnumber}
-    <span class="shop-phone{if isset($is_logged) && $is_logged} is_logged{/if}">
-        <i class="icon-phone"></i>{l s='Call us now:' mod='blockcontact'} <strong>{$telnumber}</strong>
-    </span>
+  <span class="shop-phone{if isset($is_logged) && $is_logged} is_logged{/if}">
+    <i class="icon-phone"></i>{l s='Call us now:' mod='blockcontact'} <strong>{$telnumber}</strong>
+  </span>
 {/if}

--- a/themes/community-theme-16/modules/blockcontactinfos/blockcontactinfos.tpl
+++ b/themes/community-theme-16/modules/blockcontactinfos/blockcontactinfos.tpl
@@ -26,27 +26,27 @@
 
 <!-- MODULE Block contact infos -->
 <section id="block_contact_infos" class="footer-block col-xs-12 col-sm-4">
-    <div>
-        <h4>{l s='Store Information' mod='blockcontactinfos'}</h4>
-        <ul class="toggle-footer">
-            {if $blockcontactinfos_company != ''}
-                <li>
-                    <i class="icon-map-marker"></i>{$blockcontactinfos_company|escape:'html':'UTF-8'}{if $blockcontactinfos_address != ''}, {$blockcontactinfos_address|escape:'html':'UTF-8'}{/if}
-                </li>
-            {/if}
-            {if $blockcontactinfos_phone != ''}
-                <li>
-                    <i class="icon-phone"></i>{l s='Call us now:' mod='blockcontactinfos'}
-                    <span>{$blockcontactinfos_phone|escape:'html':'UTF-8'}</span>
-                </li>
-            {/if}
-            {if $blockcontactinfos_email != ''}
-                <li>
-                    <i class="icon-envelope-alt"></i>{l s='Email:' mod='blockcontactinfos'}
-                    <span>{mailto address=$blockcontactinfos_email|escape:'html':'UTF-8' encode="hex"}</span>
-                </li>
-            {/if}
-        </ul>
-    </div>
+  <div>
+    <h4>{l s='Store Information' mod='blockcontactinfos'}</h4>
+    <ul class="toggle-footer">
+      {if $blockcontactinfos_company != ''}
+        <li>
+          <i class="icon-map-marker"></i>{$blockcontactinfos_company|escape:'html':'UTF-8'}{if $blockcontactinfos_address != ''}, {$blockcontactinfos_address|escape:'html':'UTF-8'}{/if}
+        </li>
+      {/if}
+      {if $blockcontactinfos_phone != ''}
+        <li>
+          <i class="icon-phone"></i>{l s='Call us now:' mod='blockcontactinfos'}
+          <span>{$blockcontactinfos_phone|escape:'html':'UTF-8'}</span>
+        </li>
+      {/if}
+      {if $blockcontactinfos_email != ''}
+        <li>
+          <i class="icon-envelope-alt"></i>{l s='Email:' mod='blockcontactinfos'}
+          <span>{mailto address=$blockcontactinfos_email|escape:'html':'UTF-8' encode="hex"}</span>
+        </li>
+      {/if}
+    </ul>
+  </div>
 </section>
 <!-- /MODULE Block contact infos -->

--- a/themes/community-theme-16/modules/blockcurrencies/blockcurrencies.tpl
+++ b/themes/community-theme-16/modules/blockcurrencies/blockcurrencies.tpl
@@ -24,31 +24,31 @@
 *}
 <!-- Block currencies module -->
 {if count($currencies) > 1}
-    <div id="currencies-block-top">
-        <form id="setCurrency" action="{$request_uri}" method="post">
-            <div class="current">
-                <input type="hidden" name="id_currency" id="id_currency" value=""/>
-                <input type="hidden" name="SubmitCurrency" value="" />
-                <span class="cur-label">{l s='Currency' mod='blockcurrencies'} :</span>
-                {foreach from=$currencies key=k item=f_currency}
-                    {if $cookie->id_currency == $f_currency.id_currency}<strong>{$f_currency.iso_code}</strong>{/if}
-                {/foreach}
-            </div>
-            <ul id="first-currencies" class="currencies_ul toogle_content">
-                {foreach from=$currencies key=k item=f_currency}
-                    {if strpos($f_currency.name, '('|cat:$f_currency.iso_code:')') === false}
-                        {assign var="currency_name" value={l s='%s (%s)' sprintf=[$f_currency.name, $f_currency.iso_code]}}
-                    {else}
-                        {assign var="currency_name" value=$f_currency.name}
-                    {/if}
-                    <li {if $cookie->id_currency == $f_currency.id_currency}class="selected"{/if}>
-                        <a href="javascript:setCurrency({$f_currency.id_currency});" rel="nofollow" title="{$currency_name}">
-                            {$currency_name}
-                        </a>
-                    </li>
-                {/foreach}
-            </ul>
-        </form>
-    </div>
+  <div id="currencies-block-top">
+    <form id="setCurrency" action="{$request_uri}" method="post">
+      <div class="current">
+        <input type="hidden" name="id_currency" id="id_currency" value=""/>
+        <input type="hidden" name="SubmitCurrency" value="" />
+        <span class="cur-label">{l s='Currency' mod='blockcurrencies'} :</span>
+        {foreach from=$currencies key=k item=f_currency}
+          {if $cookie->id_currency == $f_currency.id_currency}<strong>{$f_currency.iso_code}</strong>{/if}
+        {/foreach}
+      </div>
+      <ul id="first-currencies" class="currencies_ul toogle_content">
+        {foreach from=$currencies key=k item=f_currency}
+          {if strpos($f_currency.name, '('|cat:$f_currency.iso_code:')') === false}
+            {assign var="currency_name" value={l s='%s (%s)' sprintf=[$f_currency.name, $f_currency.iso_code]}}
+          {else}
+            {assign var="currency_name" value=$f_currency.name}
+          {/if}
+          <li {if $cookie->id_currency == $f_currency.id_currency}class="selected"{/if}>
+            <a href="javascript:setCurrency({$f_currency.id_currency});" rel="nofollow" title="{$currency_name}">
+              {$currency_name}
+            </a>
+          </li>
+        {/foreach}
+      </ul>
+    </form>
+  </div>
 {/if}
 <!-- /Block currencies module -->

--- a/themes/community-theme-16/modules/blockcustomerprivacy/blockcustomerprivacy.tpl
+++ b/themes/community-theme-16/modules/blockcustomerprivacy/blockcustomerprivacy.tpl
@@ -24,15 +24,15 @@
 
 <div class="error_customerprivacy" style="color:red;"></div>
 <fieldset class="account_creation customerprivacy">
-    <h3 class="page-subheading">
-        {l s='Customer data privacy' mod='blockcustomerprivacy'}
-    </h3>
-    <div style="width:21px; float:left;">
-        <div class="required checkbox">
-            <input type="checkbox" value="1" id="customer_privacy" name="customer_privacy" autocomplete="off"/>
-        </div>
+  <h3 class="page-subheading">
+    {l s='Customer data privacy' mod='blockcustomerprivacy'}
+  </h3>
+  <div style="width:21px; float:left;">
+    <div class="required checkbox">
+      <input type="checkbox" value="1" id="customer_privacy" name="customer_privacy" autocomplete="off"/>
     </div>
-    <div style="width: 92%; float: left; margin-top: 8px;">
-        <label for="customer_privacy" style="font-weight: normal;">{$privacy_message}</label>
-    </div>
+  </div>
+  <div style="width: 92%; float: left; margin-top: 8px;">
+    <label for="customer_privacy" style="font-weight: normal;">{$privacy_message}</label>
+  </div>
 </fieldset>

--- a/themes/community-theme-16/modules/blocklanguages/blocklanguages.tpl
+++ b/themes/community-theme-16/modules/blocklanguages/blocklanguages.tpl
@@ -24,32 +24,32 @@
 *}
 <!-- Block languages module -->
 {if count($languages) > 1}
-    <div id="languages-block-top" class="languages-block">
-        {foreach from=$languages key=k item=language name="languages"}
-            {if $language.iso_code == $lang_iso}
-                <div class="current">
-                    <span>{$language.name|regex_replace:"/\s\(.*\)$/":""}</span>
-                </div>
+  <div id="languages-block-top" class="languages-block">
+    {foreach from=$languages key=k item=language name="languages"}
+      {if $language.iso_code == $lang_iso}
+        <div class="current">
+          <span>{$language.name|regex_replace:"/\s\(.*\)$/":""}</span>
+        </div>
+      {/if}
+    {/foreach}
+    <ul id="first-languages" class="languages-block_ul toogle_content">
+      {foreach from=$languages key=k item=language name="languages"}
+        <li {if $language.iso_code == $lang_iso}class="selected"{/if}>
+          {if $language.iso_code != $lang_iso}
+            {assign var=indice_lang value=$language.id_lang}
+            {if isset($lang_rewrite_urls.$indice_lang)}
+              <a href="{$lang_rewrite_urls.$indice_lang|escape:'html':'UTF-8'}" title="{$language.name|escape:'html':'UTF-8'}" rel="alternate" hreflang="{$language.iso_code|escape:'html':'UTF-8'}">
+            {else}
+              <a href="{$link->getLanguageLink($language.id_lang)|escape:'html':'UTF-8'}" title="{$language.name|escape:'html':'UTF-8'}" rel="alternate" hreflang="{$language.iso_code|escape:'html':'UTF-8'}">
             {/if}
-        {/foreach}
-        <ul id="first-languages" class="languages-block_ul toogle_content">
-            {foreach from=$languages key=k item=language name="languages"}
-                <li {if $language.iso_code == $lang_iso}class="selected"{/if}>
-                {if $language.iso_code != $lang_iso}
-                    {assign var=indice_lang value=$language.id_lang}
-                    {if isset($lang_rewrite_urls.$indice_lang)}
-                        <a href="{$lang_rewrite_urls.$indice_lang|escape:'html':'UTF-8'}" title="{$language.name|escape:'html':'UTF-8'}" rel="alternate" hreflang="{$language.iso_code|escape:'html':'UTF-8'}">
-                    {else}
-                        <a href="{$link->getLanguageLink($language.id_lang)|escape:'html':'UTF-8'}" title="{$language.name|escape:'html':'UTF-8'}" rel="alternate" hreflang="{$language.iso_code|escape:'html':'UTF-8'}">
-                    {/if}
-                {/if}
-                        <span>{$language.name|regex_replace:"/\s\(.*\)$/":""}</span>
-                {if $language.iso_code != $lang_iso}
-                    </a>
-                {/if}
-                </li>
-            {/foreach}
-        </ul>
-    </div>
+          {/if}
+            <span>{$language.name|regex_replace:"/\s\(.*\)$/":""}</span>
+          {if $language.iso_code != $lang_iso}
+            </a>
+          {/if}
+        </li>
+      {/foreach}
+    </ul>
+  </div>
 {/if}
 <!-- /Block languages module -->

--- a/themes/community-theme-16/modules/blocklayered/blocklayered-no-products.tpl
+++ b/themes/community-theme-16/modules/blocklayered/blocklayered-no-products.tpl
@@ -23,5 +23,5 @@
 *  International Registred Trademark & Property of PrestaShop SA
 *}
 <div class="product_list">
-    <p class="alert alert-warning">{l s='There are no products.' mod='blocklayered'}</p>
+  <p class="alert alert-warning">{l s='There are no products.' mod='blocklayered'}</p>
 </div>

--- a/themes/community-theme-16/modules/blocklayered/blocklayered.tpl
+++ b/themes/community-theme-16/modules/blocklayered/blocklayered.tpl
@@ -24,215 +24,215 @@
 *}
 
 {if $nbr_filterBlocks != 0}
-<div id="layered_block_left" class="block">
+  <div id="layered_block_left" class="block">
     <p class="title_block">{l s='Catalog' mod='blocklayered'}</p>
     <div class="block_content">
-        <form action="#" id="layered_form">
-            <div>
-                {if isset($selected_filters) && $n_filters > 0}
-                <div id="enabled_filters">
-                    <span class="layered_subtitle" style="float: none;">
-                        {l s='Enabled filters:' mod='blocklayered'}
-                    </span>
-                    <ul>
-                        {foreach from=$selected_filters key=filter_type item=filter_values}
-                            {foreach from=$filter_values key=filter_key item=filter_value name=f_values}
-                                {foreach from=$filters item=filter}
-                                    {if $filter.type == $filter_type && isset($filter.values)}
-                                        {if isset($filter.slider)}
-                                            {if $smarty.foreach.f_values.first}
-                                                <li>
-                                                    <a href="#" data-rel="layered_{$filter.type}_slider" title="{l s='Cancel' mod='blocklayered'}"></a>
-                                                    {if $filter.format == 1}
-                                                        {l s='%1$s: %2$s - %3$s'|sprintf:$filter.name:{displayPrice price=$filter.values[0]}:{displayPrice price=$filter.values[1]}|escape:'html':'UTF-8' mod='blocklayered'}
-                                                    {else}
-                                                        {l s='%1$s: %2$s %4$s - %3$s %4$s'|sprintf:$filter.name:$filter.values[0]:$filter.values[1]:$filter.unit|escape:'html':'UTF-8' mod='blocklayered'}
-                                                    {/if}
-                                                </li>
-                                            {/if}
-                                        {else}
-                                            {foreach from=$filter.values key=id_value item=value}
-                                                {if $id_value == $filter_key && !is_numeric($filter_value) && ($filter.type eq 'id_attribute_group' || $filter.type eq 'id_feature') || $id_value == $filter_value && $filter.type neq 'id_attribute_group' && $filter.type neq 'id_feature'}
-                                                    <li>
-                                                        <a href="#" data-rel="layered_{$filter.type_lite}_{$id_value}" title="{l s='Cancel' mod='blocklayered'}"><i class="icon-remove"></i></a>
-                                                        {l s='%1$s: %2$s' mod='blocklayered' sprintf=[$filter.name, $value.name]}
-                                                    </li>
-                                                {/if}
-                                            {/foreach}
-                                        {/if}
-                                    {/if}
-                                {/foreach}
-                            {/foreach}
-                        {/foreach}
-                    </ul>
-                </div>
-                {/if}
-                {foreach from=$filters item=filter}
-                    {if isset($filter.values)}
+      <form action="#" id="layered_form">
+        <div>
+          {if isset($selected_filters) && $n_filters > 0}
+            <div id="enabled_filters">
+              <span class="layered_subtitle" style="float: none;">
+                {l s='Enabled filters:' mod='blocklayered'}
+              </span>
+              <ul>
+                {foreach from=$selected_filters key=filter_type item=filter_values}
+                  {foreach from=$filter_values key=filter_key item=filter_value name=f_values}
+                    {foreach from=$filters item=filter}
+                      {if $filter.type == $filter_type && isset($filter.values)}
                         {if isset($filter.slider)}
-                            <div class="layered_{$filter.type}" style="display: none;">
+                          {if $smarty.foreach.f_values.first}
+                            <li>
+                              <a href="#" data-rel="layered_{$filter.type}_slider" title="{l s='Cancel' mod='blocklayered'}"></a>
+                              {if $filter.format == 1}
+                                {l s='%1$s: %2$s - %3$s'|sprintf:$filter.name:{displayPrice price=$filter.values[0]}:{displayPrice price=$filter.values[1]}|escape:'html':'UTF-8' mod='blocklayered'}
+                              {else}
+                                {l s='%1$s: %2$s %4$s - %3$s %4$s'|sprintf:$filter.name:$filter.values[0]:$filter.values[1]:$filter.unit|escape:'html':'UTF-8' mod='blocklayered'}
+                              {/if}
+                            </li>
+                          {/if}
                         {else}
-                            <div class="layered_filter">
-                        {/if}
-                        <div class="layered_subtitle_heading">
-                            <span class="layered_subtitle">{$filter.name|escape:'html':'UTF-8'}</span>
-                            <!--<span class="layered_close">
-                                <a href="#" data-rel="ul_layered_{$filter.type}_{$filter.id_key}"></a>
-                            </span>-->
-                        </div>
-                        <ul id="ul_layered_{$filter.type}_{$filter.id_key}" class="layered_filter_ul{if isset($filter.is_color_group) && $filter.is_color_group} color-group{/if}">
-                            {if !isset($filter.slider)}
-                                {if $filter.filter_type == 0}
-                                    {foreach from=$filter.values key=id_value item=value name=fe}
-                                        {if $value.nbr || !$hide_0_values}
-                                        <li class="nomargin {if $smarty.foreach.fe.index >= $filter.filter_show_limit}hiddable{/if}">
-                                            {if isset($filter.is_color_group) && $filter.is_color_group}
-                                                <input class="color-option {if isset($value.checked) && $value.checked}on{/if} {if !$value.nbr}disable{/if}" type="button" name="layered_{$filter.type_lite}_{$id_value}" data-rel="{$id_value}_{$filter.id_key}" id="layered_id_attribute_group_{$id_value}" {if !$value.nbr}disabled="disabled"{/if} style="background: {if isset($value.color)}{if file_exists($smarty.const._PS_ROOT_DIR_|cat:"/img/co/$id_value.jpg")}url(img/co/{$id_value}.jpg){else}{$value.color}{/if}{else}#CCC{/if};" />
-                                                {if isset($value.checked) && $value.checked}<input type="hidden" name="layered_{$filter.type_lite}_{$id_value}" value="{$id_value}" />{/if}
-                                            {else}
-                                                <input type="checkbox" class="checkbox" name="layered_{$filter.type_lite}_{$id_value}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{/if}" value="{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}"{if isset($value.checked)} checked="checked"{/if}{if !$value.nbr} disabled="disabled"{/if} />
-                                            {/if}
-                                            <label for="layered_{$filter.type_lite}_{$id_value}"{if !$value.nbr} class="disabled"{else}{if isset($filter.is_color_group) && $filter.is_color_group} name="layered_{$filter.type_lite}_{$id_value}" class="layered_color" data-rel="{$id_value}_{$filter.id_key}"{/if}{/if}>
-                                                {if !$value.nbr}
-                                                {$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
-                                                {else}
-                                                <a href="{$value.link}"{if $value.rel|trim != ''} data-rel="{$value.rel}"{/if}>{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}</a>
-                                                {/if}
-                                            </label>
-                                        </li>
-                                        {/if}
-                                    {/foreach}
-                                {else}
-                                    {if $filter.filter_type == 1}
-                                    {foreach from=$filter.values key=id_value item=value name=fe}
-                                        {if $value.nbr || !$hide_0_values}
-                                        <li class="nomargin {if $smarty.foreach.fe.index >= $filter.filter_show_limit}hiddable{/if}">
-                                            {if isset($filter.is_color_group) && $filter.is_color_group}
-                                                <input class="radio color-option {if isset($value.checked) && $value.checked}on{/if} {if !$value.nbr}disable{/if}" type="button" name="layered_{$filter.type_lite}_{$id_value}" data-rel="{$id_value}_{$filter.id_key}" id="layered_id_attribute_group_{$id_value}" {if !$value.nbr}disabled="disabled"{/if} style="background: {if isset($value.color)}{if file_exists($smarty.const._PS_ROOT_DIR_|cat:"/img/co/$id_value.jpg")}url(img/co/{$id_value}.jpg){else}{$value.color}{/if}{else}#CCC{/if};"/>
-                                                {if isset($value.checked) && $value.checked}<input type="hidden" name="layered_{$filter.type_lite}_{$id_value}" value="{$id_value}" />{/if}
-                                            {else}
-                                                <input type="radio" class="radio layered_{$filter.type_lite}_{$id_value}" name="layered_{$filter.type_lite}{if $filter.id_key}_{$filter.id_key}{else}_1{/if}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}{/if}" value="{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}"{if isset($value.checked)} checked="checked"{/if}{if !$value.nbr} disabled="disabled"{/if} />
-                                            {/if}
-                                            <label for="layered_{$filter.type_lite}_{$id_value}"{if !$value.nbr} class="disabled"{else}{if isset($filter.is_color_group) && $filter.is_color_group} name="layered_{$filter.type_lite}_{$id_value}" class="layered_color" data-rel="{$id_value}_{$filter.id_key}"{/if}{/if}>
-                                                {if !$value.nbr}
-                                                    {$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
-                                                {else}
-                                                    <a href="{$value.link}"{if $value.rel|trim != ''} data-rel="{$value.rel}"{/if}>{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}</a>
-                                                {/if}
-                                            </label>
-                                        </li>
-                                        {/if}
-                                    {/foreach}
-                                    {else}
-                                        <select class="select form-control" {if $filter.filter_show_limit > 1}multiple="multiple" size="{$filter.filter_show_limit}"{/if}>
-                                            <option value="">{l s='No filters' mod='blocklayered'}</option>
-                                            {foreach from=$filter.values key=id_value item=value}
-                                            {if $value.nbr || !$hide_0_values}
-                                                <option style="color: {if isset($value.color)}{$value.color}{/if}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{/if}" value="{$id_value}_{$filter.id_key}" {if isset($value.checked) && $value.checked}selected="selected"{/if} {if !$value.nbr}disabled="disabled"{/if}>
-                                                    {$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
-                                                </option>
-                                            {/if}
-                                            {/foreach}
-                                        </select>
-                                    {/if}
-                                {/if}
-                            {else}
-                                {if $filter.filter_type == 0}
-                                    <label for="{$filter.type}">
-                                        {l s='Range:' mod='blocklayered'}
-                                    </label>
-                                    <span id="layered_{$filter.type}_range"></span>
-                                    <div class="layered_slider_container">
-                                        <div class="layered_slider" id="layered_{$filter.type}_slider" data-type="{$filter.type}" data-format="{$filter.format}" data-unit="{$filter.unit}"></div>
-                                    </div>
-                                {else}
-                                    {if $filter.filter_type == 1}
-                                    <li class="nomargin row">
-                                        <div class="col-xs-6 col-sm-12 col-lg-6 first-item">
-                                            {l s='From' mod='blocklayered'}
-                                            <input class="layered_{$filter.type}_range layered_input_range_min layered_input_range form-control grey" id="layered_{$filter.type}_range_min" type="text" value="{$filter.values[0]}"/>
-                                            <span class="layered_{$filter.type}_range_unit">
-                                                {$filter.unit}
-                                            </span>
-                                        </div>
-                                        <div class="col-xs-6 col-sm-12 col-lg-6">
-                                            {l s='to' mod='blocklayered'}
-                                            <input class="layered_{$filter.type}_range layered_input_range_max layered_input_range form-control grey" id="layered_{$filter.type}_range_max" type="text" value="{$filter.values[1]}"/>
-                                            <span class="layered_{$filter.type}_range_unit">
-                                                {$filter.unit}
-                                            </span>
-                                        </div>
-                                        <span class="layered_{$filter.type}_format" style="display:none;">
-                                            {$filter.format}
-                                        </span>
-                                    </li>
-                                    {else}
-                                    {foreach from=$filter.list_of_values  item=values}
-                                        <li class="nomargin {if $filter.values[1] == $values[1] && $filter.values[0] == $values[0]}layered_list_selected{/if} layered_list" onclick="$('#layered_{$filter.type}_range_min').val({$values[0]});$('#layered_{$filter.type}_range_max').val({$values[1]});reloadContent();">
-                                            - {l s='From' mod='blocklayered'} {$values[0]} {$filter.unit} {l s='to' mod='blocklayered'} {$values[1]} {$filter.unit}
-                                        </li>
-                                    {/foreach}
-                                    <li style="display: none;">
-                                        <input class="layered_{$filter.type}_range" id="layered_{$filter.type}_range_min" type="hidden" value="{$filter.values[0]}"/>
-                                        <input class="layered_{$filter.type}_range" id="layered_{$filter.type}_range_max" type="hidden" value="{$filter.values[1]}"/>
-                                    </li>
-                                    {/if}
-                                {/if}
+                          {foreach from=$filter.values key=id_value item=value}
+                            {if $id_value == $filter_key && !is_numeric($filter_value) && ($filter.type eq 'id_attribute_group' || $filter.type eq 'id_feature') || $id_value == $filter_value && $filter.type neq 'id_attribute_group' && $filter.type neq 'id_feature'}
+                              <li>
+                                <a href="#" data-rel="layered_{$filter.type_lite}_{$id_value}" title="{l s='Cancel' mod='blocklayered'}"><i class="icon-remove"></i></a>
+                                {l s='%1$s: %2$s' mod='blocklayered' sprintf=[$filter.name, $value.name]}
+                              </li>
                             {/if}
-                            {if count($filter.values) > $filter.filter_show_limit && $filter.filter_show_limit > 0 && $filter.filter_type != 2}
-                                <span class="hide-action more">{l s='Show more' mod='blocklayered'}</span>
-                                <span class="hide-action less">{l s='Show less' mod='blocklayered'}</span>
-                            {/if}
-                        </ul>
-                    </div>
-                    {/if}
-                {/foreach}
-            </div>
-            <input type="hidden" name="id_category_layered" value="{$id_category_layered}" />
-            {foreach from=$filters item=filter}
-                {if $filter.type_lite == 'id_attribute_group' && isset($filter.is_color_group) && $filter.is_color_group && $filter.filter_type != 2}
-                    {foreach from=$filter.values key=id_value item=value}
-                        {if isset($value.checked)}
-                            <input type="hidden" name="layered_id_attribute_group_{$id_value}" value="{$id_value}_{$filter.id_key}" />
+                          {/foreach}
                         {/if}
+                      {/if}
                     {/foreach}
+                  {/foreach}
+                {/foreach}
+              </ul>
+            </div>
+          {/if}
+          {foreach from=$filters item=filter}
+          {if isset($filter.values)}
+          {if isset($filter.slider)}
+          <div class="layered_{$filter.type}" style="display: none;">
+            {else}
+            <div class="layered_filter">
+              {/if}
+              <div class="layered_subtitle_heading">
+                <span class="layered_subtitle">{$filter.name|escape:'html':'UTF-8'}</span>
+                <!--<span class="layered_close">
+                  <a href="#" data-rel="ul_layered_{$filter.type}_{$filter.id_key}"></a>
+                </span>-->
+              </div>
+              <ul id="ul_layered_{$filter.type}_{$filter.id_key}" class="layered_filter_ul{if isset($filter.is_color_group) && $filter.is_color_group} color-group{/if}">
+                {if !isset($filter.slider)}
+                  {if $filter.filter_type == 0}
+                    {foreach from=$filter.values key=id_value item=value name=fe}
+                      {if $value.nbr || !$hide_0_values}
+                        <li class="nomargin {if $smarty.foreach.fe.index >= $filter.filter_show_limit}hiddable{/if}">
+                          {if isset($filter.is_color_group) && $filter.is_color_group}
+                            <input class="color-option {if isset($value.checked) && $value.checked}on{/if} {if !$value.nbr}disable{/if}" type="button" name="layered_{$filter.type_lite}_{$id_value}" data-rel="{$id_value}_{$filter.id_key}" id="layered_id_attribute_group_{$id_value}" {if !$value.nbr}disabled="disabled"{/if} style="background: {if isset($value.color)}{if file_exists($smarty.const._PS_ROOT_DIR_|cat:"/img/co/$id_value.jpg")}url(img/co/{$id_value}.jpg){else}{$value.color}{/if}{else}#CCC{/if};" />
+                            {if isset($value.checked) && $value.checked}<input type="hidden" name="layered_{$filter.type_lite}_{$id_value}" value="{$id_value}" />{/if}
+                          {else}
+                            <input type="checkbox" class="checkbox" name="layered_{$filter.type_lite}_{$id_value}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{/if}" value="{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}"{if isset($value.checked)} checked="checked"{/if}{if !$value.nbr} disabled="disabled"{/if} />
+                          {/if}
+                          <label for="layered_{$filter.type_lite}_{$id_value}"{if !$value.nbr} class="disabled"{else}{if isset($filter.is_color_group) && $filter.is_color_group} name="layered_{$filter.type_lite}_{$id_value}" class="layered_color" data-rel="{$id_value}_{$filter.id_key}"{/if}{/if}>
+                            {if !$value.nbr}
+                              {$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
+                            {else}
+                              <a href="{$value.link}"{if $value.rel|trim != ''} data-rel="{$value.rel}"{/if}>{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}</a>
+                            {/if}
+                          </label>
+                        </li>
+                      {/if}
+                    {/foreach}
+                  {else}
+                    {if $filter.filter_type == 1}
+                      {foreach from=$filter.values key=id_value item=value name=fe}
+                        {if $value.nbr || !$hide_0_values}
+                          <li class="nomargin {if $smarty.foreach.fe.index >= $filter.filter_show_limit}hiddable{/if}">
+                            {if isset($filter.is_color_group) && $filter.is_color_group}
+                              <input class="radio color-option {if isset($value.checked) && $value.checked}on{/if} {if !$value.nbr}disable{/if}" type="button" name="layered_{$filter.type_lite}_{$id_value}" data-rel="{$id_value}_{$filter.id_key}" id="layered_id_attribute_group_{$id_value}" {if !$value.nbr}disabled="disabled"{/if} style="background: {if isset($value.color)}{if file_exists($smarty.const._PS_ROOT_DIR_|cat:"/img/co/$id_value.jpg")}url(img/co/{$id_value}.jpg){else}{$value.color}{/if}{else}#CCC{/if};"/>
+                              {if isset($value.checked) && $value.checked}<input type="hidden" name="layered_{$filter.type_lite}_{$id_value}" value="{$id_value}" />{/if}
+                            {else}
+                              <input type="radio" class="radio layered_{$filter.type_lite}_{$id_value}" name="layered_{$filter.type_lite}{if $filter.id_key}_{$filter.id_key}{else}_1{/if}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}{/if}" value="{$id_value}{if $filter.id_key}_{$filter.id_key}{/if}"{if isset($value.checked)} checked="checked"{/if}{if !$value.nbr} disabled="disabled"{/if} />
+                            {/if}
+                            <label for="layered_{$filter.type_lite}_{$id_value}"{if !$value.nbr} class="disabled"{else}{if isset($filter.is_color_group) && $filter.is_color_group} name="layered_{$filter.type_lite}_{$id_value}" class="layered_color" data-rel="{$id_value}_{$filter.id_key}"{/if}{/if}>
+                              {if !$value.nbr}
+                                {$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
+                              {else}
+                                <a href="{$value.link}"{if $value.rel|trim != ''} data-rel="{$value.rel}"{/if}>{$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}</a>
+                              {/if}
+                            </label>
+                          </li>
+                        {/if}
+                      {/foreach}
+                    {else}
+                      <select class="select form-control" {if $filter.filter_show_limit > 1}multiple="multiple" size="{$filter.filter_show_limit}"{/if}>
+                        <option value="">{l s='No filters' mod='blocklayered'}</option>
+                        {foreach from=$filter.values key=id_value item=value}
+                          {if $value.nbr || !$hide_0_values}
+                            <option style="color: {if isset($value.color)}{$value.color}{/if}" id="layered_{$filter.type_lite}{if $id_value || $filter.type == 'quantity'}_{$id_value}{/if}" value="{$id_value}_{$filter.id_key}" {if isset($value.checked) && $value.checked}selected="selected"{/if} {if !$value.nbr}disabled="disabled"{/if}>
+                              {$value.name|escape:'html':'UTF-8'}{if $layered_show_qties}<span> ({$value.nbr})</span>{/if}
+                            </option>
+                          {/if}
+                        {/foreach}
+                      </select>
+                    {/if}
+                  {/if}
+                {else}
+                  {if $filter.filter_type == 0}
+                    <label for="{$filter.type}">
+                      {l s='Range:' mod='blocklayered'}
+                    </label>
+                    <span id="layered_{$filter.type}_range"></span>
+                    <div class="layered_slider_container">
+                      <div class="layered_slider" id="layered_{$filter.type}_slider" data-type="{$filter.type}" data-format="{$filter.format}" data-unit="{$filter.unit}"></div>
+                    </div>
+                  {else}
+                    {if $filter.filter_type == 1}
+                      <li class="nomargin row">
+                        <div class="col-xs-6 col-sm-12 col-lg-6 first-item">
+                          {l s='From' mod='blocklayered'}
+                          <input class="layered_{$filter.type}_range layered_input_range_min layered_input_range form-control grey" id="layered_{$filter.type}_range_min" type="text" value="{$filter.values[0]}"/>
+                          <span class="layered_{$filter.type}_range_unit">
+                            {$filter.unit}
+                          </span>
+                        </div>
+                        <div class="col-xs-6 col-sm-12 col-lg-6">
+                          {l s='to' mod='blocklayered'}
+                          <input class="layered_{$filter.type}_range layered_input_range_max layered_input_range form-control grey" id="layered_{$filter.type}_range_max" type="text" value="{$filter.values[1]}"/>
+                          <span class="layered_{$filter.type}_range_unit">
+                            {$filter.unit}
+                          </span>
+                        </div>
+                        <span class="layered_{$filter.type}_format" style="display:none;">
+                          {$filter.format}
+                        </span>
+                      </li>
+                    {else}
+                      {foreach from=$filter.list_of_values  item=values}
+                        <li class="nomargin {if $filter.values[1] == $values[1] && $filter.values[0] == $values[0]}layered_list_selected{/if} layered_list" onclick="$('#layered_{$filter.type}_range_min').val({$values[0]});$('#layered_{$filter.type}_range_max').val({$values[1]});reloadContent();">
+                          - {l s='From' mod='blocklayered'} {$values[0]} {$filter.unit} {l s='to' mod='blocklayered'} {$values[1]} {$filter.unit}
+                        </li>
+                      {/foreach}
+                      <li style="display: none;">
+                        <input class="layered_{$filter.type}_range" id="layered_{$filter.type}_range_min" type="hidden" value="{$filter.values[0]}"/>
+                        <input class="layered_{$filter.type}_range" id="layered_{$filter.type}_range_max" type="hidden" value="{$filter.values[1]}"/>
+                      </li>
+                    {/if}
+                  {/if}
                 {/if}
+                {if count($filter.values) > $filter.filter_show_limit && $filter.filter_show_limit > 0 && $filter.filter_type != 2}
+                  <span class="hide-action more">{l s='Show more' mod='blocklayered'}</span>
+                  <span class="hide-action less">{l s='Show less' mod='blocklayered'}</span>
+                {/if}
+              </ul>
+            </div>
+            {/if}
             {/foreach}
-        </form>
+          </div>
+          <input type="hidden" name="id_category_layered" value="{$id_category_layered}" />
+          {foreach from=$filters item=filter}
+            {if $filter.type_lite == 'id_attribute_group' && isset($filter.is_color_group) && $filter.is_color_group && $filter.filter_type != 2}
+              {foreach from=$filter.values key=id_value item=value}
+                {if isset($value.checked)}
+                  <input type="hidden" name="layered_id_attribute_group_{$id_value}" value="{$id_value}_{$filter.id_key}" />
+                {/if}
+              {/foreach}
+            {/if}
+          {/foreach}
+      </form>
     </div>
     <div id="layered_ajax_loader" style="display: none;">
-        <p>
-            <img src="{$img_ps_dir}loader.gif" alt="" />
-            <br />{l s='Loading...' mod='blocklayered'}
-        </p>
+      <p>
+        <img src="{$img_ps_dir}loader.gif" alt="" />
+        <br />{l s='Loading...' mod='blocklayered'}
+      </p>
     </div>
-</div>
+  </div>
 {else}
-<div id="layered_block_left" class="block">
+  <div id="layered_block_left" class="block">
     <div class="block_content">
-        <form action="#" id="layered_form">
-            <input type="hidden" name="id_category_layered" value="{$id_category_layered}" />
-        </form>
+      <form action="#" id="layered_form">
+        <input type="hidden" name="id_category_layered" value="{$id_category_layered}" />
+      </form>
     </div>
     <div style="display: none;">
-        <p>
-            <img src="{$img_ps_dir}loader.gif" alt="" />
-            <br />{l s='Loading...' mod='blocklayered'}
-        </p>
+      <p>
+        <img src="{$img_ps_dir}loader.gif" alt="" />
+        <br />{l s='Loading...' mod='blocklayered'}
+      </p>
     </div>
-</div>
+  </div>
 {/if}
 {if $nbr_filterBlocks != 0}
-{strip}
+  {strip}
     {if version_compare($smarty.const._PS_VERSION_,'1.5','>')}
-        {addJsDef param_product_url='#'|cat:$param_product_url}
+      {addJsDef param_product_url='#'|cat:$param_product_url}
     {else}
-        {addJsDef param_product_url=''}
+      {addJsDef param_product_url=''}
     {/if}
     {addJsDef blocklayeredSliderName=$blocklayeredSliderName}
 
     {if isset($filters) && $filters|@count}
-        {addJsDef filters=$filters}
+      {addJsDef filters=$filters}
     {/if}
-{/strip}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/modules/blocklink/blocklink.tpl
+++ b/themes/community-theme-16/modules/blocklink/blocklink.tpl
@@ -25,21 +25,21 @@
 
 <!-- Block links module -->
 <div id="links_block_left" class="block">
-    <p class="title_block">
+  <p class="title_block">
     {if $url}
-        <a href="{$url|escape}">{$title|escape}</a>
+      <a href="{$url|escape}">{$title|escape}</a>
     {else}
-        {$title|escape}
+      {$title|escape}
     {/if}
-    </p>
-    <div class="block_content list-block">
-        <ul>
-            {foreach from=$blocklink_links item=blocklink_link}
-                {if isset($blocklink_link.$lang)} 
-                    <li><a href="{$blocklink_link.url|escape}"{if $blocklink_link.newWindow} onclick="window.open(this.href);return false;"{/if}>{$blocklink_link.$lang|escape}</a></li>
-                {/if}
-            {/foreach}
-        </ul>
-    </div>
+  </p>
+  <div class="block_content list-block">
+    <ul>
+      {foreach from=$blocklink_links item=blocklink_link}
+        {if isset($blocklink_link.$lang)}
+          <li><a href="{$blocklink_link.url|escape}"{if $blocklink_link.newWindow} onclick="window.open(this.href);return false;"{/if}>{$blocklink_link.$lang|escape}</a></li>
+        {/if}
+      {/foreach}
+    </ul>
+  </div>
 </div>
 <!-- /Block links module -->

--- a/themes/community-theme-16/modules/blockmanufacturer/blockmanufacturer.tpl
+++ b/themes/community-theme-16/modules/blockmanufacturer/blockmanufacturer.tpl
@@ -25,46 +25,46 @@
 
 <!-- Block manufacturers module -->
 <div id="manufacturers_block_left" class="block blockmanufacturer">
-    <p class="title_block">
-        {if $display_link_manufacturer}
-            <a href="{$link->getPageLink('manufacturer')|escape:'html':'UTF-8'}" title="{l s='Manufacturers' mod='blockmanufacturer'}">
-        {/if}
-                {l s='Manufacturers' mod='blockmanufacturer'}
-        {if $display_link_manufacturer}
-            </a>
-        {/if}
-    </p>
-    <div class="block_content list-block">
-        {if $manufacturers}
-            {if $text_list}
-            <ul>
-                {foreach from=$manufacturers item=manufacturer name=manufacturer_list}
-                    {if $smarty.foreach.manufacturer_list.iteration <= $text_list_nb}
-                    <li class="{if $smarty.foreach.manufacturer_list.last}last_item{elseif $smarty.foreach.manufacturer_list.first}first_item{else}item{/if}">
-                        <a
-                        href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}" title="{l s='More about %s' mod='blockmanufacturer' sprintf=[$manufacturer.name]}">
-                            {$manufacturer.name|escape:'html':'UTF-8'}
-                        </a>
-                    </li>
-                    {/if}
-                {/foreach}
-            </ul>
+  <p class="title_block">
+    {if $display_link_manufacturer}
+      <a href="{$link->getPageLink('manufacturer')|escape:'html':'UTF-8'}" title="{l s='Manufacturers' mod='blockmanufacturer'}">
+    {/if}
+      {l s='Manufacturers' mod='blockmanufacturer'}
+    {if $display_link_manufacturer}
+      </a>
+    {/if}
+  </p>
+  <div class="block_content list-block">
+    {if $manufacturers}
+      {if $text_list}
+        <ul>
+          {foreach from=$manufacturers item=manufacturer name=manufacturer_list}
+            {if $smarty.foreach.manufacturer_list.iteration <= $text_list_nb}
+              <li class="{if $smarty.foreach.manufacturer_list.last}last_item{elseif $smarty.foreach.manufacturer_list.first}first_item{else}item{/if}">
+                <a
+                  href="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}" title="{l s='More about %s' mod='blockmanufacturer' sprintf=[$manufacturer.name]}">
+                  {$manufacturer.name|escape:'html':'UTF-8'}
+                </a>
+              </li>
             {/if}
-            {if $form_list}
-                <form action="{$smarty.server.SCRIPT_NAME|escape:'html':'UTF-8'}" method="get">
-                    <div class="form-group selector1">
-                        <select class="form-control" name="manufacturer_list">
-                            <option value="0">{l s='All manufacturers' mod='blockmanufacturer'}</option>
-                        {foreach from=$manufacturers item=manufacturer}
-                            <option value="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">{$manufacturer.name|escape:'html':'UTF-8'}</option>
-                        {/foreach}
-                        </select>
-                    </div>
-                </form>
-            {/if}
-        {else}
-            <p>{l s='No manufacturer' mod='blockmanufacturer'}</p>
-        {/if}
-    </div>
+          {/foreach}
+        </ul>
+      {/if}
+      {if $form_list}
+        <form action="{$smarty.server.SCRIPT_NAME|escape:'html':'UTF-8'}" method="get">
+          <div class="form-group selector1">
+            <select class="form-control" name="manufacturer_list">
+              <option value="0">{l s='All manufacturers' mod='blockmanufacturer'}</option>
+              {foreach from=$manufacturers item=manufacturer}
+                <option value="{$link->getmanufacturerLink($manufacturer.id_manufacturer, $manufacturer.link_rewrite)|escape:'html':'UTF-8'}">{$manufacturer.name|escape:'html':'UTF-8'}</option>
+              {/foreach}
+            </select>
+          </div>
+        </form>
+      {/if}
+    {else}
+      <p>{l s='No manufacturer' mod='blockmanufacturer'}</p>
+    {/if}
+  </div>
 </div>
 <!-- /Block manufacturers module -->

--- a/themes/community-theme-16/modules/blockmyaccount/blockmyaccount.tpl
+++ b/themes/community-theme-16/modules/blockmyaccount/blockmyaccount.tpl
@@ -25,57 +25,57 @@
 
 <!-- Block myaccount module -->
 <div class="block myaccount-column">
-    <p class="title_block">
-        <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='My account' mod='blockmyaccount'}">
-            {l s='My account' mod='blockmyaccount'}
+  <p class="title_block">
+    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='My account' mod='blockmyaccount'}">
+      {l s='My account' mod='blockmyaccount'}
+    </a>
+  </p>
+  <div class="block_content list-block">
+    <ul>
+      <li>
+        <a href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='My orders' mod='blockmyaccount'}">
+          {l s='My orders' mod='blockmyaccount'}
         </a>
-    </p>
-    <div class="block_content list-block">
-        <ul>
-            <li>
-                <a href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='My orders' mod='blockmyaccount'}">
-                    {l s='My orders' mod='blockmyaccount'}
-                </a>
-            </li>
-            {if $returnAllowed}
-                <li>
-                    <a href="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" title="{l s='My merchandise returns' mod='blockmyaccount'}">
-                        {l s='My merchandise returns' mod='blockmyaccount'}
-                    </a>
-                </li>
-            {/if}
-            <li>
-                <a href="{$link->getPageLink('order-slip', true)|escape:'html':'UTF-8'}" title="{l s='My credit slips' mod='blockmyaccount'}">
-                    {l s='My credit slips' mod='blockmyaccount'}
-                </a>
-            </li>
-            <li>
-                <a href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" title="{l s='My addresses' mod='blockmyaccount'}">
-                    {l s='My addresses' mod='blockmyaccount'}
-                </a>
-            </li>
-            <li>
-                <a href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" title="{l s='My personal info' mod='blockmyaccount'}">
-                    {l s='My personal info' mod='blockmyaccount'}
-                </a>
-            </li>
-            {if $voucherAllowed}
-                <li>
-                    <a href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" title="{l s='My vouchers' mod='blockmyaccount'}">
-                        {l s='My vouchers' mod='blockmyaccount'}
-                    </a>
-                </li>
-            {/if}
-            {$HOOK_BLOCK_MY_ACCOUNT}
-        </ul>
-        <div class="logout">
-            <a
-            class="btn btn-default button button-small"
-            href="{$link->getPageLink('index', true, NULL, "mylogout")|escape:'html':'UTF-8'}"
-            title="{l s='Sign out' mod='blockmyaccount'}">
-                <span>{l s='Sign out' mod='blockmyaccount'}<i class="icon-chevron-right right"></i></span>
-            </a>
-        </div>
+      </li>
+      {if $returnAllowed}
+        <li>
+          <a href="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" title="{l s='My merchandise returns' mod='blockmyaccount'}">
+            {l s='My merchandise returns' mod='blockmyaccount'}
+          </a>
+        </li>
+      {/if}
+      <li>
+        <a href="{$link->getPageLink('order-slip', true)|escape:'html':'UTF-8'}" title="{l s='My credit slips' mod='blockmyaccount'}">
+          {l s='My credit slips' mod='blockmyaccount'}
+        </a>
+      </li>
+      <li>
+        <a href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" title="{l s='My addresses' mod='blockmyaccount'}">
+          {l s='My addresses' mod='blockmyaccount'}
+        </a>
+      </li>
+      <li>
+        <a href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" title="{l s='My personal info' mod='blockmyaccount'}">
+          {l s='My personal info' mod='blockmyaccount'}
+        </a>
+      </li>
+      {if $voucherAllowed}
+        <li>
+          <a href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" title="{l s='My vouchers' mod='blockmyaccount'}">
+            {l s='My vouchers' mod='blockmyaccount'}
+          </a>
+        </li>
+      {/if}
+      {$HOOK_BLOCK_MY_ACCOUNT}
+    </ul>
+    <div class="logout">
+      <a
+        class="btn btn-default button button-small"
+        href="{$link->getPageLink('index', true, NULL, "mylogout")|escape:'html':'UTF-8'}"
+        title="{l s='Sign out' mod='blockmyaccount'}">
+        <span>{l s='Sign out' mod='blockmyaccount'}<i class="icon-chevron-right right"></i></span>
+      </a>
     </div>
+  </div>
 </div>
 <!-- /Block myaccount module -->

--- a/themes/community-theme-16/modules/blockmyaccountfooter/blockmyaccountfooter.tpl
+++ b/themes/community-theme-16/modules/blockmyaccountfooter/blockmyaccountfooter.tpl
@@ -25,18 +25,18 @@
 
 <!-- Block myaccount module -->
 <section class="footer-block col-xs-12 col-sm-4">
-    <h4><a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='Manage my customer account' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My account' mod='blockmyaccountfooter'}</a></h4>
-    <div class="block_content toggle-footer">
-        <ul class="bullet">
-            <li><a href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='My orders' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My orders' mod='blockmyaccountfooter'}</a></li>
-            {if $returnAllowed}<li><a href="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" title="{l s='My merchandise returns' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My merchandise returns' mod='blockmyaccountfooter'}</a></li>{/if}
-            <li><a href="{$link->getPageLink('order-slip', true)|escape:'html':'UTF-8'}" title="{l s='My credit slips' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My credit slips' mod='blockmyaccountfooter'}</a></li>
-            <li><a href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" title="{l s='My addresses' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My addresses' mod='blockmyaccountfooter'}</a></li>
-            <li><a href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" title="{l s='Manage my personal information' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My personal info' mod='blockmyaccountfooter'}</a></li>
-            {if $voucherAllowed}<li><a href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" title="{l s='My vouchers' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My vouchers' mod='blockmyaccountfooter'}</a></li>{/if}
-            {$HOOK_BLOCK_MY_ACCOUNT}
-            {if $is_logged}<li><a href="{$link->getPageLink('index')}?mylogout" title="{l s='Sign out' mod='blockmyaccountfooter'}" rel="nofollow">{l s='Sign out' mod='blockmyaccountfooter'}</a></li>{/if}
-        </ul>
-    </div>
+  <h4><a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='Manage my customer account' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My account' mod='blockmyaccountfooter'}</a></h4>
+  <div class="block_content toggle-footer">
+    <ul class="bullet">
+      <li><a href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='My orders' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My orders' mod='blockmyaccountfooter'}</a></li>
+      {if $returnAllowed}<li><a href="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" title="{l s='My merchandise returns' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My merchandise returns' mod='blockmyaccountfooter'}</a></li>{/if}
+      <li><a href="{$link->getPageLink('order-slip', true)|escape:'html':'UTF-8'}" title="{l s='My credit slips' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My credit slips' mod='blockmyaccountfooter'}</a></li>
+      <li><a href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" title="{l s='My addresses' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My addresses' mod='blockmyaccountfooter'}</a></li>
+      <li><a href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" title="{l s='Manage my personal information' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My personal info' mod='blockmyaccountfooter'}</a></li>
+      {if $voucherAllowed}<li><a href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" title="{l s='My vouchers' mod='blockmyaccountfooter'}" rel="nofollow">{l s='My vouchers' mod='blockmyaccountfooter'}</a></li>{/if}
+      {$HOOK_BLOCK_MY_ACCOUNT}
+      {if $is_logged}<li><a href="{$link->getPageLink('index')}?mylogout" title="{l s='Sign out' mod='blockmyaccountfooter'}" rel="nofollow">{l s='Sign out' mod='blockmyaccountfooter'}</a></li>{/if}
+    </ul>
+  </div>
 </section>
 <!-- /Block myaccount module -->

--- a/themes/community-theme-16/modules/blocknewproducts/blocknewproducts.tpl
+++ b/themes/community-theme-16/modules/blocknewproducts/blocknewproducts.tpl
@@ -24,40 +24,40 @@
 *}
 <!-- MODULE Block new products -->
 <div id="new-products_block_right" class="block products_block">
-    <h4 class="title_block">
-        <a href="{$link->getPageLink('new-products')|escape:'html'}" title="{l s='New products' mod='blocknewproducts'}">{l s='New products' mod='blocknewproducts'}</a>
-    </h4>
-    <div class="block_content products-block">
-        {if $new_products !== false}
-            <ul class="products">
-                {foreach from=$new_products item=newproduct name=myLoop}
-                    <li class="clearfix">
-                        <a class="products-block-image" href="{$newproduct.link|escape:'html'}" title="{$newproduct.legend|escape:html:'UTF-8'}"><img class="replace-2x img-responsive" src="{$link->getImageLink($newproduct.link_rewrite, $newproduct.id_image, 'small_default')|escape:'html'}" alt="{$newproduct.name|escape:html:'UTF-8'}" /></a>
-                        <div class="product-content">
-                            <h5>
-                                <a class="product-name" href="{$newproduct.link|escape:'html'}" title="{$newproduct.name|escape:html:'UTF-8'}">{$newproduct.name|strip_tags|escape:html:'UTF-8'}</a>
-                            </h5>
-                            <p class="product-description">{$newproduct.description_short|strip_tags:'UTF-8'|truncate:75:'...'}</p>
-                            {if (!$PS_CATALOG_MODE AND ((isset($newproduct.show_price) && $newproduct.show_price) || (isset($newproduct.available_for_order) && $newproduct.available_for_order)))}
-                                {if isset($newproduct.show_price) && $newproduct.show_price && !isset($restricted_country_mode)}
-                                    <div class="price-box">
-                                        <span class="price">
-                                            {if !$priceDisplay}{convertPrice price=$newproduct.price}{else}{convertPrice price=$newproduct.price_tax_exc}{/if}
-                                        </span>
-                                        {hook h="displayProductPriceBlock" product=$newproduct type="price"}
-                                    </div>
-                                {/if}
-                            {/if}
-                        </div>
-                    </li>
-                {/foreach}
-            </ul>
-            <div>
-                <a href="{$link->getPageLink('new-products')|escape:'html'}" title="{l s='All new products' mod='blocknewproducts'}" class="btn btn-default button button-small"><span>{l s='All new products' mod='blocknewproducts'}<i class="icon-chevron-right right"></i></span></a>
+  <h4 class="title_block">
+    <a href="{$link->getPageLink('new-products')|escape:'html'}" title="{l s='New products' mod='blocknewproducts'}">{l s='New products' mod='blocknewproducts'}</a>
+  </h4>
+  <div class="block_content products-block">
+    {if $new_products !== false}
+      <ul class="products">
+        {foreach from=$new_products item=newproduct name=myLoop}
+          <li class="clearfix">
+            <a class="products-block-image" href="{$newproduct.link|escape:'html'}" title="{$newproduct.legend|escape:html:'UTF-8'}"><img class="replace-2x img-responsive" src="{$link->getImageLink($newproduct.link_rewrite, $newproduct.id_image, 'small_default')|escape:'html'}" alt="{$newproduct.name|escape:html:'UTF-8'}" /></a>
+            <div class="product-content">
+              <h5>
+                <a class="product-name" href="{$newproduct.link|escape:'html'}" title="{$newproduct.name|escape:html:'UTF-8'}">{$newproduct.name|strip_tags|escape:html:'UTF-8'}</a>
+              </h5>
+              <p class="product-description">{$newproduct.description_short|strip_tags:'UTF-8'|truncate:75:'...'}</p>
+              {if (!$PS_CATALOG_MODE AND ((isset($newproduct.show_price) && $newproduct.show_price) || (isset($newproduct.available_for_order) && $newproduct.available_for_order)))}
+                {if isset($newproduct.show_price) && $newproduct.show_price && !isset($restricted_country_mode)}
+                  <div class="price-box">
+                    <span class="price">
+                      {if !$priceDisplay}{convertPrice price=$newproduct.price}{else}{convertPrice price=$newproduct.price_tax_exc}{/if}
+                    </span>
+                    {hook h="displayProductPriceBlock" product=$newproduct type="price"}
+                  </div>
+                {/if}
+              {/if}
             </div>
-        {else}
-            <p>&raquo; {l s='Do not allow new products at this time.' mod='blocknewproducts'}</p>
-        {/if}
-    </div>
+          </li>
+        {/foreach}
+      </ul>
+      <div>
+        <a href="{$link->getPageLink('new-products')|escape:'html'}" title="{l s='All new products' mod='blocknewproducts'}" class="btn btn-default button button-small"><span>{l s='All new products' mod='blocknewproducts'}<i class="icon-chevron-right right"></i></span></a>
+      </div>
+    {else}
+      <p>&raquo; {l s='Do not allow new products at this time.' mod='blocknewproducts'}</p>
+    {/if}
+  </div>
 </div>
 <!-- /MODULE Block new products -->

--- a/themes/community-theme-16/modules/blocknewsletter/blocknewsletter.tpl
+++ b/themes/community-theme-16/modules/blocknewsletter/blocknewsletter.tpl
@@ -24,30 +24,30 @@
 *}
 <!-- Block Newsletter module-->
 <div id="newsletter_block_left" class="block">
-    <h4>{l s='Newsletter' mod='blocknewsletter'}</h4>
-    <div class="block_content">
-        <form action="{$link->getPageLink('index', null, null, null, false, null, true)|escape:'html':'UTF-8'}" method="post">
-            <div class="form-group{if isset($msg) && $msg } {if $nw_error}form-error{else}form-ok{/if}{/if}" >
-                <input class="inputNew form-control grey newsletter-input" id="newsletter-input" type="text" name="email" size="18" value="{if isset($msg) && $msg}{$msg}{elseif isset($value) && $value}{$value}{else}{l s='Enter your e-mail' mod='blocknewsletter'}{/if}" />
-                <button type="submit" name="submitNewsletter" class="btn btn-default button button-small">
-                    <span>{l s='Ok' mod='blocknewsletter'}</span>
-                </button>
-                <input type="hidden" name="action" value="0" />
-            </div>
-        </form>
-    </div>
-    {hook h="displayBlockNewsletterBottom" from='blocknewsletter'}
+  <h4>{l s='Newsletter' mod='blocknewsletter'}</h4>
+  <div class="block_content">
+    <form action="{$link->getPageLink('index', null, null, null, false, null, true)|escape:'html':'UTF-8'}" method="post">
+      <div class="form-group{if isset($msg) && $msg } {if $nw_error}form-error{else}form-ok{/if}{/if}" >
+        <input class="inputNew form-control grey newsletter-input" id="newsletter-input" type="text" name="email" size="18" value="{if isset($msg) && $msg}{$msg}{elseif isset($value) && $value}{$value}{else}{l s='Enter your e-mail' mod='blocknewsletter'}{/if}" />
+        <button type="submit" name="submitNewsletter" class="btn btn-default button button-small">
+          <span>{l s='Ok' mod='blocknewsletter'}</span>
+        </button>
+        <input type="hidden" name="action" value="0" />
+      </div>
+    </form>
+  </div>
+  {hook h="displayBlockNewsletterBottom" from='blocknewsletter'}
 </div>
 <!-- /Block Newsletter module-->
 {strip}
-{if isset($msg) && $msg}
-{addJsDef msg_newsl=$msg|@addcslashes:'\''}
-{/if}
-{if isset($nw_error)}
-{addJsDef nw_error=$nw_error}
-{/if}
-{addJsDefL name=placeholder_blocknewsletter}{l s='Enter your e-mail' mod='blocknewsletter' js=1}{/addJsDefL}
-{if isset($msg) && $msg}
+  {if isset($msg) && $msg}
+    {addJsDef msg_newsl=$msg|@addcslashes:'\''}
+  {/if}
+  {if isset($nw_error)}
+    {addJsDef nw_error=$nw_error}
+  {/if}
+  {addJsDefL name=placeholder_blocknewsletter}{l s='Enter your e-mail' mod='blocknewsletter' js=1}{/addJsDefL}
+  {if isset($msg) && $msg}
     {addJsDefL name=alert_blocknewsletter}{l s='Newsletter : %1$s' sprintf=$msg js=1 mod="blocknewsletter"}{/addJsDefL}
-{/if}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/modules/blockrss/blockrss.tpl
+++ b/themes/community-theme-16/modules/blockrss/blockrss.tpl
@@ -25,17 +25,17 @@
 
 <!-- Block RSS module-->
 <div id="rss_block_left" class="block">
-    <p class="title_block">{$title}</p>
-    <div class="block_content">
-        {if $rss_links}
-            <ul>
-                {foreach from=$rss_links item='rss_link'}
-                    <li><a href="{$rss_link.url}">{$rss_link.title}</a></li>
-                {/foreach}
-            </ul>
-        {else}
-            <p>{l s='No RSS feed added' mod='blockrss'}</p>
-        {/if}
-    </div>
+  <p class="title_block">{$title}</p>
+  <div class="block_content">
+    {if $rss_links}
+      <ul>
+        {foreach from=$rss_links item='rss_link'}
+          <li><a href="{$rss_link.url}">{$rss_link.title}</a></li>
+        {/foreach}
+      </ul>
+    {else}
+      <p>{l s='No RSS feed added' mod='blockrss'}</p>
+    {/if}
+  </div>
 </div>
 <!-- /Block RSS module-->

--- a/themes/community-theme-16/modules/blocksearch/blocksearch-top.tpl
+++ b/themes/community-theme-16/modules/blocksearch/blocksearch-top.tpl
@@ -24,14 +24,14 @@
 *}
 <!-- Block search module TOP -->
 <div id="search_block_top" class="col-sm-4 clearfix">
-    <form id="searchbox" method="get" action="{$link->getPageLink('search', null, null, null, false, null, true)|escape:'html':'UTF-8'}" >
-        <input type="hidden" name="controller" value="search" />
-        <input type="hidden" name="orderby" value="position" />
-        <input type="hidden" name="orderway" value="desc" />
-        <input class="search_query form-control" type="text" id="search_query_top" name="search_query" placeholder="{l s='Search' mod='blocksearch'}" value="{$search_query|escape:'htmlall':'UTF-8'|stripslashes}" />
-        <button type="submit" name="submit_search" class="btn btn-default button-search">
-            <span>{l s='Search' mod='blocksearch'}</span>
-        </button>
-    </form>
+  <form id="searchbox" method="get" action="{$link->getPageLink('search', null, null, null, false, null, true)|escape:'html':'UTF-8'}" >
+    <input type="hidden" name="controller" value="search" />
+    <input type="hidden" name="orderby" value="position" />
+    <input type="hidden" name="orderway" value="desc" />
+    <input class="search_query form-control" type="text" id="search_query_top" name="search_query" placeholder="{l s='Search' mod='blocksearch'}" value="{$search_query|escape:'htmlall':'UTF-8'|stripslashes}" />
+    <button type="submit" name="submit_search" class="btn btn-default button-search">
+      <span>{l s='Search' mod='blocksearch'}</span>
+    </button>
+  </form>
 </div>
 <!-- /Block search module TOP -->

--- a/themes/community-theme-16/modules/blocksearch/blocksearch.tpl
+++ b/themes/community-theme-16/modules/blocksearch/blocksearch.tpl
@@ -25,16 +25,16 @@
 
 <!-- Block search module -->
 <div id="search_block_left" class="block exclusive">
-    <p class="title_block">{l s='Search' mod='blocksearch'}</p>
-    <form method="get" action="{$link->getPageLink('search', true, null, null, false, null, true)|escape:'html':'UTF-8'}" id="searchbox">
-        <label for="search_query_block">{l s='Search products:' mod='blocksearch'}</label>
-        <p class="block_content clearfix">
-            <input type="hidden" name="orderby" value="position" />
-            <input type="hidden" name="controller" value="search" />
-            <input type="hidden" name="orderway" value="desc" />
-            <input class="search_query form-control grey" type="text" id="search_query_block" name="search_query" value="{$search_query|escape:'htmlall':'UTF-8'|stripslashes}" />
-            <button type="submit" id="search_button" class="btn btn-default button button-small"><span><i class="icon-search"></i></span></button>
-        </p>
-    </form>
+  <p class="title_block">{l s='Search' mod='blocksearch'}</p>
+  <form method="get" action="{$link->getPageLink('search', true, null, null, false, null, true)|escape:'html':'UTF-8'}" id="searchbox">
+    <label for="search_query_block">{l s='Search products:' mod='blocksearch'}</label>
+    <p class="block_content clearfix">
+      <input type="hidden" name="orderby" value="position" />
+      <input type="hidden" name="controller" value="search" />
+      <input type="hidden" name="orderway" value="desc" />
+      <input class="search_query form-control grey" type="text" id="search_query_block" name="search_query" value="{$search_query|escape:'htmlall':'UTF-8'|stripslashes}" />
+      <button type="submit" id="search_button" class="btn btn-default button button-small"><span><i class="icon-search"></i></span></button>
+    </p>
+  </form>
 </div>
 <!-- /Block search module -->

--- a/themes/community-theme-16/modules/blocksocial/blocksocial.tpl
+++ b/themes/community-theme-16/modules/blocksocial/blocksocial.tpl
@@ -24,64 +24,64 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <section id="social_block" class="pull-right">
-    <ul>
-        {if isset($facebook_url) && $facebook_url != ''}
-            <li class="facebook">
-                <a class="_blank" href="{$facebook_url|escape:html:'UTF-8'}">
-                    <span>{l s='Facebook' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($twitter_url) && $twitter_url != ''}
-            <li class="twitter">
-                <a class="_blank" href="{$twitter_url|escape:html:'UTF-8'}">
-                    <span>{l s='Twitter' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($rss_url) && $rss_url != ''}
-            <li class="rss">
-                <a class="_blank" href="{$rss_url|escape:html:'UTF-8'}">
-                    <span>{l s='RSS' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($youtube_url) && $youtube_url != ''}
-            <li class="youtube">
-                <a class="_blank" href="{$youtube_url|escape:html:'UTF-8'}">
-                    <span>{l s='Youtube' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($google_plus_url) && $google_plus_url != ''}
-            <li class="google-plus">
-                <a class="_blank" href="{$google_plus_url|escape:html:'UTF-8'}" rel="publisher">
-                    <span>{l s='Google Plus' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($pinterest_url) && $pinterest_url != ''}
-            <li class="pinterest">
-                <a class="_blank" href="{$pinterest_url|escape:html:'UTF-8'}">
-                    <span>{l s='Pinterest' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($vimeo_url) && $vimeo_url != ''}
-            <li class="vimeo">
-                <a class="_blank" href="{$vimeo_url|escape:html:'UTF-8'}">
-                    <span>{l s='Vimeo' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-        {if isset($instagram_url) && $instagram_url != ''}
-            <li class="instagram">
-                <a class="_blank" href="{$instagram_url|escape:html:'UTF-8'}">
-                    <span>{l s='Instagram' mod='blocksocial'}</span>
-                </a>
-            </li>
-        {/if}
-    </ul>
-    <h4>{l s='Follow us' mod='blocksocial'}</h4>
+  <ul>
+    {if isset($facebook_url) && $facebook_url != ''}
+      <li class="facebook">
+        <a class="_blank" href="{$facebook_url|escape:html:'UTF-8'}">
+          <span>{l s='Facebook' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($twitter_url) && $twitter_url != ''}
+      <li class="twitter">
+        <a class="_blank" href="{$twitter_url|escape:html:'UTF-8'}">
+          <span>{l s='Twitter' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($rss_url) && $rss_url != ''}
+      <li class="rss">
+        <a class="_blank" href="{$rss_url|escape:html:'UTF-8'}">
+          <span>{l s='RSS' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($youtube_url) && $youtube_url != ''}
+      <li class="youtube">
+        <a class="_blank" href="{$youtube_url|escape:html:'UTF-8'}">
+          <span>{l s='Youtube' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($google_plus_url) && $google_plus_url != ''}
+      <li class="google-plus">
+        <a class="_blank" href="{$google_plus_url|escape:html:'UTF-8'}" rel="publisher">
+          <span>{l s='Google Plus' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($pinterest_url) && $pinterest_url != ''}
+      <li class="pinterest">
+        <a class="_blank" href="{$pinterest_url|escape:html:'UTF-8'}">
+          <span>{l s='Pinterest' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($vimeo_url) && $vimeo_url != ''}
+      <li class="vimeo">
+        <a class="_blank" href="{$vimeo_url|escape:html:'UTF-8'}">
+          <span>{l s='Vimeo' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+    {if isset($instagram_url) && $instagram_url != ''}
+      <li class="instagram">
+        <a class="_blank" href="{$instagram_url|escape:html:'UTF-8'}">
+          <span>{l s='Instagram' mod='blocksocial'}</span>
+        </a>
+      </li>
+    {/if}
+  </ul>
+  <h4>{l s='Follow us' mod='blocksocial'}</h4>
 </section>
 <div class="clearfix"></div>

--- a/themes/community-theme-16/modules/blockspecials/blockspecials.tpl
+++ b/themes/community-theme-16/modules/blockspecials/blockspecials.tpl
@@ -25,68 +25,68 @@
 
 <!-- MODULE Block specials -->
 <div id="special_block_right" class="block">
-    <p class="title_block">
-        <a href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}" title="{l s='Specials' mod='blockspecials'}">
-            {l s='Specials' mod='blockspecials'}
-        </a>
-    </p>
-    <div class="block_content products-block">
+  <p class="title_block">
+    <a href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}" title="{l s='Specials' mod='blockspecials'}">
+      {l s='Specials' mod='blockspecials'}
+    </a>
+  </p>
+  <div class="block_content products-block">
     {if $special}
-        <ul>
-            <li class="clearfix">
-                <a class="products-block-image" href="{$special.link|escape:'html':'UTF-8'}">
-                    <img 
-                    class="replace-2x img-responsive" 
-                    src="{$link->getImageLink($special.link_rewrite, $special.id_image, 'small_default')|escape:'html':'UTF-8'}" 
-                    alt="{$special.legend|escape:'html':'UTF-8'}" 
-                    title="{$special.name|escape:'html':'UTF-8'}" />
-                </a>
-                <div class="product-content">
-                    <h5>
-                        <a class="product-name" href="{$special.link|escape:'html':'UTF-8'}" title="{$special.name|escape:'html':'UTF-8'}">
-                            {$special.name|escape:'html':'UTF-8'}
-                        </a>
-                    </h5>
-                    {if isset($special.description_short) && $special.description_short}
-                        <p class="product-description">
-                            {$special.description_short|strip_tags:'UTF-8'|truncate:40}
-                        </p>
-                    {/if}
-                    <div class="price-box">
-                        {if !$PS_CATALOG_MODE}
-                            <span class="price special-price">
-                                {if !$priceDisplay}
-                                    {displayWtPrice p=$special.price}{else}{displayWtPrice p=$special.price_tax_exc}
-                                {/if}
-                            </span>
-                             {if $special.specific_prices}
-                                {assign var='specific_prices' value=$special.specific_prices}
-                                {if $specific_prices.reduction_type == 'percentage' && ($specific_prices.from == $specific_prices.to OR ($smarty.now|date_format:'%Y-%m-%d %H:%M:%S' <= $specific_prices.to && $smarty.now|date_format:'%Y-%m-%d %H:%M:%S' >= $specific_prices.from))}
-                                    <span class="price-percent-reduction">-{$specific_prices.reduction*100|floatval}%</span>
-                                {/if}
-                            {/if}
-                             <span class="old-price">
-                                {if !$priceDisplay}
-                                    {displayWtPrice p=$special.price_without_reduction}{else}{displayWtPrice p=$priceWithoutReduction_tax_excl}
-                                {/if}
-                            </span>
-                            {hook h="displayProductPriceBlock" product=$special type="price"}
-                        {/if}
-                    </div>
-                </div>
-            </li>
-        </ul>
-        <div>
-            <a
-            class="btn btn-default button button-small" 
-            href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}" 
-            title="{l s='All specials' mod='blockspecials'}">
-                <span>{l s='All specials' mod='blockspecials'}<i class="icon-chevron-right right"></i></span>
-            </a>
-        </div>
+      <ul>
+        <li class="clearfix">
+          <a class="products-block-image" href="{$special.link|escape:'html':'UTF-8'}">
+            <img
+              class="replace-2x img-responsive"
+              src="{$link->getImageLink($special.link_rewrite, $special.id_image, 'small_default')|escape:'html':'UTF-8'}"
+              alt="{$special.legend|escape:'html':'UTF-8'}"
+              title="{$special.name|escape:'html':'UTF-8'}" />
+          </a>
+          <div class="product-content">
+            <h5>
+              <a class="product-name" href="{$special.link|escape:'html':'UTF-8'}" title="{$special.name|escape:'html':'UTF-8'}">
+                {$special.name|escape:'html':'UTF-8'}
+              </a>
+            </h5>
+            {if isset($special.description_short) && $special.description_short}
+              <p class="product-description">
+                {$special.description_short|strip_tags:'UTF-8'|truncate:40}
+              </p>
+            {/if}
+            <div class="price-box">
+              {if !$PS_CATALOG_MODE}
+                <span class="price special-price">
+                  {if !$priceDisplay}
+                    {displayWtPrice p=$special.price}{else}{displayWtPrice p=$special.price_tax_exc}
+                  {/if}
+                </span>
+                {if $special.specific_prices}
+                  {assign var='specific_prices' value=$special.specific_prices}
+                  {if $specific_prices.reduction_type == 'percentage' && ($specific_prices.from == $specific_prices.to OR ($smarty.now|date_format:'%Y-%m-%d %H:%M:%S' <= $specific_prices.to && $smarty.now|date_format:'%Y-%m-%d %H:%M:%S' >= $specific_prices.from))}
+                    <span class="price-percent-reduction">-{$specific_prices.reduction*100|floatval}%</span>
+                  {/if}
+                {/if}
+                <span class="old-price">
+                  {if !$priceDisplay}
+                    {displayWtPrice p=$special.price_without_reduction}{else}{displayWtPrice p=$priceWithoutReduction_tax_excl}
+                  {/if}
+                </span>
+                {hook h="displayProductPriceBlock" product=$special type="price"}
+              {/if}
+            </div>
+          </div>
+        </li>
+      </ul>
+      <div>
+        <a
+          class="btn btn-default button button-small"
+          href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}"
+          title="{l s='All specials' mod='blockspecials'}">
+          <span>{l s='All specials' mod='blockspecials'}<i class="icon-chevron-right right"></i></span>
+        </a>
+      </div>
     {else}
-        <div>{l s='No special products at this time.' mod='blockspecials'}</div>
+      <div>{l s='No special products at this time.' mod='blockspecials'}</div>
     {/if}
-    </div>
+  </div>
 </div>
 <!-- /MODULE Block specials -->

--- a/themes/community-theme-16/modules/blockstore/blockstore.tpl
+++ b/themes/community-theme-16/modules/blockstore/blockstore.tpl
@@ -25,30 +25,30 @@
 
 <!-- Block stores module -->
 <div id="stores_block_left" class="block">
-    <p class="title_block">
-        <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockstore'}">
-            {l s='Our stores' mod='blockstore'}
-        </a>
+  <p class="title_block">
+    <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockstore'}">
+      {l s='Our stores' mod='blockstore'}
+    </a>
+  </p>
+  <div class="block_content blockstore">
+    <p class="store_image">
+      <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockstore'}">
+        <img class="img-responsive" src="{$link->getMediaLink("`$module_dir``$store_img|escape:'htmlall':'UTF-8'`")}" alt="{l s='Our stores' mod='blockstore'}" />
+      </a>
     </p>
-    <div class="block_content blockstore">
-        <p class="store_image">
-            <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='Our stores' mod='blockstore'}">
-                <img class="img-responsive" src="{$link->getMediaLink("`$module_dir``$store_img|escape:'htmlall':'UTF-8'`")}" alt="{l s='Our stores' mod='blockstore'}" />
-            </a>
-        </p>
-        {if !empty($store_text)}
-        <p class="store-description">
-            {$store_text}
-        </p>
-        {/if}
-        <div>
-            <a
-            class="btn btn-default button button-small"
-            href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}"
-            title="{l s='Our stores' mod='blockstore'}">
-                <span>{l s='Discover our stores' mod='blockstore'}<i class="icon-chevron-right right"></i></span>
-            </a>
-        </div>
+    {if !empty($store_text)}
+      <p class="store-description">
+        {$store_text}
+      </p>
+    {/if}
+    <div>
+      <a
+        class="btn btn-default button button-small"
+        href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}"
+        title="{l s='Our stores' mod='blockstore'}">
+        <span>{l s='Discover our stores' mod='blockstore'}<i class="icon-chevron-right right"></i></span>
+      </a>
     </div>
+  </div>
 </div>
 <!-- /Block stores module -->

--- a/themes/community-theme-16/modules/blocksupplier/blocksupplier.tpl
+++ b/themes/community-theme-16/modules/blocksupplier/blocksupplier.tpl
@@ -25,51 +25,51 @@
 
 <!-- Block suppliers module -->
 <div id="suppliers_block_left" class="block blocksupplier">
-    <p class="title_block">
-        {if $display_link_supplier}
-            <a href="{$link->getPageLink('supplier')|escape:'html':'UTF-8'}" title="{l s='Suppliers' mod='blocksupplier'}">
-        {/if}
-            {l s='Suppliers' mod='blocksupplier'}
-        {if $display_link_supplier}
-            </a>
-        {/if}
-    </p>
-    <div class="block_content list-block">
-        {if $suppliers}
-            {if $text_list}
-            <ul>
-            {foreach from=$suppliers item=supplier name=supplier_list}
-                {if $smarty.foreach.supplier_list.iteration <= $text_list_nb}
-                <li class="{if $smarty.foreach.supplier_list.last}last_item{elseif $smarty.foreach.supplier_list.first}first_item{else}item{/if}">
+  <p class="title_block">
+    {if $display_link_supplier}
+    <a href="{$link->getPageLink('supplier')|escape:'html':'UTF-8'}" title="{l s='Suppliers' mod='blocksupplier'}">
+      {/if}
+      {l s='Suppliers' mod='blocksupplier'}
+      {if $display_link_supplier}
+    </a>
+    {/if}
+  </p>
+  <div class="block_content list-block">
+    {if $suppliers}
+      {if $text_list}
+        <ul>
+          {foreach from=$suppliers item=supplier name=supplier_list}
+            {if $smarty.foreach.supplier_list.iteration <= $text_list_nb}
+              <li class="{if $smarty.foreach.supplier_list.last}last_item{elseif $smarty.foreach.supplier_list.first}first_item{else}item{/if}">
                 {if $display_link_supplier}
-                    <a
-                    href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}"
-                    title="{l s='More about' mod='blocksupplier'} {$supplier.name}">
+                <a
+                  href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}"
+                  title="{l s='More about' mod='blocksupplier'} {$supplier.name}">
+                  {/if}
+                  {$supplier.name|escape:'html':'UTF-8'}
+                  {if $display_link_supplier}
+                </a>
                 {/if}
-                {$supplier.name|escape:'html':'UTF-8'}
-                {if $display_link_supplier}
-                    </a>
-                {/if}
-                </li>
-                {/if}
-            {/foreach}
-            </ul>
+              </li>
             {/if}
-            {if $form_list}
-                <form action="{$smarty.server.SCRIPT_NAME|escape:'html':'UTF-8'}" method="get">
-                    <div class="form-group selector1">
-                        <select class="form-control" name="supplier_list">
-                            <option value="0">{l s='All suppliers' mod='blocksupplier'}</option>
-                        {foreach from=$suppliers item=supplier}
-                            <option value="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">{$supplier.name|escape:'html':'UTF-8'}</option>
-                        {/foreach}
-                        </select>
-                    </div>
-                </form>
-            {/if}
-        {else}
-            <p>{l s='No supplier' mod='blocksupplier'}</p>
-        {/if}
-    </div>
+          {/foreach}
+        </ul>
+      {/if}
+      {if $form_list}
+        <form action="{$smarty.server.SCRIPT_NAME|escape:'html':'UTF-8'}" method="get">
+          <div class="form-group selector1">
+            <select class="form-control" name="supplier_list">
+              <option value="0">{l s='All suppliers' mod='blocksupplier'}</option>
+              {foreach from=$suppliers item=supplier}
+                <option value="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">{$supplier.name|escape:'html':'UTF-8'}</option>
+              {/foreach}
+            </select>
+          </div>
+        </form>
+      {/if}
+    {else}
+      <p>{l s='No supplier' mod='blocksupplier'}</p>
+    {/if}
+  </div>
 </div>
 <!-- /Block suppliers module -->

--- a/themes/community-theme-16/modules/blocktags/blocktags.tpl
+++ b/themes/community-theme-16/modules/blocktags/blocktags.tpl
@@ -25,23 +25,23 @@
 
 <!-- Block tags module -->
 <div id="tags_block_left" class="block tags_block">
-    <p class="title_block">
-        {l s='Tags' mod='blocktags'}
-    </p>
-    <div class="block_content">
-        {if $tags}
-            {foreach from=$tags item=tag name=myLoop}
-                <a
-                class="{$tag.class} {if $smarty.foreach.myLoop.last}last_item{elseif $smarty.foreach.myLoop.first}first_item{else}item{/if}"
-                href="{$link->getPageLink('search', true, NULL, "tag={$tag.name|urlencode}")|escape:'html':'UTF-8'}"
-                title="{l s='More about' mod='blocktags'} {$tag.name|escape:'html':'UTF-8'}"
-                >
-                    {$tag.name|escape:'html':'UTF-8'}
-                </a>
-            {/foreach}
-        {else}
-            {l s='No tags specified yet' mod='blocktags'}
-        {/if}
-    </div>
+  <p class="title_block">
+    {l s='Tags' mod='blocktags'}
+  </p>
+  <div class="block_content">
+    {if $tags}
+      {foreach from=$tags item=tag name=myLoop}
+        <a
+          class="{$tag.class} {if $smarty.foreach.myLoop.last}last_item{elseif $smarty.foreach.myLoop.first}first_item{else}item{/if}"
+          href="{$link->getPageLink('search', true, NULL, "tag={$tag.name|urlencode}")|escape:'html':'UTF-8'}"
+          title="{l s='More about' mod='blocktags'} {$tag.name|escape:'html':'UTF-8'}"
+        >
+          {$tag.name|escape:'html':'UTF-8'}
+        </a>
+      {/foreach}
+    {else}
+      {l s='No tags specified yet' mod='blocktags'}
+    {/if}
+  </div>
 </div>
 <!-- /Block tags module -->

--- a/themes/community-theme-16/modules/blocktopmenu/blocktopmenu.tpl
+++ b/themes/community-theme-16/modules/blocktopmenu/blocktopmenu.tpl
@@ -1,22 +1,22 @@
 {if $MENU != ''}
-    <!-- Menu -->
-    <div id="block_top_menu" class="sf-contener clearfix col-lg-12">
-        <div class="cat-title">{l s="Menu" mod="blocktopmenu"}</div>
-        <ul class="sf-menu clearfix menu-content">
-            {$MENU}
-            {if $MENU_SEARCH}
-                <li class="sf-search noBack" style="float:right">
-                    <form id="searchbox" action="{$link->getPageLink('search')|escape:'html':'UTF-8'}" method="get">
-                        <p>
-                            <input type="hidden" name="controller" value="search" />
-                            <input type="hidden" value="position" name="orderby"/>
-                            <input type="hidden" value="desc" name="orderway"/>
-                            <input type="text" name="search_query" value="{if isset($smarty.get.search_query)}{$smarty.get.search_query|escape:'html':'UTF-8'}{/if}" />
-                        </p>
-                    </form>
-                </li>
-            {/if}
-        </ul>
-    </div>
-    <!--/ Menu -->
+  <!-- Menu -->
+  <div id="block_top_menu" class="sf-contener clearfix col-lg-12">
+    <div class="cat-title">{l s="Menu" mod="blocktopmenu"}</div>
+    <ul class="sf-menu clearfix menu-content">
+      {$MENU}
+      {if $MENU_SEARCH}
+        <li class="sf-search noBack" style="float:right">
+          <form id="searchbox" action="{$link->getPageLink('search')|escape:'html':'UTF-8'}" method="get">
+            <p>
+              <input type="hidden" name="controller" value="search" />
+              <input type="hidden" value="position" name="orderby"/>
+              <input type="hidden" value="desc" name="orderway"/>
+              <input type="text" name="search_query" value="{if isset($smarty.get.search_query)}{$smarty.get.search_query|escape:'html':'UTF-8'}{/if}" />
+            </p>
+          </form>
+        </li>
+      {/if}
+    </ul>
+  </div>
+  <!--/ Menu -->
 {/if}

--- a/themes/community-theme-16/modules/blockuserinfo/nav.tpl
+++ b/themes/community-theme-16/modules/blockuserinfo/nav.tpl
@@ -1,18 +1,18 @@
 <!-- Block user information module NAV  -->
 {if $is_logged}
-    <div class="header_user_info">
-        <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='View my customer account' mod='blockuserinfo'}" class="account" rel="nofollow"><span>{$cookie->customer_firstname} {$cookie->customer_lastname}</span></a>
-    </div>
+  <div class="header_user_info">
+    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='View my customer account' mod='blockuserinfo'}" class="account" rel="nofollow"><span>{$cookie->customer_firstname} {$cookie->customer_lastname}</span></a>
+  </div>
 {/if}
 <div class="header_user_info">
-    {if $is_logged}
-        <a class="logout" href="{$link->getPageLink('index', true, NULL, "mylogout")|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Log me out' mod='blockuserinfo'}">
-            {l s='Sign out' mod='blockuserinfo'}
-        </a>
-    {else}
-        <a class="login" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Log in to your customer account' mod='blockuserinfo'}">
-            {l s='Sign in' mod='blockuserinfo'}
-        </a>
-    {/if}
+  {if $is_logged}
+    <a class="logout" href="{$link->getPageLink('index', true, NULL, "mylogout")|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Log me out' mod='blockuserinfo'}">
+      {l s='Sign out' mod='blockuserinfo'}
+    </a>
+  {else}
+    <a class="login" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Log in to your customer account' mod='blockuserinfo'}">
+      {l s='Sign in' mod='blockuserinfo'}
+    </a>
+  {/if}
 </div>
 <!-- /Block usmodule NAV -->

--- a/themes/community-theme-16/modules/blockviewed/blockviewed.tpl
+++ b/themes/community-theme-16/modules/blockviewed/blockviewed.tpl
@@ -25,31 +25,31 @@
 
 <!-- Block Viewed products -->
 <div id="viewed-products_block_left" class="block">
-    <p class="title_block">{l s='Viewed products' mod='blockviewed'}</p>
-    <div class="block_content products-block">
-        <ul>
-            {foreach from=$productsViewedObj item=viewedProduct name=myLoop}
-                <li class="clearfix{if $smarty.foreach.myLoop.last} last_item{elseif $smarty.foreach.myLoop.first} first_item{else} item{/if}">
-                    <a
-                    class="products-block-image"
-                    href="{$viewedProduct->product_link|escape:'html':'UTF-8'}"
-                    title="{l s='More about %s' mod='blockviewed' sprintf=[$viewedProduct->name|escape:'html':'UTF-8']}" >
-                        <img
-                        src="{if isset($viewedProduct->id_image) && $viewedProduct->id_image}{$link->getImageLink($viewedProduct->link_rewrite, $viewedProduct->cover, 'small_default')}{else}{$img_prod_dir}{$lang_iso}-default-medium_default.jpg{/if}"
-                        alt="{$viewedProduct->legend|escape:'html':'UTF-8'}" />
-                    </a>
-                    <div class="product-content">
-                        <h5>
-                            <a class="product-name"
-                            href="{$viewedProduct->product_link|escape:'html':'UTF-8'}"
-                            title="{l s='More about %s' mod='blockviewed' sprintf=[$viewedProduct->name|escape:'html':'UTF-8']}">
-                                {$viewedProduct->name|truncate:25:'...'|escape:'html':'UTF-8'}
-                            </a>
-                        </h5>
-                        <p class="product-description">{$viewedProduct->description_short|strip_tags:'UTF-8'|truncate:40}</p>
-                    </div>
-                </li>
-            {/foreach}
-        </ul>
-    </div>
+  <p class="title_block">{l s='Viewed products' mod='blockviewed'}</p>
+  <div class="block_content products-block">
+    <ul>
+      {foreach from=$productsViewedObj item=viewedProduct name=myLoop}
+        <li class="clearfix{if $smarty.foreach.myLoop.last} last_item{elseif $smarty.foreach.myLoop.first} first_item{else} item{/if}">
+          <a
+            class="products-block-image"
+            href="{$viewedProduct->product_link|escape:'html':'UTF-8'}"
+            title="{l s='More about %s' mod='blockviewed' sprintf=[$viewedProduct->name|escape:'html':'UTF-8']}" >
+            <img
+              src="{if isset($viewedProduct->id_image) && $viewedProduct->id_image}{$link->getImageLink($viewedProduct->link_rewrite, $viewedProduct->cover, 'small_default')}{else}{$img_prod_dir}{$lang_iso}-default-medium_default.jpg{/if}"
+              alt="{$viewedProduct->legend|escape:'html':'UTF-8'}" />
+          </a>
+          <div class="product-content">
+            <h5>
+              <a class="product-name"
+                 href="{$viewedProduct->product_link|escape:'html':'UTF-8'}"
+                 title="{l s='More about %s' mod='blockviewed' sprintf=[$viewedProduct->name|escape:'html':'UTF-8']}">
+                {$viewedProduct->name|truncate:25:'...'|escape:'html':'UTF-8'}
+              </a>
+            </h5>
+            <p class="product-description">{$viewedProduct->description_short|strip_tags:'UTF-8'|truncate:40}</p>
+          </div>
+        </li>
+      {/foreach}
+    </ul>
+  </div>
 </div>

--- a/themes/community-theme-16/modules/blockwishlist/blockwishlist-ajax.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/blockwishlist-ajax.tpl
@@ -23,34 +23,34 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if $products}
-    <dl class="products">
-        {foreach from=$products item=product name=i}
-            <dt class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
-                <span class="quantity-formated">
-                    <span class="quantity">{$product.quantity|intval}</span>x
-                </span>
-                <a class="cart_block_product_name" href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}">
-                    {$product.name|truncate:13:'...'|escape:'html':'UTF-8'}
-                </a>
-                <a class="ajax_cart_block_remove_link" href="javascript:;" onclick="javascript:WishlistCart('wishlist_block_list', 'delete', '{$product.id_product}', {$product.id_product_attribute}, '0');" rel="nofollow" title="{l s='remove this product from my wishlist' mod='blockwishlist'}">
-                    <i class="icon-remove-sign"></i>
-                </a>
-            </dt>
-            {if isset($product.attributes_small)}
-            <dd class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
-                <a href="{$link->getProductLink($product.id_product, $product.link_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockwishlist'}">
-                    {$product.attributes_small|escape:'html':'UTF-8'}
-                </a>
-            </dd>
-            {/if}
-        {/foreach}
-    </dl>
+  <dl class="products">
+    {foreach from=$products item=product name=i}
+      <dt class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
+        <span class="quantity-formated">
+          <span class="quantity">{$product.quantity|intval}</span>x
+        </span>
+        <a class="cart_block_product_name" href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}">
+          {$product.name|truncate:13:'...'|escape:'html':'UTF-8'}
+        </a>
+        <a class="ajax_cart_block_remove_link" href="javascript:;" onclick="javascript:WishlistCart('wishlist_block_list', 'delete', '{$product.id_product}', {$product.id_product_attribute}, '0');" rel="nofollow" title="{l s='remove this product from my wishlist' mod='blockwishlist'}">
+          <i class="icon-remove-sign"></i>
+        </a>
+      </dt>
+      {if isset($product.attributes_small)}
+        <dd class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
+          <a href="{$link->getProductLink($product.id_product, $product.link_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockwishlist'}">
+            {$product.attributes_small|escape:'html':'UTF-8'}
+          </a>
+        </dd>
+      {/if}
+    {/foreach}
+  </dl>
 {else}
-    <dl class="products no-products">
-        {if isset($error) && $error}
-            <dt>{l s='You must create a wishlist before adding products' mod='blockwishlist'}</dt>
-        {else}
-            <dt>{l s='No products' mod='blockwishlist'}</dt>
-        {/if}
-    </dl>
+  <dl class="products no-products">
+    {if isset($error) && $error}
+      <dt>{l s='You must create a wishlist before adding products' mod='blockwishlist'}</dt>
+    {else}
+      <dt>{l s='No products' mod='blockwishlist'}</dt>
+    {/if}
+  </dl>
 {/if}

--- a/themes/community-theme-16/modules/blockwishlist/blockwishlist-extra.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/blockwishlist-extra.tpl
@@ -23,32 +23,32 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <p class="buttons_bottom_block no-print">
-{if $wishlists|count == 1}
-    <a id="wishlist_button_nopop" href="#" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value); return false;" rel="nofollow"  title="{l s='Add to my wishlist' mod='blockwishlist'}">
-        {l s='Add to wishlist' mod='blockwishlist'}
-    </a>
-{else}
-    {foreach name=wl from=$wishlists item=wishlist}
-        {if $smarty.foreach.wl.first}
-            <a id="wishlist_button" tabindex="0" data-toggle="popover" data-trigger="focus" title="{l s='Wishlist' mod='blockwishlist'}" data-placement="bottom">{l s='Add to wishlist' mod='blockwishlist'}</a>
-                <div hidden id="popover-content">
-                    <table class="table" border="1">
-                        <tbody>
-        {/if}
-                            <tr title="{$wishlist.name}" value="{$wishlist.id_wishlist}" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value, '{$wishlist.id_wishlist}');">
-                                <td>
-                                    {l s='Add to %s' sprintf=[$wishlist.name] mod='blockwishlist'}
-                                </td>
-                            </tr>
-        {if $smarty.foreach.wl.last}
-                    </tbody>
-                </table>
-            </div>
-        {/if}
-    {foreachelse}
-        <a href="#" id="wishlist_button_nopop" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value); return false;" rel="nofollow"  title="{l s='Add to my wishlist' mod='blockwishlist'}">
-            {l s='Add to wishlist' mod='blockwishlist'}
-        </a>
-    {/foreach}
+  {if $wishlists|count == 1}
+  <a id="wishlist_button_nopop" href="#" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value); return false;" rel="nofollow"  title="{l s='Add to my wishlist' mod='blockwishlist'}">
+    {l s='Add to wishlist' mod='blockwishlist'}
+  </a>
+  {else}
+  {foreach name=wl from=$wishlists item=wishlist}
+  {if $smarty.foreach.wl.first}
+  <a id="wishlist_button" tabindex="0" data-toggle="popover" data-trigger="focus" title="{l s='Wishlist' mod='blockwishlist'}" data-placement="bottom">{l s='Add to wishlist' mod='blockwishlist'}</a>
+  <div hidden id="popover-content">
+  <table class="table" border="1">
+  <tbody>
+  {/if}
+  <tr title="{$wishlist.name}" value="{$wishlist.id_wishlist}" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value, '{$wishlist.id_wishlist}');">
+    <td>
+      {l s='Add to %s' sprintf=[$wishlist.name] mod='blockwishlist'}
+    </td>
+  </tr>
+  {if $smarty.foreach.wl.last}
+    </tbody>
+    </table>
+    </div>
+  {/if}
+  {foreachelse}
+  <a href="#" id="wishlist_button_nopop" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value); return false;" rel="nofollow"  title="{l s='Add to my wishlist' mod='blockwishlist'}">
+    {l s='Add to wishlist' mod='blockwishlist'}
+  </a>
+  {/foreach}
 {/if}
 </p>

--- a/themes/community-theme-16/modules/blockwishlist/blockwishlist.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/blockwishlist.tpl
@@ -23,61 +23,61 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div id="wishlist_block" class="block account">
-    <h4 class="title_block">
-        <a href="{$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'html':'UTF-8'}" title="{l s='My wishlists' mod='blockwishlist'}" rel="nofollow">
-            {l s='Wishlist' mod='blockwishlist'}
-        </a>
-    </h4>
-    <div class="block_content">
-        <div id="wishlist_block_list" class="expanded">
-            {if $wishlist_products}
-                <dl class="products">
-                    {foreach from=$wishlist_products item=product name=i}
-                        <dt class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
-                            <span class="quantity-formated">
-                                <span class="quantity">{$product.quantity|intval}</span>x
-                            </span>
-                            <a class="cart_block_product_name" href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}">
-                                {$product.name|truncate:30:'...'|escape:'html':'UTF-8'}
-                            </a>
-                            <a class="ajax_cart_block_remove_link" href="javascript:;" rel="nofollow" title="{l s='remove this product from my wishlist' mod='blockwishlist'}" onclick="javascript:WishlistCart('wishlist_block_list', 'delete', '{$product.id_product}', {$product.id_product_attribute}, '0', '{if isset($token)}{$token}{/if}');">
-                                <i class="icon-remove-sign "></i>
-                            </a>
-                        </dt>
-                        {if isset($product.attributes_small)}
-                            <dd class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
-                                <a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail'}">
-                                    {$product.attributes_small|escape:'html':'UTF-8'}
-                                </a>
-                            </dd>
-                        {/if}
-                    {/foreach}
-                </dl>
-            {else}
-                <dl class="products no-products">
-                    <dt>{l s='No products' mod='blockwishlist'}</dt>
-                    <dd></dd>
-                </dl>
+  <h4 class="title_block">
+    <a href="{$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'html':'UTF-8'}" title="{l s='My wishlists' mod='blockwishlist'}" rel="nofollow">
+      {l s='Wishlist' mod='blockwishlist'}
+    </a>
+  </h4>
+  <div class="block_content">
+    <div id="wishlist_block_list" class="expanded">
+      {if $wishlist_products}
+        <dl class="products">
+          {foreach from=$wishlist_products item=product name=i}
+            <dt class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
+              <span class="quantity-formated">
+                <span class="quantity">{$product.quantity|intval}</span>x
+              </span>
+              <a class="cart_block_product_name" href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}">
+                {$product.name|truncate:30:'...'|escape:'html':'UTF-8'}
+              </a>
+              <a class="ajax_cart_block_remove_link" href="javascript:;" rel="nofollow" title="{l s='remove this product from my wishlist' mod='blockwishlist'}" onclick="javascript:WishlistCart('wishlist_block_list', 'delete', '{$product.id_product}', {$product.id_product_attribute}, '0', '{if isset($token)}{$token}{/if}');">
+                <i class="icon-remove-sign "></i>
+              </a>
+            </dt>
+            {if isset($product.attributes_small)}
+              <dd class="{if $smarty.foreach.i.first}first_item{elseif $smarty.foreach.i.last}last_item{else}item{/if}">
+                <a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail'}">
+                  {$product.attributes_small|escape:'html':'UTF-8'}
+                </a>
+              </dd>
             {/if}
-        </div> <!-- #wishlist_block_list -->
+          {/foreach}
+        </dl>
+      {else}
+        <dl class="products no-products">
+          <dt>{l s='No products' mod='blockwishlist'}</dt>
+          <dd></dd>
+        </dl>
+      {/if}
+    </div> <!-- #wishlist_block_list -->
 
-        <div class="lnk">
-            {if $wishlists}
-                <div class="form-group selector1">
-                    <select name="wishlists" id="wishlists" class="form-control">
-                        {foreach from=$wishlists item=wishlist name=i}
-                                <option value="{$wishlist.id_wishlist}"{if $id_wishlist eq $wishlist.id_wishlist or ($id_wishlist == false and $smarty.foreach.i.first)} selected="selected"{/if}>
-                                    {$wishlist.name|truncate:22:'...'|escape:'html':'UTF-8'}
-                                </option>
-                        {/foreach}
-                    </select>
-                </div>
-            {/if}
-            <a class="btn btn-default button button-small" href="{$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'html':'UTF-8'}" title="{l s='My wishlists' mod='blockwishlist'}">
-                <span>
-                    {l s='My wishlists' mod='blockwishlist'}<i class="icon-chevron-right right"></i>
-                </span>
-            </a>
-        </div> <!-- .lnk -->
-    </div> <!-- .block_content -->
+    <div class="lnk">
+      {if $wishlists}
+        <div class="form-group selector1">
+          <select name="wishlists" id="wishlists" class="form-control">
+            {foreach from=$wishlists item=wishlist name=i}
+              <option value="{$wishlist.id_wishlist}"{if $id_wishlist eq $wishlist.id_wishlist or ($id_wishlist == false and $smarty.foreach.i.first)} selected="selected"{/if}>
+                {$wishlist.name|truncate:22:'...'|escape:'html':'UTF-8'}
+              </option>
+            {/foreach}
+          </select>
+        </div>
+      {/if}
+      <a class="btn btn-default button button-small" href="{$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'html':'UTF-8'}" title="{l s='My wishlists' mod='blockwishlist'}">
+        <span>
+          {l s='My wishlists' mod='blockwishlist'}<i class="icon-chevron-right right"></i>
+        </span>
+      </a>
+    </div> <!-- .lnk -->
+  </div> <!-- .block_content -->
 </div> <!-- #wishlist_block -->

--- a/themes/community-theme-16/modules/blockwishlist/blockwishlist_button.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/blockwishlist_button.tpl
@@ -24,34 +24,34 @@
 *}
 
 {if isset($wishlists) && count($wishlists) > 1}
-<div class="wishlist">
+  <div class="wishlist">
     {foreach name=wl from=$wishlists item=wishlist}
-        {if $smarty.foreach.wl.first}
-            <a class="wishlist_button_list" tabindex="0" data-toggle="popover" data-trigger="focus" title="{l s='Wishlist' mod='blockwishlist'}" data-placement="bottom">{l s='Add to wishlist' mod='blockwishlist'}</a>
-                <div hidden class="popover-content">
-                    <table class="table" border="1">
-                        <tbody>
-        {/if}
-                            <tr title="{$wishlist.name}" value="{$wishlist.id_wishlist}" onclick="WishlistCart('wishlist_block_list', 'add', '{$product.id_product|intval}', false, 1, '{$wishlist.id_wishlist}');">
-                                <td>
-                                    {l s='Add to %s' sprintf=[$wishlist.name] mod='blockwishlist'}
-                                </td>
-                            </tr>
-        {if $smarty.foreach.wl.last}
-                    </tbody>
-                </table>
-            </div>
-        {/if}
-    {foreachelse}
-        <a href="#" id="wishlist_button_nopop" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value); return false;" rel="nofollow"  title="{l s='Add to my wishlist' mod='blockwishlist'}">
-            {l s='Add to wishlist' mod='blockwishlist'}
-        </a>
+      {if $smarty.foreach.wl.first}
+        <a class="wishlist_button_list" tabindex="0" data-toggle="popover" data-trigger="focus" title="{l s='Wishlist' mod='blockwishlist'}" data-placement="bottom">{l s='Add to wishlist' mod='blockwishlist'}</a>
+        <div hidden class="popover-content">
+        <table class="table" border="1">
+        <tbody>
+      {/if}
+      <tr title="{$wishlist.name}" value="{$wishlist.id_wishlist}" onclick="WishlistCart('wishlist_block_list', 'add', '{$product.id_product|intval}', false, 1, '{$wishlist.id_wishlist}');">
+        <td>
+          {l s='Add to %s' sprintf=[$wishlist.name] mod='blockwishlist'}
+        </td>
+      </tr>
+      {if $smarty.foreach.wl.last}
+        </tbody>
+        </table>
+        </div>
+      {/if}
+      {foreachelse}
+      <a href="#" id="wishlist_button_nopop" onclick="WishlistCart('wishlist_block_list', 'add', '{$id_product|intval}', $('#idCombination').val(), document.getElementById('quantity_wanted').value); return false;" rel="nofollow"  title="{l s='Add to my wishlist' mod='blockwishlist'}">
+        {l s='Add to wishlist' mod='blockwishlist'}
+      </a>
     {/foreach}
-    </div>
+  </div>
 {else}
-<div class="wishlist">
+  <div class="wishlist">
     <a class="addToWishlist wishlistProd_{$product.id_product|intval}" href="#" rel="{$product.id_product|intval}" onclick="WishlistCart('wishlist_block_list', 'add', '{$product.id_product|intval}', false, 1); return false;">
-        {l s="Add to Wishlist" mod='blockwishlist'}
+      {l s="Add to Wishlist" mod='blockwishlist'}
     </a>
-</div>
+  </div>
 {/if}

--- a/themes/community-theme-16/modules/blockwishlist/blockwishlist_top.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/blockwishlist_top.tpl
@@ -23,8 +23,8 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {strip}
-{addJsDef wishlistProductsIds=$wishlist_products}
-{addJsDefL name=loggin_required}{l s='You must be logged in to manage your wishlist.' mod='blockwishlist' js=1}{/addJsDefL}
-{addJsDefL name=added_to_wishlist}{l s='The product was successfully added to your wishlist.' mod='blockwishlist' js=1}{/addJsDefL}
-{addJsDef mywishlist_url=$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'quotes':'UTF-8'}
+  {addJsDef wishlistProductsIds=$wishlist_products}
+  {addJsDefL name=loggin_required}{l s='You must be logged in to manage your wishlist.' mod='blockwishlist' js=1}{/addJsDefL}
+  {addJsDefL name=added_to_wishlist}{l s='The product was successfully added to your wishlist.' mod='blockwishlist' js=1}{/addJsDefL}
+  {addJsDef mywishlist_url=$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'quotes':'UTF-8'}
 {/strip}

--- a/themes/community-theme-16/modules/blockwishlist/my-account.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/my-account.tpl
@@ -25,9 +25,9 @@
 
 <!-- MODULE WishList -->
 <li class="lnk_wishlist">
-    <a href="{$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'html':'UTF-8'}" title="{l s='My wishlists' mod='blockwishlist'}">
-        <i class="icon-heart"></i>
-        <span>{l s='My wishlists' mod='blockwishlist'}</span>
-    </a>
+  <a href="{$link->getModuleLink('blockwishlist', 'mywishlist', array(), true)|escape:'html':'UTF-8'}" title="{l s='My wishlists' mod='blockwishlist'}">
+    <i class="icon-heart"></i>
+    <span>{l s='My wishlists' mod='blockwishlist'}</span>
+  </a>
 </li>
 <!-- END : MODULE WishList -->

--- a/themes/community-theme-16/modules/blockwishlist/views/templates/front/managewishlist.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/views/templates/front/managewishlist.tpl
@@ -24,218 +24,218 @@
 *}
 
 {if $products}
-    {if !$refresh}
-        <div class="wishlistLinkTop">
-        <a id="hideWishlist" class="button_account icon pull-right" href="#" onclick="WishlistVisibility('wishlistLinkTop', 'Wishlist'); return false;" rel="nofollow" title="{l s='Close this wishlist' mod='blockwishlist'}">
-            <i class="icon-remove"></i>
+{if !$refresh}
+<div class="wishlistLinkTop">
+  <a id="hideWishlist" class="button_account icon pull-right" href="#" onclick="WishlistVisibility('wishlistLinkTop', 'Wishlist'); return false;" rel="nofollow" title="{l s='Close this wishlist' mod='blockwishlist'}">
+    <i class="icon-remove"></i>
+  </a>
+  <ul class="clearfix display_list">
+    <li>
+      <a  id="hideBoughtProducts" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought', 'BoughtProducts'); return false;" title="{l s='Hide products' mod='blockwishlist'}">
+        {l s='Hide products' mod='blockwishlist'}
+      </a>
+      <a id="showBoughtProducts" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought', 'BoughtProducts'); return false;" title="{l s='Show products' mod='blockwishlist'}">
+        {l s='Show products' mod='blockwishlist'}
+      </a>
+    </li>
+    {if count($productsBoughts)}
+      <li>
+        <a id="hideBoughtProductsInfos" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought_infos', 'BoughtProductsInfos'); return false;" title="{l s='Hide products' mod='blockwishlist'}">
+          {l s="Hide bought products' info" mod='blockwishlist'}
         </a>
-        <ul class="clearfix display_list">
-            <li>
-                <a  id="hideBoughtProducts" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought', 'BoughtProducts'); return false;" title="{l s='Hide products' mod='blockwishlist'}">
-                    {l s='Hide products' mod='blockwishlist'}
+        <a id="showBoughtProductsInfos" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought_infos', 'BoughtProductsInfos'); return false;" title="{l s='Show products' mod='blockwishlist'}">
+          {l s="Show bought products' info" mod='blockwishlist'}
+        </a>
+      </li>
+    {/if}
+  </ul>
+  <p class="wishlisturl form-group">
+    <label>{l s='Permalink' mod='blockwishlist'}:</label>
+    <input type="text" class="form-control" value="{$link->getModuleLink('blockwishlist', 'view', ['token' => $token_wish])|escape:'html':'UTF-8'}" readonly="readonly"/>
+  </p>
+  <p class="submit">
+  <div id="showSendWishlist">
+    <a class="btn btn-default button button-small" href="#" onclick="WishlistVisibility('wl_send', 'SendWishlist'); return false;" title="{l s='Send this wishlist' mod='blockwishlist'}">
+      <span>{l s='Send this wishlist' mod='blockwishlist'}</span>
+    </a>
+  </div>
+  </p>
+  {/if}
+  <div class="wlp_bought">
+    {assign var='nbItemsPerLine' value=4}
+    {assign var='nbItemsPerLineTablet' value=3}
+    {assign var='nbLi' value=$products|@count}
+    {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
+    {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
+    <ul class="row wlp_bought_list">
+      {foreach from=$products item=product name=i}
+        {math equation="(total%perLine)" total=$smarty.foreach.i.total perLine=$nbItemsPerLine assign=totModulo}
+        {math equation="(total%perLineT)" total=$smarty.foreach.i.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
+        {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
+        {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
+        <li id="wlp_{$product.id_product}_{$product.id_product_attribute}"
+            class="col-xs-12 col-sm-4 col-md-3 {if $smarty.foreach.i.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModulo)}last-line{/if} {if $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModuloTablet)}last-tablet-line{/if}">
+          <div class="row">
+            <div class="col-xs-6 col-sm-12">
+              <div class="product_image">
+                <a href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockwishlist'}">
+                  <img class="replace-2x img-responsive"  src="{$link->getImageLink($product.link_rewrite, $product.cover, 'home_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}"/>
                 </a>
-                <a id="showBoughtProducts" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought', 'BoughtProducts'); return false;" title="{l s='Show products' mod='blockwishlist'}">
-                    {l s='Show products' mod='blockwishlist'}
-                </a>
-            </li>
-            {if count($productsBoughts)}
-                <li>
-                    <a id="hideBoughtProductsInfos" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought_infos', 'BoughtProductsInfos'); return false;" title="{l s='Hide products' mod='blockwishlist'}">
-                        {l s="Hide bought products' info" mod='blockwishlist'}
-                    </a>
-                    <a id="showBoughtProductsInfos" class="button_account" href="#" onclick="WishlistVisibility('wlp_bought_infos', 'BoughtProductsInfos'); return false;" title="{l s='Show products' mod='blockwishlist'}">
-                        {l s="Show bought products' info" mod='blockwishlist'}
-                    </a>
-                </li>
-            {/if}
-        </ul>
-        <p class="wishlisturl form-group">
-            <label>{l s='Permalink' mod='blockwishlist'}:</label>
-            <input type="text" class="form-control" value="{$link->getModuleLink('blockwishlist', 'view', ['token' => $token_wish])|escape:'html':'UTF-8'}" readonly="readonly"/>
-        </p>
-        <p class="submit">
-            <div id="showSendWishlist">
-                <a class="btn btn-default button button-small" href="#" onclick="WishlistVisibility('wl_send', 'SendWishlist'); return false;" title="{l s='Send this wishlist' mod='blockwishlist'}">
-                    <span>{l s='Send this wishlist' mod='blockwishlist'}</span>
-                </a>
+              </div>
             </div>
-        </p>
-    {/if}
-    <div class="wlp_bought">
-        {assign var='nbItemsPerLine' value=4}
-        {assign var='nbItemsPerLineTablet' value=3}
-        {assign var='nbLi' value=$products|@count}
-        {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
-        {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
-        <ul class="row wlp_bought_list">
-            {foreach from=$products item=product name=i}
-                {math equation="(total%perLine)" total=$smarty.foreach.i.total perLine=$nbItemsPerLine assign=totModulo}
-                {math equation="(total%perLineT)" total=$smarty.foreach.i.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
-                {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
-                {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
-                <li id="wlp_{$product.id_product}_{$product.id_product_attribute}"
-                    class="col-xs-12 col-sm-4 col-md-3 {if $smarty.foreach.i.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModulo)}last-line{/if} {if $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModuloTablet)}last-tablet-line{/if}">
-                    <div class="row">
-                        <div class="col-xs-6 col-sm-12">
-                            <div class="product_image">
-                                <a href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockwishlist'}">
-                                    <img class="replace-2x img-responsive"  src="{$link->getImageLink($product.link_rewrite, $product.cover, 'home_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}"/>
-                                </a>
-                            </div>
-                        </div>
-                        <div class="col-xs-6 col-sm-12">
-                            <div class="product_infos">
-                                <a class="lnkdel" href="javascript:;" onclick="WishlistProductManage('wlp_bought', 'delete', '{$id_wishlist}', '{$product.id_product}', '{$product.id_product_attribute}', $('#quantity_{$product.id_product}_{$product.id_product_attribute}').val(), $('#priority_{$product.id_product}_{$product.id_product_attribute}').val());" title="{l s='Delete' mod='blockwishlist'}">
-                                    <i class="icon-remove-sign"></i>
-                                </a>
+            <div class="col-xs-6 col-sm-12">
+              <div class="product_infos">
+                <a class="lnkdel" href="javascript:;" onclick="WishlistProductManage('wlp_bought', 'delete', '{$id_wishlist}', '{$product.id_product}', '{$product.id_product_attribute}', $('#quantity_{$product.id_product}_{$product.id_product_attribute}').val(), $('#priority_{$product.id_product}_{$product.id_product_attribute}').val());" title="{l s='Delete' mod='blockwishlist'}">
+                  <i class="icon-remove-sign"></i>
+                </a>
 
-                                <p id="s_title" class="product-name">
-                                    {$product.name|truncate:30:'...'|escape:'html':'UTF-8'}
-                                    {if isset($product.attributes_small)}
-                                        <small>
-                                            <a href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockwishlist'}">
-                                                {$product.attributes_small|escape:'html':'UTF-8'}
-                                            </a>
-                                        </small>
-                                    {/if}
-                                </p>
-                                <div class="wishlist_product_detail">
-                                    <p class="form-group">
-                                        <label for="quantity_{$product.id_product}_{$product.id_product_attribute}">
-                                            {l s='Quantity' mod='blockwishlist'}:
-                                        </label>
-                                        <input type="text" class="form-control grey" id="quantity_{$product.id_product}_{$product.id_product_attribute}" value="{$product.quantity|intval}" size="3"/>
-                                    </p>
-
-                                    <p class="form-group">
-                                        <label for="priority_{$product.id_product}_{$product.id_product_attribute}">
-                                            {l s='Priority' mod='blockwishlist'}:
-                                        </label>
-                                        <select id="priority_{$product.id_product}_{$product.id_product_attribute}" class="form-control grey">
-                                            <option value="0"{if $product.priority eq 0} selected="selected"{/if}>
-                                                {l s='High' mod='blockwishlist'}
-                                            </option>
-                                            <option value="1"{if $product.priority eq 1} selected="selected"{/if}>
-                                                {l s='Medium' mod='blockwishlist'}
-                                            </option>
-                                            <option value="2"{if $product.priority eq 2} selected="selected"{/if}>
-                                                {l s='Low' mod='blockwishlist'}
-                                            </option>
-                                        </select>
-                                    </p>
-                                </div>
-                                <div class="btn_action">
-                                    <a class="btn btn-default button button-small"  href="javascript:;" onclick="WishlistProductManage('wlp_bought_{$product.id_product_attribute}', 'update', '{$id_wishlist}', '{$product.id_product}', '{$product.id_product_attribute}', $('#quantity_{$product.id_product}_{$product.id_product_attribute}').val(), $('#priority_{$product.id_product}_{$product.id_product_attribute}').val());" title="{l s='Save' mod='blockwishlist'}">
-                                        <span>{l s='Save' mod='blockwishlist'}</span>
-                                    </a>
-                                    {if $wishlists|count > 1}
-                                        {foreach name=wl from=$wishlists item=wishlist}
-                                            {if $smarty.foreach.wl.first}
-                                                <a class="btn btn-default button button-small wishlist_change_button" tabindex="0" data-toggle="popover" data-trigger="focus" title="{l s='Move to a wishlist' mod='blockwishlist'}" data-placement="bottom">
-                                                    <span>{l s='Move' mod='blockwishlist'}</span>
-                                                    </a>
-                                                    <div hidden class="popover-content">
-                                                        <table class="table" border="1">
-                                                            <tbody>
-                                            {/if}
-                                            {if $id_wishlist != {$wishlist.id_wishlist}}
-                                                                <tr title="{$wishlist.name}" value="{$wishlist.id_wishlist}" onclick="wishlistProductChange({$product.id_product}, {$product.id_product_attribute}, '{$id_wishlist}', '{$wishlist.id_wishlist}');">
-                                                                    <td>
-                                                                        {l s='Move to %s'|sprintf:$wishlist.name mod='blockwishlist'}
-                                                                    </td>
-                                                                </tr>
-                                            {/if}
-                                            {if $smarty.foreach.wl.last}
-                                                        </tbody>
-                                                    </table>
-                                                </div>
-                                            {/if}
-                                        {/foreach}
-                                    {/if}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </li>
-            {/foreach}
-        </ul>
-    </div>
-    {if !$refresh}
-        <form method="post" class="wl_send box unvisible" onsubmit="return (false);">
-        <a id="hideSendWishlist" class="button_account btn icon"  href="#" onclick="WishlistVisibility('wl_send', 'SendWishlist'); return false;" rel="nofollow" title="{l s='Close this wishlist' mod='blockwishlist'}">
-            <i class="icon-remove"></i>
-        </a>
-            <fieldset>
-                <div class="required form-group">
-                    <label for="email1">{l s='Email' mod='blockwishlist'}1 <sup>*</sup></label>
-                    <input type="text" name="email1" id="email1" class="form-control"/>
-                </div>
-                {section name=i loop=11 start=2}
-                    <div class="form-group">
-                        <label for="email{$smarty.section.i.index}">{l s='Email' mod='blockwishlist'}{$smarty.section.i.index}</label>
-                        <input type="text" name="email{$smarty.section.i.index}" id="email{$smarty.section.i.index}"
-                               class="form-control"/>
-                    </div>
-                {/section}
-                <div class="submit">
-                    <button class="btn btn-default button button-small" type="submit" name="submitWishlist"
-                            onclick="WishlistSend('wl_send', '{$id_wishlist}', 'email');">
-                        <span>{l s='Send' mod='blockwishlist'}</span>
-                    </button>
-                </div>
-                <p class="required">
-                    <sup>*</sup> {l s='Required field' mod='blockwishlist'}
+                <p id="s_title" class="product-name">
+                  {$product.name|truncate:30:'...'|escape:'html':'UTF-8'}
+                  {if isset($product.attributes_small)}
+                    <small>
+                      <a href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}" title="{l s='Product detail' mod='blockwishlist'}">
+                        {$product.attributes_small|escape:'html':'UTF-8'}
+                      </a>
+                    </small>
+                  {/if}
                 </p>
-            </fieldset>
-        </form>
-        {if count($productsBoughts)}
-            <table class="wlp_bought_infos unvisible table table-bordered table-responsive">
-                <thead>
-                <tr>
-                    <th class="first_item">{l s='Product' mod='blockwishlist'}</th>
-                    <th class="item">{l s='Quantity' mod='blockwishlist'}</th>
-                    <th class="item">{l s='Offered by' mod='blockwishlist'}</th>
-                    <th class="last_item">{l s='Date' mod='blockwishlist'}</th>
-                </tr>
-                </thead>
-                <tbody>
-                {foreach from=$productsBoughts item=product name=i}
-                    {foreach from=$product.bought item=bought name=j}
-                        {if $bought.quantity > 0}
-                            <tr>
-                                <td class="first_item">
-                                    <span style="float:left;">
-                                        <img
-                                                src="{$link->getImageLink($product.link_rewrite, $product.cover, 'small_default')|escape:'html':'UTF-8'}"
-                                                alt="{$product.name|escape:'html':'UTF-8'}"/>
-                                    </span>
-                                    <span style="float:left;">
-                                        {$product.name|truncate:40:'...'|escape:'html':'UTF-8'}
-                                        {if isset($product.attributes_small)}
-                                            <br/>
-                                            <i>{$product.attributes_small|escape:'html':'UTF-8'}</i>
-                                        {/if}
-                                    </span>
-                                </td>
-                                <td class="item align_center">
-                                    {$bought.quantity|intval}
-                                </td>
-                                <td class="item align_center">
-                                    {$bought.firstname} {$bought.lastname}
-                                </td>
-                                <td class="last_item align_center">
-                                    {$bought.date_add|date_format:"%Y-%m-%d"}
-                                </td>
-                            </tr>
-                        {/if}
+                <div class="wishlist_product_detail">
+                  <p class="form-group">
+                    <label for="quantity_{$product.id_product}_{$product.id_product_attribute}">
+                      {l s='Quantity' mod='blockwishlist'}:
+                    </label>
+                    <input type="text" class="form-control grey" id="quantity_{$product.id_product}_{$product.id_product_attribute}" value="{$product.quantity|intval}" size="3"/>
+                  </p>
+
+                  <p class="form-group">
+                    <label for="priority_{$product.id_product}_{$product.id_product_attribute}">
+                      {l s='Priority' mod='blockwishlist'}:
+                    </label>
+                    <select id="priority_{$product.id_product}_{$product.id_product_attribute}" class="form-control grey">
+                      <option value="0"{if $product.priority eq 0} selected="selected"{/if}>
+                        {l s='High' mod='blockwishlist'}
+                      </option>
+                      <option value="1"{if $product.priority eq 1} selected="selected"{/if}>
+                        {l s='Medium' mod='blockwishlist'}
+                      </option>
+                      <option value="2"{if $product.priority eq 2} selected="selected"{/if}>
+                        {l s='Low' mod='blockwishlist'}
+                      </option>
+                    </select>
+                  </p>
+                </div>
+                <div class="btn_action">
+                  <a class="btn btn-default button button-small"  href="javascript:;" onclick="WishlistProductManage('wlp_bought_{$product.id_product_attribute}', 'update', '{$id_wishlist}', '{$product.id_product}', '{$product.id_product_attribute}', $('#quantity_{$product.id_product}_{$product.id_product_attribute}').val(), $('#priority_{$product.id_product}_{$product.id_product_attribute}').val());" title="{l s='Save' mod='blockwishlist'}">
+                    <span>{l s='Save' mod='blockwishlist'}</span>
+                  </a>
+                  {if $wishlists|count > 1}
+                    {foreach name=wl from=$wishlists item=wishlist}
+                      {if $smarty.foreach.wl.first}
+                        <a class="btn btn-default button button-small wishlist_change_button" tabindex="0" data-toggle="popover" data-trigger="focus" title="{l s='Move to a wishlist' mod='blockwishlist'}" data-placement="bottom">
+                          <span>{l s='Move' mod='blockwishlist'}</span>
+                        </a>
+                        <div hidden class="popover-content">
+                        <table class="table" border="1">
+                        <tbody>
+                      {/if}
+                      {if $id_wishlist != {$wishlist.id_wishlist}}
+                        <tr title="{$wishlist.name}" value="{$wishlist.id_wishlist}" onclick="wishlistProductChange({$product.id_product}, {$product.id_product_attribute}, '{$id_wishlist}', '{$wishlist.id_wishlist}');">
+                          <td>
+                            {l s='Move to %s'|sprintf:$wishlist.name mod='blockwishlist'}
+                          </td>
+                        </tr>
+                      {/if}
+                      {if $smarty.foreach.wl.last}
+                        </tbody>
+                        </table>
+                        </div>
+                      {/if}
                     {/foreach}
-                {/foreach}
-                </tbody>
-            </table>
-        {/if}
+                  {/if}
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      {/foreach}
+    </ul>
+  </div>
+  {if !$refresh}
+    <form method="post" class="wl_send box unvisible" onsubmit="return (false);">
+      <a id="hideSendWishlist" class="button_account btn icon"  href="#" onclick="WishlistVisibility('wl_send', 'SendWishlist'); return false;" rel="nofollow" title="{l s='Close this wishlist' mod='blockwishlist'}">
+        <i class="icon-remove"></i>
+      </a>
+      <fieldset>
+        <div class="required form-group">
+          <label for="email1">{l s='Email' mod='blockwishlist'}1 <sup>*</sup></label>
+          <input type="text" name="email1" id="email1" class="form-control"/>
+        </div>
+        {section name=i loop=11 start=2}
+          <div class="form-group">
+            <label for="email{$smarty.section.i.index}">{l s='Email' mod='blockwishlist'}{$smarty.section.i.index}</label>
+            <input type="text" name="email{$smarty.section.i.index}" id="email{$smarty.section.i.index}"
+                   class="form-control"/>
+          </div>
+        {/section}
+        <div class="submit">
+          <button class="btn btn-default button button-small" type="submit" name="submitWishlist"
+                  onclick="WishlistSend('wl_send', '{$id_wishlist}', 'email');">
+            <span>{l s='Send' mod='blockwishlist'}</span>
+          </button>
+        </div>
+        <p class="required">
+          <sup>*</sup> {l s='Required field' mod='blockwishlist'}
+        </p>
+      </fieldset>
+    </form>
+    {if count($productsBoughts)}
+      <table class="wlp_bought_infos unvisible table table-bordered table-responsive">
+        <thead>
+        <tr>
+          <th class="first_item">{l s='Product' mod='blockwishlist'}</th>
+          <th class="item">{l s='Quantity' mod='blockwishlist'}</th>
+          <th class="item">{l s='Offered by' mod='blockwishlist'}</th>
+          <th class="last_item">{l s='Date' mod='blockwishlist'}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {foreach from=$productsBoughts item=product name=i}
+          {foreach from=$product.bought item=bought name=j}
+            {if $bought.quantity > 0}
+              <tr>
+                <td class="first_item">
+                  <span style="float:left;">
+                    <img
+                      src="{$link->getImageLink($product.link_rewrite, $product.cover, 'small_default')|escape:'html':'UTF-8'}"
+                      alt="{$product.name|escape:'html':'UTF-8'}"/>
+                  </span>
+                  <span style="float:left;">
+                    {$product.name|truncate:40:'...'|escape:'html':'UTF-8'}
+                    {if isset($product.attributes_small)}
+                      <br/>
+                      <i>{$product.attributes_small|escape:'html':'UTF-8'}</i>
+                    {/if}
+                  </span>
+                </td>
+                <td class="item align_center">
+                  {$bought.quantity|intval}
+                </td>
+                <td class="item align_center">
+                  {$bought.firstname} {$bought.lastname}
+                </td>
+                <td class="last_item align_center">
+                  {$bought.date_add|date_format:"%Y-%m-%d"}
+                </td>
+              </tr>
+            {/if}
+          {/foreach}
+        {/foreach}
+        </tbody>
+      </table>
     {/if}
-{else}
-    <p class="alert alert-warning">
-        {l s='No products' mod='blockwishlist'}
-    </p>
-{/if}
+  {/if}
+  {else}
+  <p class="alert alert-warning">
+    {l s='No products' mod='blockwishlist'}
+  </p>
+  {/if}

--- a/themes/community-theme-16/modules/blockwishlist/views/templates/front/mywishlist.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/views/templates/front/mywishlist.tpl
@@ -24,120 +24,120 @@
 *}
 
 <div id="mywishlist">
-    {capture name=path}
-        <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-            {l s='My account' mod='blockwishlist'}
-        </a>
-        <span class="navigation-pipe">
-            {$navigationPipe}
-        </span>
-        <span class="navigation_page">
-            {l s='My wishlists' mod='blockwishlist'}
-        </span>
-    {/capture}
+  {capture name=path}
+    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+      {l s='My account' mod='blockwishlist'}
+    </a>
+    <span class="navigation-pipe">
+      {$navigationPipe}
+    </span>
+    <span class="navigation_page">
+      {l s='My wishlists' mod='blockwishlist'}
+    </span>
+  {/capture}
 
-    <h1 class="page-heading">{l s='My wishlists' mod='blockwishlist'}</h1>
+  <h1 class="page-heading">{l s='My wishlists' mod='blockwishlist'}</h1>
 
-    {include file="$tpl_dir./errors.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
 
-    {if $id_customer|intval neq 0}
-        <form method="post" class="std box" id="form_wishlist">
-            <fieldset>
-                <h3 class="page-subheading">{l s='New wishlist' mod='blockwishlist'}</h3>
-                <div class="form-group">
-                    <input type="hidden" name="token" value="{$token|escape:'html':'UTF-8'}" />
-                    <label class="align_right" for="name">
-                        {l s='Name' mod='blockwishlist'}
-                    </label>
-                    <input type="text" id="name" name="name" class="inputTxt form-control" value="{if isset($smarty.post.name) and $errors|@count > 0}{$smarty.post.name|escape:'html':'UTF-8'}{/if}" />
-                </div>
-                <p class="submit">
-                    <button id="submitWishlist" class="btn btn-default button button-medium" type="submit" name="submitWishlist">
-                        <span>{l s='Save' mod='blockwishlist'}<i class="icon-chevron-right right"></i></span>
-                    </button>
-                </p>
-            </fieldset>
-        </form>
-        {if $wishlists}
-            <div id="block-history" class="block-center">
-                <table class="table table-bordered">
-                    <thead>
-                        <tr>
-                            <th class="first_item">{l s='Name' mod='blockwishlist'}</th>
-                            <th class="item mywishlist_first">{l s='Qty' mod='blockwishlist'}</th>
-                            <th class="item mywishlist_first">{l s='Viewed' mod='blockwishlist'}</th>
-                            <th class="item mywishlist_second">{l s='Created' mod='blockwishlist'}</th>
-                            <th class="item mywishlist_second">{l s='Direct Link' mod='blockwishlist'}</th>
-                            <th class="item mywishlist_second">{l s='Default' mod='blockwishlist'}</th>
-                            <th class="last_item mywishlist_first">{l s='Delete' mod='blockwishlist'}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {section name=i loop=$wishlists}
-                            <tr id="wishlist_{$wishlists[i].id_wishlist|intval}">
-                                <td style="width:200px;">
-                                    <a href="#" onclick="javascript:event.preventDefault();WishlistManage('block-order-detail', '{$wishlists[i].id_wishlist|intval}');">
-                                        {$wishlists[i].name|truncate:30:'...'|escape:'html':'UTF-8'}
-                                    </a>
-                                </td>
-                                <td class="bold align_center">
-                                    {assign var=n value=0}
-                                    {foreach from=$nbProducts item=nb name=i}
-                                        {if $nb.id_wishlist eq $wishlists[i].id_wishlist}
-                                            {assign var=n value=$nb.nbProducts|intval}
-                                        {/if}
-                                    {/foreach}
-                                    {if $n}
-                                        {$n|intval}
-                                    {else}
-                                        0
-                                    {/if}
-                                </td>
-                                <td>{$wishlists[i].counter|intval}</td>
-                                <td>{$wishlists[i].date_add|date_format:"%Y-%m-%d"}</td>
-                                <td>
-                                    <a href="#" onclick="javascript:event.preventDefault();WishlistManage('block-order-detail', '{$wishlists[i].id_wishlist|intval}');">
-                                        {l s='View' mod='blockwishlist'}
-                                    </a>
-                                </td>
-                                <td class="wishlist_default">
-                                    {if isset($wishlists[i].default) && $wishlists[i].default == 1}
-                                        <p class="is_wish_list_default">
-                                            <i class="icon icon-check-square"></i>
-                                        </p>
-                                    {else}
-                                        <a href="#" onclick="javascript:event.preventDefault();(WishlistDefault('wishlist_{$wishlists[i].id_wishlist|intval}', '{$wishlists[i].id_wishlist|intval}'));">
-                                            <i class="icon icon-square"></i>
-                                        </a>
-                                    {/if}
-                                </td>
-                                <td class="wishlist_delete">
-                                    <a class="icon" href="#" onclick="javascript:event.preventDefault();return (WishlistDelete('wishlist_{$wishlists[i].id_wishlist|intval}', '{$wishlists[i].id_wishlist|intval}', '{l s='Do you really want to delete this wishlist ?' mod='blockwishlist' js=1}'));">
-                                        <i class="icon-remove"></i>
-                                    </a>
-                                </td>
-                            </tr>
-                        {/section}
-                    </tbody>
-                </table>
-            </div>
-            <div id="block-order-detail">&nbsp;</div>
-        {/if}
+  {if $id_customer|intval neq 0}
+    <form method="post" class="std box" id="form_wishlist">
+      <fieldset>
+        <h3 class="page-subheading">{l s='New wishlist' mod='blockwishlist'}</h3>
+        <div class="form-group">
+          <input type="hidden" name="token" value="{$token|escape:'html':'UTF-8'}" />
+          <label class="align_right" for="name">
+            {l s='Name' mod='blockwishlist'}
+          </label>
+          <input type="text" id="name" name="name" class="inputTxt form-control" value="{if isset($smarty.post.name) and $errors|@count > 0}{$smarty.post.name|escape:'html':'UTF-8'}{/if}" />
+        </div>
+        <p class="submit">
+          <button id="submitWishlist" class="btn btn-default button button-medium" type="submit" name="submitWishlist">
+            <span>{l s='Save' mod='blockwishlist'}<i class="icon-chevron-right right"></i></span>
+          </button>
+        </p>
+      </fieldset>
+    </form>
+    {if $wishlists}
+      <div id="block-history" class="block-center">
+        <table class="table table-bordered">
+          <thead>
+          <tr>
+            <th class="first_item">{l s='Name' mod='blockwishlist'}</th>
+            <th class="item mywishlist_first">{l s='Qty' mod='blockwishlist'}</th>
+            <th class="item mywishlist_first">{l s='Viewed' mod='blockwishlist'}</th>
+            <th class="item mywishlist_second">{l s='Created' mod='blockwishlist'}</th>
+            <th class="item mywishlist_second">{l s='Direct Link' mod='blockwishlist'}</th>
+            <th class="item mywishlist_second">{l s='Default' mod='blockwishlist'}</th>
+            <th class="last_item mywishlist_first">{l s='Delete' mod='blockwishlist'}</th>
+          </tr>
+          </thead>
+          <tbody>
+          {section name=i loop=$wishlists}
+            <tr id="wishlist_{$wishlists[i].id_wishlist|intval}">
+              <td style="width:200px;">
+                <a href="#" onclick="javascript:event.preventDefault();WishlistManage('block-order-detail', '{$wishlists[i].id_wishlist|intval}');">
+                  {$wishlists[i].name|truncate:30:'...'|escape:'html':'UTF-8'}
+                </a>
+              </td>
+              <td class="bold align_center">
+                {assign var=n value=0}
+                {foreach from=$nbProducts item=nb name=i}
+                  {if $nb.id_wishlist eq $wishlists[i].id_wishlist}
+                    {assign var=n value=$nb.nbProducts|intval}
+                  {/if}
+                {/foreach}
+                {if $n}
+                  {$n|intval}
+                {else}
+                  0
+                {/if}
+              </td>
+              <td>{$wishlists[i].counter|intval}</td>
+              <td>{$wishlists[i].date_add|date_format:"%Y-%m-%d"}</td>
+              <td>
+                <a href="#" onclick="javascript:event.preventDefault();WishlistManage('block-order-detail', '{$wishlists[i].id_wishlist|intval}');">
+                  {l s='View' mod='blockwishlist'}
+                </a>
+              </td>
+              <td class="wishlist_default">
+                {if isset($wishlists[i].default) && $wishlists[i].default == 1}
+                  <p class="is_wish_list_default">
+                    <i class="icon icon-check-square"></i>
+                  </p>
+                {else}
+                  <a href="#" onclick="javascript:event.preventDefault();(WishlistDefault('wishlist_{$wishlists[i].id_wishlist|intval}', '{$wishlists[i].id_wishlist|intval}'));">
+                    <i class="icon icon-square"></i>
+                  </a>
+                {/if}
+              </td>
+              <td class="wishlist_delete">
+                <a class="icon" href="#" onclick="javascript:event.preventDefault();return (WishlistDelete('wishlist_{$wishlists[i].id_wishlist|intval}', '{$wishlists[i].id_wishlist|intval}', '{l s='Do you really want to delete this wishlist ?' mod='blockwishlist' js=1}'));">
+                  <i class="icon-remove"></i>
+                </a>
+              </td>
+            </tr>
+          {/section}
+          </tbody>
+        </table>
+      </div>
+      <div id="block-order-detail">&nbsp;</div>
     {/if}
-    <ul class="footer_links clearfix">
-        <li>
-            <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-                <span>
-                    <i class="icon-chevron-left"></i>{l s='Back to Your Account' mod='blockwishlist'}
-                </span>
-            </a>
-        </li>
-        <li>
-            <a class="btn btn-default button button-small" href="{$base_dir|escape:'html':'UTF-8'}">
-                <span>
-                    <i class="icon-chevron-left"></i>{l s='Home' mod='blockwishlist'}
-                </span>
-            </a>
-        </li>
-    </ul>
+  {/if}
+  <ul class="footer_links clearfix">
+    <li>
+      <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+        <span>
+          <i class="icon-chevron-left"></i>{l s='Back to Your Account' mod='blockwishlist'}
+        </span>
+      </a>
+    </li>
+    <li>
+      <a class="btn btn-default button button-small" href="{$base_dir|escape:'html':'UTF-8'}">
+        <span>
+          <i class="icon-chevron-left"></i>{l s='Home' mod='blockwishlist'}
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>

--- a/themes/community-theme-16/modules/blockwishlist/views/templates/front/view.tpl
+++ b/themes/community-theme-16/modules/blockwishlist/views/templates/front/view.tpl
@@ -23,136 +23,136 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div id="view_wishlist">
-    {capture name=path}
-        <a href="{$link->getPageLink('my-account', true)|escape:'html'}">{l s='My account' mod='blockwishlist'}</a>
-        <span class="navigation-pipe">{$navigationPipe}</span>
-        <a href="{$link->getModuleLink('blockwishlist', 'mywishlist')|escape:'html'}">{l s='My wishlists' mod='blockwishlist'}</a>
-        <span class="navigation-pipe">{$navigationPipe}</span>
-        {$current_wishlist.name}
-    {/capture}
+  {capture name=path}
+    <a href="{$link->getPageLink('my-account', true)|escape:'html'}">{l s='My account' mod='blockwishlist'}</a>
+    <span class="navigation-pipe">{$navigationPipe}</span>
+    <a href="{$link->getModuleLink('blockwishlist', 'mywishlist')|escape:'html'}">{l s='My wishlists' mod='blockwishlist'}</a>
+    <span class="navigation-pipe">{$navigationPipe}</span>
+    {$current_wishlist.name}
+  {/capture}
 
-    <h1 class="page-heading bottom-indent">
-        {l s='Wishlist' mod='blockwishlist'}
-    </h1>
-    {if $wishlists}
-        <p>
-            <strong class="dark">
-                {l s='Other wishlists of %1s %2s:' sprintf=[$current_wishlist.firstname, $current_wishlist.lastname] mod='blockwishlist'}
-            </strong>
-            {foreach from=$wishlists item=wishlist name=i}
-                {if $wishlist.id_wishlist != $current_wishlist.id_wishlist}
-                    <a href="{$link->getModuleLink('blockwishlist', 'view', ['token' => $wishlist.token])|escape:'html':'UTF-8'}" rel="nofollow" title="{$wishlist.name}">
-                        {$wishlist.name}
+  <h1 class="page-heading bottom-indent">
+    {l s='Wishlist' mod='blockwishlist'}
+  </h1>
+  {if $wishlists}
+    <p>
+      <strong class="dark">
+        {l s='Other wishlists of %1s %2s:' sprintf=[$current_wishlist.firstname, $current_wishlist.lastname] mod='blockwishlist'}
+      </strong>
+      {foreach from=$wishlists item=wishlist name=i}
+        {if $wishlist.id_wishlist != $current_wishlist.id_wishlist}
+          <a href="{$link->getModuleLink('blockwishlist', 'view', ['token' => $wishlist.token])|escape:'html':'UTF-8'}" rel="nofollow" title="{$wishlist.name}">
+            {$wishlist.name}
+          </a>
+          {if !$smarty.foreach.i.last}
+            /
+          {/if}
+        {/if}
+      {/foreach}
+    </p>
+  {/if}
+
+  <div class="wlp_bought">
+    {assign var='nbItemsPerLine' value=3}
+    {assign var='nbItemsPerLineTablet' value=2}
+    {assign var='nbLi' value=$products|@count}
+    {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
+    {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
+    <ul class="row wlp_bought_list">
+      {foreach from=$products item=product name=i}
+        {math equation="(total%perLine)" total=$smarty.foreach.i.total perLine=$nbItemsPerLine assign=totModulo}
+        {math equation="(total%perLineT)" total=$smarty.foreach.i.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
+        {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
+        {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
+        <li
+          id="wlp_{$product.id_product}_{$product.id_product_attribute}"
+          class="ajax_block_product col-xs-12 col-sm-6 col-md-4 {if $smarty.foreach.i.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModulo)}last-line{/if} {if $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModuloTablet)}last-tablet-line{/if}">
+          <div class="row">
+            <div class="col-xs-6 col-sm-12">
+              <div class="product_image">
+                <a
+                  href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}"
+                  title="{l s='Product detail' mod='blockwishlist'}">
+                  <img
+                    class="replace-2x img-responsive"
+                    src="{$link->getImageLink($product.link_rewrite, $product.cover, 'home_default')|escape:'html':'UTF-8'}"
+                    alt="{$product.name|escape:'html':'UTF-8'}"/>
+                </a>
+              </div>
+            </div>
+            <div class="col-xs-6 col-sm-12">
+              <div class="product_infos">
+                <p id="s_title" class="product-name">
+                  {$product.name|truncate:30:'...'|escape:'html':'UTF-8'}
+                  {if isset($product.attributes_small)}
+                    <a
+                      href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}"
+                      title="{l s='Product detail' mod='blockwishlist'}">
+                      <small>{$product.attributes_small|escape:'html':'UTF-8'}</small>
                     </a>
-                    {if !$smarty.foreach.i.last}
-                        /
+                  {/if}
+                </p>
+                <div class="wishlist_product_detail">
+                  <p class="form-group">
+                    <label for="quantity_{$product.id_product}_{$product.id_product_attribute}">
+                      {l s='Quantity' mod='blockwishlist'}:
+                    </label>
+                    <input class="form-control grey" type="text"
+                           id="quantity_{$product.id_product}_{$product.id_product_attribute}"
+                           value="{$product.quantity|intval}" size="3"/>
+                  </p>
+
+                  <p class="form-group selector1">
+                    <span><strong>{l s='Priority' mod='blockwishlist'}:</strong> {$product.priority_name}</span>
+                  </p>
+                  <div class="btn_action">
+                    {if (isset($product.attribute_quantity) && $product.attribute_quantity >= 1) || (!isset($product.attribute_quantity) && $product.product_quantity >= 1) || (isset($product.allow_oosp) && $product.allow_oosp)}
+                      {if !$ajax}
+                        <form id="addtocart_{$product.id_product|intval}_{$product.id_product_attribute|intval}"
+                              action="{$link->getPageLink('cart')|escape:'html':'UTF-8'}"
+                              method="post">
+                          <p class="hidden">
+                            <input type="hidden" name="id_product"
+                                   value="{$product.id_product|intval}"
+                                   id="product_page_product_id"/>
+                            <input type="hidden" name="add" value="1"/>
+                            <input type="hidden" name="token" value="{$token}"/>
+                            <input type="hidden" name="id_product_attribute"
+                                   id="idCombination"
+                                   value="{$product.id_product_attribute|intval}"/>
+                          </p>
+                        </form>
+                      {/if}
+                      <a
+                        href="javascript:void(0);"
+                        class="button ajax_add_to_cart_button btn btn-default"
+                        onclick="WishlistBuyProduct('{$token|escape:'html':'UTF-8'}', '{$product.id_product}', '{$product.id_product_attribute}', '{$product.id_product}_{$product.id_product_attribute}', this, {$ajax});"
+                        title="{l s='Add to cart' mod='blockwishlist'}"
+                        rel="nofollow">
+                        <span>{l s='Add to cart' mod='blockwishlist'}</span>
+                      </a>
+                    {else}
+                      <span class="button ajax_add_to_cart_button btn btn-default disabled">
+                        <span>{l s='Add to cart' mod='blockwishlist'}</span>
+                      </span>
                     {/if}
-                {/if}
-            {/foreach}
-        </p>
-    {/if}
-
-    <div class="wlp_bought">
-        {assign var='nbItemsPerLine' value=3}
-        {assign var='nbItemsPerLineTablet' value=2}
-        {assign var='nbLi' value=$products|@count}
-        {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
-        {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
-        <ul class="row wlp_bought_list">
-            {foreach from=$products item=product name=i}
-                {math equation="(total%perLine)" total=$smarty.foreach.i.total perLine=$nbItemsPerLine assign=totModulo}
-                {math equation="(total%perLineT)" total=$smarty.foreach.i.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
-                {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
-                {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
-                <li
-                        id="wlp_{$product.id_product}_{$product.id_product_attribute}"
-                        class="ajax_block_product col-xs-12 col-sm-6 col-md-4 {if $smarty.foreach.i.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModulo)}last-line{/if} {if $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.i.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.i.iteration > ($smarty.foreach.i.total - $totModuloTablet)}last-tablet-line{/if}">
-                    <div class="row">
-                        <div class="col-xs-6 col-sm-12">
-                            <div class="product_image">
-                                <a
-                                        href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}"
-                                        title="{l s='Product detail' mod='blockwishlist'}">
-                                    <img
-                                            class="replace-2x img-responsive"
-                                            src="{$link->getImageLink($product.link_rewrite, $product.cover, 'home_default')|escape:'html':'UTF-8'}"
-                                            alt="{$product.name|escape:'html':'UTF-8'}"/>
-                                </a>
-                            </div>
-                        </div>
-                        <div class="col-xs-6 col-sm-12">
-                            <div class="product_infos">
-                                <p id="s_title" class="product-name">
-                                    {$product.name|truncate:30:'...'|escape:'html':'UTF-8'}
-                                    {if isset($product.attributes_small)}
-                                        <a
-                                                href="{$link->getProductlink($product.id_product, $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}"
-                                                title="{l s='Product detail' mod='blockwishlist'}">
-                                            <small>{$product.attributes_small|escape:'html':'UTF-8'}</small>
-                                        </a>
-                                    {/if}
-                                </p>
-                                <div class="wishlist_product_detail">
-                                    <p class="form-group">
-                                        <label for="quantity_{$product.id_product}_{$product.id_product_attribute}">
-                                            {l s='Quantity' mod='blockwishlist'}:
-                                        </label>
-                                        <input class="form-control grey" type="text"
-                                               id="quantity_{$product.id_product}_{$product.id_product_attribute}"
-                                               value="{$product.quantity|intval}" size="3"/>
-                                    </p>
-
-                                    <p class="form-group selector1">
-                                        <span><strong>{l s='Priority' mod='blockwishlist'}:</strong> {$product.priority_name}</span>
-                                    </p>
-                                    <div class="btn_action">
-                                        {if (isset($product.attribute_quantity) && $product.attribute_quantity >= 1) || (!isset($product.attribute_quantity) && $product.product_quantity >= 1) || (isset($product.allow_oosp) && $product.allow_oosp)}
-                                            {if !$ajax}
-                                                <form id="addtocart_{$product.id_product|intval}_{$product.id_product_attribute|intval}"
-                                                      action="{$link->getPageLink('cart')|escape:'html':'UTF-8'}"
-                                                      method="post">
-                                                    <p class="hidden">
-                                                        <input type="hidden" name="id_product"
-                                                               value="{$product.id_product|intval}"
-                                                               id="product_page_product_id"/>
-                                                        <input type="hidden" name="add" value="1"/>
-                                                        <input type="hidden" name="token" value="{$token}"/>
-                                                        <input type="hidden" name="id_product_attribute"
-                                                               id="idCombination"
-                                                               value="{$product.id_product_attribute|intval}"/>
-                                                    </p>
-                                                </form>
-                                            {/if}
-                                            <a
-                                                    href="javascript:void(0);"
-                                                    class="button ajax_add_to_cart_button btn btn-default"
-                                                    onclick="WishlistBuyProduct('{$token|escape:'html':'UTF-8'}', '{$product.id_product}', '{$product.id_product_attribute}', '{$product.id_product}_{$product.id_product_attribute}', this, {$ajax});"
-                                                    title="{l s='Add to cart' mod='blockwishlist'}"
-                                                    rel="nofollow">
-                                                <span>{l s='Add to cart' mod='blockwishlist'}</span>
-                                            </a>
-                                        {else}
-                                            <span class="button ajax_add_to_cart_button btn btn-default disabled">
-                                                <span>{l s='Add to cart' mod='blockwishlist'}</span>
-                                            </span>
-                                        {/if}
-                                        <a
-                                                class="button lnk_view btn btn-default"
-                                                href="{$link->getProductLink($product.id_product,  $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}"
-                                                title="{l s='View' mod='blockwishlist'}"
-                                                rel="nofollow">
-                                            <span>{l s='View' mod='blockwishlist'}</span>
-                                        </a>
-                                    </div>
-                                    <!-- .btn_action -->
-                                </div>
-                                <!-- .wishlist_product_detail -->
-                            </div>
-                            <!-- .product_infos -->
-                        </div>
-                    </div>
-                </li>
-            {/foreach}
-        </ul>
-    </div>
+                    <a
+                      class="button lnk_view btn btn-default"
+                      href="{$link->getProductLink($product.id_product,  $product.link_rewrite, $product.category_rewrite)|escape:'html':'UTF-8'}"
+                      title="{l s='View' mod='blockwishlist'}"
+                      rel="nofollow">
+                      <span>{l s='View' mod='blockwishlist'}</span>
+                    </a>
+                  </div>
+                  <!-- .btn_action -->
+                </div>
+                <!-- .wishlist_product_detail -->
+              </div>
+              <!-- .product_infos -->
+            </div>
+          </div>
+        </li>
+      {/foreach}
+    </ul>
+  </div>
 </div> <!-- #view_wishlist -->

--- a/themes/community-theme-16/modules/carriercompare/template/carriercompare.tpl
+++ b/themes/community-theme-16/modules/carriercompare/template/carriercompare.tpl
@@ -23,70 +23,70 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !$opc}
-<form class="box" id="compare_shipping_form" method="post" action="#" >
+  <form class="box" id="compare_shipping_form" method="post" action="#" >
     <fieldset id="compare_shipping">
-        <h1 class="page-heading bottom-indent">{l s='Estimate the cost of shipping & taxes.' mod='carriercompare'}</h1>
-        <div class="form-group">
-            <label for="id_country">{l s='Country' mod='carriercompare'}</label>
-            <select name="id_country" id="id_country" class="form-control">
-                {foreach from=$countries item=country}
-                    <option value="{$country.id_country}" {if $id_country == $country.id_country}selected="selected"{/if}>{$country.name|escape:'html':'UTF-8'}</option>
-                {/foreach}
-            </select>
-        </div>
-        <div id="states" class="form-group" style="display: none;">
-            <label for="id_state">{l s='State' mod='carriercompare'}</label>
-            <select name="id_state" id="id_state" class="form-control">
-                <option></option>
-            </select>
-        </div>
-        <div class="form-group last">
-            <label for="zipcode">{l s='Zip/postal code' mod='carriercompare'}</label>
-            <input class="form-control" type="text" name="zipcode" id="zipcode" value="{$zipcode|escape:'html':'UTF-8'}"/> ({l s='Needed for certain carriers.' mod='carriercompare'})
-        </div>
-        <div id="carriercompare_errors" style="display: none;">
-            <ul id="carriercompare_errors_list"></ul><br />
-        </div>
-        <div id="SE_AjaxDisplay">
-            <img src="{$new_base_dir}loader.gif" alt="Loading data" /><br />
-            <p></p>
-        </div>
-        <div id="availableCarriers" style="display: none;">
-            <table cellspacing="0" cellpadding="0" id="availableCarriers_table" class="table table-bordered">
-                <thead>
-                    <tr>
-                        <th class="carrier_action first_item"></th>
-                        <th class="carrier_name item">{l s='Carrier' mod='carriercompare'}</th>
-                        <th class="carrier_infos item">{l s='Information' mod='carriercompare'}</th>
-                        <th class="carrier_price last_item">{l s='Price' mod='carriercompare'}</th>
-                    </tr>
-                </thead>
-                <tbody id="carriers_list">
+      <h1 class="page-heading bottom-indent">{l s='Estimate the cost of shipping & taxes.' mod='carriercompare'}</h1>
+      <div class="form-group">
+        <label for="id_country">{l s='Country' mod='carriercompare'}</label>
+        <select name="id_country" id="id_country" class="form-control">
+          {foreach from=$countries item=country}
+            <option value="{$country.id_country}" {if $id_country == $country.id_country}selected="selected"{/if}>{$country.name|escape:'html':'UTF-8'}</option>
+          {/foreach}
+        </select>
+      </div>
+      <div id="states" class="form-group" style="display: none;">
+        <label for="id_state">{l s='State' mod='carriercompare'}</label>
+        <select name="id_state" id="id_state" class="form-control">
+          <option></option>
+        </select>
+      </div>
+      <div class="form-group last">
+        <label for="zipcode">{l s='Zip/postal code' mod='carriercompare'}</label>
+        <input class="form-control" type="text" name="zipcode" id="zipcode" value="{$zipcode|escape:'html':'UTF-8'}"/> ({l s='Needed for certain carriers.' mod='carriercompare'})
+      </div>
+      <div id="carriercompare_errors" style="display: none;">
+        <ul id="carriercompare_errors_list"></ul><br />
+      </div>
+      <div id="SE_AjaxDisplay">
+        <img src="{$new_base_dir}loader.gif" alt="Loading data" /><br />
+        <p></p>
+      </div>
+      <div id="availableCarriers" style="display: none;">
+        <table cellspacing="0" cellpadding="0" id="availableCarriers_table" class="table table-bordered">
+          <thead>
+          <tr>
+            <th class="carrier_action first_item"></th>
+            <th class="carrier_name item">{l s='Carrier' mod='carriercompare'}</th>
+            <th class="carrier_infos item">{l s='Information' mod='carriercompare'}</th>
+            <th class="carrier_price last_item">{l s='Price' mod='carriercompare'}</th>
+          </tr>
+          </thead>
+          <tbody id="carriers_list">
 
-                </tbody>
-            </table>
-        </div>
-        <p class="alert alert-warning text-center" id="noCarrier" style="display: none;">
-            {l s='No carrier has been made available for this selection.' mod='carriercompare'}
-        </p>
-        <p class="SE_SubmitRefreshCard">
-            <button class="btn btn-default button button-small" id="carriercompare_submit" type="button" name="carriercompare_submit">
-                <span>{l s='Update cart' mod='carriercompare'}<i class="icon-chevron-right right"></i></span>
-            </button>
-            <button id="update_carriers_list" type="button" class="btn btn-default button button-small">
-                <span>{l s='Update carrier list' mod='carriercompare'}<i class="icon-chevron-right right"></i></span>
-            </button>
-        </p>
+          </tbody>
+        </table>
+      </div>
+      <p class="alert alert-warning text-center" id="noCarrier" style="display: none;">
+        {l s='No carrier has been made available for this selection.' mod='carriercompare'}
+      </p>
+      <p class="SE_SubmitRefreshCard">
+        <button class="btn btn-default button button-small" id="carriercompare_submit" type="button" name="carriercompare_submit">
+          <span>{l s='Update cart' mod='carriercompare'}<i class="icon-chevron-right right"></i></span>
+        </button>
+        <button id="update_carriers_list" type="button" class="btn btn-default button button-small">
+          <span>{l s='Update carrier list' mod='carriercompare'}<i class="icon-chevron-right right"></i></span>
+        </button>
+      </p>
     </fieldset>
-</form>
-{addJsDef taxEnabled=$use_taxes}
-{addJsDef displayPrice=$priceDisplay}
-{addJsDef id_carrier=$id_carrier|intval}
-{addJsDef id_state=$id_state|intval}
-{addJsDef SE_RefreshMethod=$refresh_method|intval}
+  </form>
+  {addJsDef taxEnabled=$use_taxes}
+  {addJsDef displayPrice=$priceDisplay}
+  {addJsDef id_carrier=$id_carrier|intval}
+  {addJsDef id_state=$id_state|intval}
+  {addJsDef SE_RefreshMethod=$refresh_method|intval}
 
-{addJsDefL name=SE_RedirectTS}{l s='Refreshing the page and updating your cart...' mod='carriercompare' js=1}{/addJsDefL}
-{addJsDefL name=SE_RefreshStateTS}{l s='Checking available states...' mod='carriercompare' js=1}{/addJsDefL}
-{addJsDefL name=SE_RetrievingInfoTS}{l s='Retrieving information...' mod='carriercompare' js=1}{/addJsDefL}
-{addJsDefL name=txtFree}{l s='Free!' mod='carriercompare' js=1}{/addJsDefL}
+  {addJsDefL name=SE_RedirectTS}{l s='Refreshing the page and updating your cart...' mod='carriercompare' js=1}{/addJsDefL}
+  {addJsDefL name=SE_RefreshStateTS}{l s='Checking available states...' mod='carriercompare' js=1}{/addJsDefL}
+  {addJsDefL name=SE_RetrievingInfoTS}{l s='Retrieving information...' mod='carriercompare' js=1}{/addJsDefL}
+  {addJsDefL name=txtFree}{l s='Free!' mod='carriercompare' js=1}{/addJsDefL}
 {/if}

--- a/themes/community-theme-16/modules/carriercompare/template/configuration.tpl
+++ b/themes/community-theme-16/modules/carriercompare/template/configuration.tpl
@@ -1,29 +1,29 @@
 {if isset($display_error)}
-    {if $display_error}
-        <div class="error">{l s='An error occurred during form validation.' mod='carriercompare'}</div>
-    {else}
-        <div class="conf">{l s='Configuration updated' mod='carriercompare'}</div>
-    {/if}
+  {if $display_error}
+    <div class="error">{l s='An error occurred during form validation.' mod='carriercompare'}</div>
+  {else}
+    <div class="conf">{l s='Configuration updated' mod='carriercompare'}</div>
+  {/if}
 {/if}
 
 <form method="post" action="{$smarty.server.REQUEST_URI|escape:'html':'UTF-8'}">
-    <fieldset>
-        <div class="warn">
-            {l s='This module is only available during the standard five-step checkout process. The carrier list has already been defined for one-page checkout.' mod='carriercompare'}
-        </div>
-        <legend>{l s='Global Configuration' mod='carriercompare'}</legend>
+  <fieldset>
+    <div class="warn">
+      {l s='This module is only available during the standard five-step checkout process. The carrier list has already been defined for one-page checkout.' mod='carriercompare'}
+    </div>
+    <legend>{l s='Global Configuration' mod='carriercompare'}</legend>
 
-        <label for="refresh_method">Refresh carrier list method</label>
-        <div class="margin-form">
-            <select id="refresh_method" name="refresh_method">
-                <option value="0" {if $refresh_method == 0}selected{/if}>{l s='Anytime' mod='carriercompare'}</option>
-                <option value="1" {if $refresh_method == 1}selected{/if}>{l s='The required information is set.' mod='carriercompare'}</option>
-            </select>
-            <p>{l s='How would you like to refresh information for a customer?' mod='carriercompare'}</p>
-        </div>
+    <label for="refresh_method">Refresh carrier list method</label>
+    <div class="margin-form">
+      <select id="refresh_method" name="refresh_method">
+        <option value="0" {if $refresh_method == 0}selected{/if}>{l s='Anytime' mod='carriercompare'}</option>
+        <option value="1" {if $refresh_method == 1}selected{/if}>{l s='The required information is set.' mod='carriercompare'}</option>
+      </select>
+      <p>{l s='How would you like to refresh information for a customer?' mod='carriercompare'}</p>
+    </div>
 
-        <div class="margin-form">
-            <input name="setGlobalConfiguration" type="submit" class="button" value="{l s='Submit' mod='carriercompare'}">
-        </div>
-    </fieldset>
+    <div class="margin-form">
+      <input name="setGlobalConfiguration" type="submit" class="button" value="{l s='Submit' mod='carriercompare'}">
+    </div>
+  </fieldset>
 </form>

--- a/themes/community-theme-16/modules/cashondelivery/views/templates/front/validation.tpl
+++ b/themes/community-theme-16/modules/cashondelivery/views/templates/front/validation.tpl
@@ -31,24 +31,24 @@
 {include file="$tpl_dir./order-steps.tpl"}
 
 <form action="{$link->getModuleLink('cashondelivery', 'validation', [], true)|escape:'html'}" method="post">
-    <div class="box">
-        <input type="hidden" name="confirm" value="1" />
-        <h3 class="page-subheading">{l s='Cash on delivery (COD) payment' mod='cashondelivery'}</h3>
-        <p>
-            - {l s='You have chosen the Cash on Delivery method.' mod='cashondelivery'}
-            <br/>
-            - {l s='The total amount of your order is' mod='cashondelivery'}
-            <span id="amount_{$currencies.0.id_currency}" class="price">{convertPrice price=$total}</span>
-            {if $use_taxes == 1}
-                {l s='(tax incl.)' mod='cashondelivery'}
-            {/if}
-        </p>
-        <p>
-            <b>{l s='Please confirm your order by clicking \'I confirm my order\'.' mod='cashondelivery'}.</b>
-        </p>        
-    </div>
-    <p class="cart_navigation" id="cart_navigation">
-        <a href="{$link->getPageLink('order', true)}?step=3" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Other payment methods' mod='cashondelivery'}</a>
-        <button type="submit" class="button btn btn-default button-medium"><span>{l s='I confirm my order' mod='cashondelivery'}</span></button>
+  <div class="box">
+    <input type="hidden" name="confirm" value="1" />
+    <h3 class="page-subheading">{l s='Cash on delivery (COD) payment' mod='cashondelivery'}</h3>
+    <p>
+      - {l s='You have chosen the Cash on Delivery method.' mod='cashondelivery'}
+      <br/>
+      - {l s='The total amount of your order is' mod='cashondelivery'}
+      <span id="amount_{$currencies.0.id_currency}" class="price">{convertPrice price=$total}</span>
+      {if $use_taxes == 1}
+        {l s='(tax incl.)' mod='cashondelivery'}
+      {/if}
     </p>
+    <p>
+      <b>{l s='Please confirm your order by clicking \'I confirm my order\'.' mod='cashondelivery'}.</b>
+    </p>
+  </div>
+  <p class="cart_navigation" id="cart_navigation">
+    <a href="{$link->getPageLink('order', true)}?step=3" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Other payment methods' mod='cashondelivery'}</a>
+    <button type="submit" class="button btn btn-default button-medium"><span>{l s='I confirm my order' mod='cashondelivery'}</span></button>
+  </p>
 </form>

--- a/themes/community-theme-16/modules/cashondelivery/views/templates/hook/confirmation.tpl
+++ b/themes/community-theme-16/modules/cashondelivery/views/templates/hook/confirmation.tpl
@@ -23,10 +23,10 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="box">
-    <p>{l s='Your order on' mod='cashondelivery'} <span class="bold">{$shop_name}</span> {l s='is complete.' mod='cashondelivery'}
-        <br />
-        {l s='You have chosen the cash on delivery method.' mod='cashondelivery'}
-        <br /><span class="bold">{l s='Your order will be sent very soon.' mod='cashondelivery'}</span>
-        <br />{l s='For any questions or for further information, please contact our' mod='cashondelivery'} <a href="{$link->getPageLink('contact-form', true)|escape:'html'}">{l s='customer support' mod='cashondelivery'}</a>.
-    </p>
+  <p>{l s='Your order on' mod='cashondelivery'} <span class="bold">{$shop_name}</span> {l s='is complete.' mod='cashondelivery'}
+    <br />
+    {l s='You have chosen the cash on delivery method.' mod='cashondelivery'}
+    <br /><span class="bold">{l s='Your order will be sent very soon.' mod='cashondelivery'}</span>
+    <br />{l s='For any questions or for further information, please contact our' mod='cashondelivery'} <a href="{$link->getPageLink('contact-form', true)|escape:'html'}">{l s='customer support' mod='cashondelivery'}</a>.
+  </p>
 </div>

--- a/themes/community-theme-16/modules/cashondelivery/views/templates/hook/payment.tpl
+++ b/themes/community-theme-16/modules/cashondelivery/views/templates/hook/payment.tpl
@@ -23,12 +23,12 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="row">
-    <div class="col-xs-12">
-        <p class="payment_module">
-            <a class="cash" href="{$link->getModuleLink('cashondelivery', 'validation', [], true)|escape:'html'}" title="{l s='Pay with cash on delivery (COD)' mod='cashondelivery'}" rel="nofollow">
-                {l s='Pay with cash on delivery (COD)' mod='cashondelivery'}
-                <span>({l s='You pay for the merchandise upon delivery' mod='cashondelivery'})</span>
-            </a>
-        </p>
-    </div>
+  <div class="col-xs-12">
+    <p class="payment_module">
+      <a class="cash" href="{$link->getModuleLink('cashondelivery', 'validation', [], true)|escape:'html'}" title="{l s='Pay with cash on delivery (COD)' mod='cashondelivery'}" rel="nofollow">
+        {l s='Pay with cash on delivery (COD)' mod='cashondelivery'}
+        <span>({l s='You pay for the merchandise upon delivery' mod='cashondelivery'})</span>
+      </a>
+    </p>
+  </div>
 </div>

--- a/themes/community-theme-16/modules/cheque/views/templates/front/payment_execution.tpl
+++ b/themes/community-theme-16/modules/cheque/views/templates/front/payment_execution.tpl
@@ -31,55 +31,55 @@
 {include file="$tpl_dir./order-steps.tpl"}
 
 {if isset($nbProducts) && $nbProducts <= 0}
-    <p class="alert alert-warning">{l s='Your shopping cart is empty.' mod='cheque'}</p>
+  <p class="alert alert-warning">{l s='Your shopping cart is empty.' mod='cheque'}</p>
 {else}
 
-    <form action="{$link->getModuleLink('cheque', 'validation', [], true)|escape:'html':'UTF-8'}" method="post">
-        <div class="box cheque-box">
-            <h3 class="page-subheading">{l s='Check payment' mod='cheque'}</h3>
-            <p class="cheque-indent">
-                <strong class="dark">
-                    {l s='You have chosen to pay by check.' mod='cheque'} {l s='Here is a short summary of your order:' mod='cheque'}
-                </strong>
-            </p>
-            <p>
-                - {l s='The total amount of your order comes to:' mod='cheque'}
-                <span id="amount" class="price">{displayPrice price=$total}</span>
-                {if $use_taxes == 1}
-                    {l s='(tax incl.)' mod='cheque'}
-                {/if}
-            </p>
-            <p>
-                -
-                {if isset($currencies) && $currencies|@count > 1}
-                    {l s='We accept several currencies to receive payments by check.' mod='cheque'}
-                    <br />
-                    <div class="form-group">
-                        <label>{l s='Choose one of the following:' mod='cheque'}</label>
-                        <select id="currency_payment" class="form-control" name="currency_payment">
-                        {foreach from=$currencies item=currency}
-                            <option value="{$currency.id_currency}"{if isset($currencies) && $currency.id_currency == $cust_currency} selected="selected"{/if}>{$currency.name}</option>
-                        {/foreach}
-                        </select>
-                    </div>
-                {else}
-                    {l s='We allow the following currencies to be sent by check:' mod='cheque'}&nbsp;<b>{$currencies.0.name}</b>
-                    <input type="hidden" name="currency_payment" value="{$currencies.0.id_currency}" />
-                {/if}
-            </p>
-            <p>
-                - {l s='Check owner and address information will be displayed on the next page.' mod='cheque'}
-                <br />
-                - {l s='Please confirm your order by clicking \'I confirm my order\'' mod='cheque'}.
-            </p>
-        </div>
-        <p class="cart_navigation clearfix" id="cart_navigation">
-            <a href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}" class="button-exclusive btn btn-default">
-                <i class="icon-chevron-left"></i>{l s='Other payment methods' mod='cheque'}
-            </a>
-            <button type="submit" class="button btn btn-default button-medium">
-                <span>{l s='I confirm my order' mod='cheque'}<i class="icon-chevron-right right"></i></span>
-            </button>
-        </p>
-    </form>
+  <form action="{$link->getModuleLink('cheque', 'validation', [], true)|escape:'html':'UTF-8'}" method="post">
+    <div class="box cheque-box">
+      <h3 class="page-subheading">{l s='Check payment' mod='cheque'}</h3>
+      <p class="cheque-indent">
+        <strong class="dark">
+          {l s='You have chosen to pay by check.' mod='cheque'} {l s='Here is a short summary of your order:' mod='cheque'}
+        </strong>
+      </p>
+      <p>
+        - {l s='The total amount of your order comes to:' mod='cheque'}
+        <span id="amount" class="price">{displayPrice price=$total}</span>
+        {if $use_taxes == 1}
+          {l s='(tax incl.)' mod='cheque'}
+        {/if}
+      </p>
+      <p>
+        -
+        {if isset($currencies) && $currencies|@count > 1}
+        {l s='We accept several currencies to receive payments by check.' mod='cheque'}
+        <br />
+      <div class="form-group">
+        <label>{l s='Choose one of the following:' mod='cheque'}</label>
+        <select id="currency_payment" class="form-control" name="currency_payment">
+          {foreach from=$currencies item=currency}
+            <option value="{$currency.id_currency}"{if isset($currencies) && $currency.id_currency == $cust_currency} selected="selected"{/if}>{$currency.name}</option>
+          {/foreach}
+        </select>
+      </div>
+      {else}
+        {l s='We allow the following currencies to be sent by check:' mod='cheque'}&nbsp;<b>{$currencies.0.name}</b>
+        <input type="hidden" name="currency_payment" value="{$currencies.0.id_currency}" />
+      {/if}
+      </p>
+      <p>
+        - {l s='Check owner and address information will be displayed on the next page.' mod='cheque'}
+        <br />
+        - {l s='Please confirm your order by clicking \'I confirm my order\'' mod='cheque'}.
+      </p>
+    </div>
+    <p class="cart_navigation clearfix" id="cart_navigation">
+      <a href="{$link->getPageLink('order', true, NULL, "step=3")|escape:'html':'UTF-8'}" class="button-exclusive btn btn-default">
+        <i class="icon-chevron-left"></i>{l s='Other payment methods' mod='cheque'}
+      </a>
+      <button type="submit" class="button btn btn-default button-medium">
+        <span>{l s='I confirm my order' mod='cheque'}<i class="icon-chevron-right right"></i></span>
+      </button>
+    </p>
+  </form>
 {/if}

--- a/themes/community-theme-16/modules/cheque/views/templates/hook/infos.tpl
+++ b/themes/community-theme-16/modules/cheque/views/templates/hook/infos.tpl
@@ -24,8 +24,8 @@
 *}
 
 <div class="alert alert-info">
-<img src="../modules/cheque/cheque.jpg" style="float:left; margin-right:15px;" width="86" height="49">
-<p><strong>{l s="This module allows you to accept payments by check." mod='cheque'}</strong></p>
-<p>{l s="If the client chooses this payment method, the order status will change to 'Waiting for payment.'" mod='cheque'}</p>
-<p>{l s="You will need to manually confirm the order as soon as you receive a check." mod='cheque'}</p>
+  <img src="../modules/cheque/cheque.jpg" style="float:left; margin-right:15px;" width="86" height="49">
+  <p><strong>{l s="This module allows you to accept payments by check." mod='cheque'}</strong></p>
+  <p>{l s="If the client chooses this payment method, the order status will change to 'Waiting for payment.'" mod='cheque'}</p>
+  <p>{l s="You will need to manually confirm the order as soon as you receive a check." mod='cheque'}</p>
 </div>

--- a/themes/community-theme-16/modules/cheque/views/templates/hook/payment.tpl
+++ b/themes/community-theme-16/modules/cheque/views/templates/hook/payment.tpl
@@ -23,11 +23,11 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="row">
-    <div class="col-xs-12">
-        <p class="payment_module">
-            <a class="cheque" href="{$link->getModuleLink('cheque', 'payment', [], true)|escape:'html':'UTF-8'}" title="{l s='Pay by check.' mod='cheque'}">
-                {l s='Pay by check' mod='cheque'} <span>{l s='(order processing will be longer)' mod='cheque'}</span>
-            </a>
-        </p>
-    </div>
+  <div class="col-xs-12">
+    <p class="payment_module">
+      <a class="cheque" href="{$link->getModuleLink('cheque', 'payment', [], true)|escape:'html':'UTF-8'}" title="{l s='Pay by check.' mod='cheque'}">
+        {l s='Pay by check' mod='cheque'} <span>{l s='(order processing will be longer)' mod='cheque'}</span>
+      </a>
+    </p>
+  </div>
 </div>

--- a/themes/community-theme-16/modules/cheque/views/templates/hook/payment_return.tpl
+++ b/themes/community-theme-16/modules/cheque/views/templates/hook/payment_return.tpl
@@ -24,24 +24,24 @@
 *}
 
 {if $status == 'ok'}
-    <p class="alert alert-success">{l s='Your order on %s is complete.' sprintf=$shop_name mod='cheque'}</p>
-    <div class="box order-confirmation">
-        <h3 class="page-subheading">{l s='Your check must include:' mod='cheque'}</h3>
-        - {l s='Payment amount.' mod='cheque'} <span class="price"><strong>{$total_to_pay}</strong></span>
-        <br />- {l s='Payable to the order of' mod='cheque'} <strong>{if $chequeName}{$chequeName}{else}___________{/if}</strong>
-        <br />- {l s='Mail to' mod='cheque'} <strong>{if $chequeAddress}{$chequeAddress}{else}___________{/if}</strong>
-        {if !isset($reference) && isset($id_order) && $id_order}
-            <br />- {l s='Do not forget to insert your order number #%d.' sprintf=$id_order mod='cheque'}
-        {else}
-            <br />- {l s='Do not forget to insert your order reference %s.' sprintf=$reference mod='cheque'}
-        {/if}
-        <br />- {l s='An email has been sent to you with this information.' mod='cheque'}
-        <br />- <strong>{l s='Your order will be sent as soon as we receive your payment.' mod='cheque'}</strong>
-        <br />- {l s='For any questions or for further information, please contact our' mod='cheque'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer service department.' mod='cheque'}</a>.
-    </div>
+  <p class="alert alert-success">{l s='Your order on %s is complete.' sprintf=$shop_name mod='cheque'}</p>
+  <div class="box order-confirmation">
+    <h3 class="page-subheading">{l s='Your check must include:' mod='cheque'}</h3>
+    - {l s='Payment amount.' mod='cheque'} <span class="price"><strong>{$total_to_pay}</strong></span>
+    <br />- {l s='Payable to the order of' mod='cheque'} <strong>{if $chequeName}{$chequeName}{else}___________{/if}</strong>
+    <br />- {l s='Mail to' mod='cheque'} <strong>{if $chequeAddress}{$chequeAddress}{else}___________{/if}</strong>
+    {if !isset($reference) && isset($id_order) && $id_order}
+      <br />- {l s='Do not forget to insert your order number #%d.' sprintf=$id_order mod='cheque'}
+    {else}
+      <br />- {l s='Do not forget to insert your order reference %s.' sprintf=$reference mod='cheque'}
+    {/if}
+    <br />- {l s='An email has been sent to you with this information.' mod='cheque'}
+    <br />- <strong>{l s='Your order will be sent as soon as we receive your payment.' mod='cheque'}</strong>
+    <br />- {l s='For any questions or for further information, please contact our' mod='cheque'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer service department.' mod='cheque'}</a>.
+  </div>
 {else}
-    <p class="alert alert-warning">
-        {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our' mod='cheque'}
-        <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer service department.' mod='cheque'}</a>.
-    </p>
+  <p class="alert alert-warning">
+    {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our' mod='cheque'}
+    <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer service department.' mod='cheque'}</a>.
+  </p>
 {/if}

--- a/themes/community-theme-16/modules/crossselling/crossselling.tpl
+++ b/themes/community-theme-16/modules/crossselling/crossselling.tpl
@@ -23,47 +23,47 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($orderProducts) && count($orderProducts)}
-    <section id="crossselling" class="page-product-box">
-        <h3 class="productscategory_h2 page-product-heading">
-            {if $page_name == 'product'}
-                {l s='Customers who bought this product also bought:' mod='crossselling'}
-            {else}
-                {l s='We recommend' mod='crossselling'}
-            {/if}
-        </h3>
-        <div id="crossselling_list">
-            <ul id="crossselling_list_car" class="clearfix">
-                {foreach from=$orderProducts item='orderProduct' name=orderProduct}
-                    <li class="product-box item" itemprop="isRelatedTo" itemscope itemtype="https://schema.org/Product">
-                        <a class="lnk_img product-image" href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}" >
-                            <img itemprop="image" src="{$orderProduct.image}" alt="{$orderProduct.name|htmlspecialchars}" />
-                        </a>
-                        <div class="s_title_block">
-                            <h5 itemprop="name" class="product-name">
-                                <a itemprop="url" href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}">
-                                    {$orderProduct.name|truncate:15:'...'|escape:'html':'UTF-8'}
-                                </a>
-                            </h5>
+  <section id="crossselling" class="page-product-box">
+    <h3 class="productscategory_h2 page-product-heading">
+      {if $page_name == 'product'}
+        {l s='Customers who bought this product also bought:' mod='crossselling'}
+      {else}
+        {l s='We recommend' mod='crossselling'}
+      {/if}
+    </h3>
+    <div id="crossselling_list">
+      <ul id="crossselling_list_car" class="clearfix">
+        {foreach from=$orderProducts item='orderProduct' name=orderProduct}
+          <li class="product-box item" itemprop="isRelatedTo" itemscope itemtype="https://schema.org/Product">
+            <a class="lnk_img product-image" href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}" >
+              <img itemprop="image" src="{$orderProduct.image}" alt="{$orderProduct.name|htmlspecialchars}" />
+            </a>
+            <div class="s_title_block">
+              <h5 itemprop="name" class="product-name">
+                <a itemprop="url" href="{$orderProduct.link|escape:'html':'UTF-8'}" title="{$orderProduct.name|htmlspecialchars}">
+                  {$orderProduct.name|truncate:15:'...'|escape:'html':'UTF-8'}
+                </a>
+              </h5>
 
-                            {if isset($orderProduct.description_short)}<p>{$orderProduct.description_short|strip_tags:'UTF-8'|truncate:50:'...'}</p>{/if}
-                        </div>
-                        {if $crossDisplayPrice AND $orderProduct.show_price == 1 AND !isset($restricted_country_mode) AND !$PS_CATALOG_MODE}
-                            <p class="price_display">
-                                <span class="price">{convertPrice price=$orderProduct.displayed_price}</span>
-                            </p>
-                        {/if}
-                        <div class="clearfix" style="margin-top:5px">
-                            {if !$PS_CATALOG_MODE && ($orderProduct.allow_oosp || $orderProduct.quantity > 0)}
-                                <div class="no-print">
-                                    <a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$orderProduct.id_product|intval}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" data-id-product="{$orderProduct.id_product|intval}" title="{l s='Add to cart' mod='crossselling'}">
-                                        <span>{l s='Add to cart' mod='crossselling'}</span>
-                                    </a>
-                                </div>
-                            {/if}
-                        </div>
-                    </li>
-                {/foreach}
-            </ul>
-        </div>
-    </section>
+              {if isset($orderProduct.description_short)}<p>{$orderProduct.description_short|strip_tags:'UTF-8'|truncate:50:'...'}</p>{/if}
+            </div>
+            {if $crossDisplayPrice AND $orderProduct.show_price == 1 AND !isset($restricted_country_mode) AND !$PS_CATALOG_MODE}
+              <p class="price_display">
+                <span class="price">{convertPrice price=$orderProduct.displayed_price}</span>
+              </p>
+            {/if}
+            <div class="clearfix" style="margin-top:5px">
+              {if !$PS_CATALOG_MODE && ($orderProduct.allow_oosp || $orderProduct.quantity > 0)}
+                <div class="no-print">
+                  <a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$orderProduct.id_product|intval}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" data-id-product="{$orderProduct.id_product|intval}" title="{l s='Add to cart' mod='crossselling'}">
+                    <span>{l s='Add to cart' mod='crossselling'}</span>
+                  </a>
+                </div>
+              {/if}
+            </div>
+          </li>
+        {/foreach}
+      </ul>
+    </div>
+  </section>
 {/if}

--- a/themes/community-theme-16/modules/favoriteproducts/views/templates/front/favoriteproducts-account.tpl
+++ b/themes/community-theme-16/modules/favoriteproducts/views/templates/front/favoriteproducts-account.tpl
@@ -23,55 +23,55 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {capture name=path}
-    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-        {l s='My account' mod='favoriteproducts'}
-    </a>
-    <span class="navigation-pipe">{$navigationPipe}</span>
-    <span class="navigation_page">{l s='My favorite products' mod='favoriteproducts'}</span>
+  <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+    {l s='My account' mod='favoriteproducts'}
+  </a>
+  <span class="navigation-pipe">{$navigationPipe}</span>
+  <span class="navigation_page">{l s='My favorite products' mod='favoriteproducts'}</span>
 {/capture}
 
 <div id="favoriteproducts_block_account">
-    <h1 class="page-heading">{l s='My favorite products' mod='favoriteproducts'}</h1>
-    {if $favoriteProducts}
-        <ul class="row">
-            {foreach from=$favoriteProducts item=favoriteProduct}
-            <li class="col-xs-12">
-                <div class="favoriteproduct clearfix inner-content">
-                    <a 
-                    class="product_img_link"
-                    href="{$link->getProductLink($favoriteProduct.id_product, null, null, null, null, $favoriteProduct.id_shop)|escape:'html':'UTF-8'}">
-                        <img 
-                        src="{$link->getImageLink($favoriteProduct.link_rewrite, $favoriteProduct.image, 'medium_default')|escape:'html':'UTF-8'}" 
-                        alt=""/>
-                    </a>
-                    <p class="s_title_block">
-                        <a href="{$link->getProductLink($favoriteProduct.id_product, null, null, null, null, $favoriteProduct.id_shop)|escape:'html':'UTF-8'}">
-                            {$favoriteProduct.name|escape:'html':'UTF-8'}
-                        </a>
-                    </p>
-                    <div class="product_desc">{$favoriteProduct.description_short|strip_tags|escape:'html':'UTF-8'}</div>
-                    <div class="remove">
-                        <a href="#" rel="ajax_id_favoriteproduct_{$favoriteProduct.id_product}">
-                            <i class="icon-remove"></i>
-                        </a>
-                    </div>
-                </div>
-            </li>
-            {/foreach}
-        </ul>
-    {else}
-        <p class="alert alert-warning">{l s='No favorite products have been determined just yet. ' mod='favoriteproducts'}</p>
-    {/if}
-
-    <ul class="footer_links clearfix">
-        <li>
+  <h1 class="page-heading">{l s='My favorite products' mod='favoriteproducts'}</h1>
+  {if $favoriteProducts}
+    <ul class="row">
+      {foreach from=$favoriteProducts item=favoriteProduct}
+        <li class="col-xs-12">
+          <div class="favoriteproduct clearfix inner-content">
             <a
-            class="btn btn-default button button-small"
-            href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-                <span>
-                    <i class="icon-chevron-left"></i>{l s='Back to your account' mod='favoriteproducts'}
-                </span>
+              class="product_img_link"
+              href="{$link->getProductLink($favoriteProduct.id_product, null, null, null, null, $favoriteProduct.id_shop)|escape:'html':'UTF-8'}">
+              <img
+                src="{$link->getImageLink($favoriteProduct.link_rewrite, $favoriteProduct.image, 'medium_default')|escape:'html':'UTF-8'}"
+                alt=""/>
             </a>
+            <p class="s_title_block">
+              <a href="{$link->getProductLink($favoriteProduct.id_product, null, null, null, null, $favoriteProduct.id_shop)|escape:'html':'UTF-8'}">
+                {$favoriteProduct.name|escape:'html':'UTF-8'}
+              </a>
+            </p>
+            <div class="product_desc">{$favoriteProduct.description_short|strip_tags|escape:'html':'UTF-8'}</div>
+            <div class="remove">
+              <a href="#" rel="ajax_id_favoriteproduct_{$favoriteProduct.id_product}">
+                <i class="icon-remove"></i>
+              </a>
+            </div>
+          </div>
         </li>
+      {/foreach}
     </ul>
+  {else}
+    <p class="alert alert-warning">{l s='No favorite products have been determined just yet. ' mod='favoriteproducts'}</p>
+  {/if}
+
+  <ul class="footer_links clearfix">
+    <li>
+      <a
+        class="btn btn-default button button-small"
+        href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+        <span>
+          <i class="icon-chevron-left"></i>{l s='Back to your account' mod='favoriteproducts'}
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>

--- a/themes/community-theme-16/modules/favoriteproducts/views/templates/hook/favoriteproducts-extra.tpl
+++ b/themes/community-theme-16/modules/favoriteproducts/views/templates/hook/favoriteproducts-extra.tpl
@@ -24,19 +24,19 @@
 *}
 
 {if !$isCustomerFavoriteProduct AND $is_logged}
-<li id="favoriteproducts_block_extra_add" class="add">
+  <li id="favoriteproducts_block_extra_add" class="add">
     {l s='Add this product to my list of favorites.' mod='favoriteproducts'}
-</li>
+  </li>
 {/if}
 {if $isCustomerFavoriteProduct AND $is_logged}
-<li id="favoriteproducts_block_extra_remove">
+  <li id="favoriteproducts_block_extra_remove">
     {l s='Remove this product from my favorite\'s list. ' mod='favoriteproducts'}
-</li>
+  </li>
 {/if}
 
 <li id="favoriteproducts_block_extra_added">
-    {l s='Remove this product from my favorite\'s list. ' mod='favoriteproducts'}
+  {l s='Remove this product from my favorite\'s list. ' mod='favoriteproducts'}
 </li>
 <li id="favoriteproducts_block_extra_removed">
-    {l s='Add this product to my list of favorites.' mod='favoriteproducts'}
+  {l s='Add this product to my list of favorites.' mod='favoriteproducts'}
 </li>

--- a/themes/community-theme-16/modules/favoriteproducts/views/templates/hook/favoriteproducts-header.tpl
+++ b/themes/community-theme-16/modules/favoriteproducts/views/templates/hook/favoriteproducts-header.tpl
@@ -23,9 +23,9 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {strip}
-{addJsDef favorite_products_url_add=$link->getModuleLink('favoriteproducts', 'actions', ['process' => 'add'], Tools::usingSecureMode())|escape:'quotes':'UTF-8'}
-{addJsDef favorite_products_url_remove=$link->getModuleLink('favoriteproducts', 'actions', ['process' => 'remove'], Tools::usingSecureMode())|escape:'quotes':'UTF-8'}
-{if isset($smarty.get.id_product)}
+  {addJsDef favorite_products_url_add=$link->getModuleLink('favoriteproducts', 'actions', ['process' => 'add'], Tools::usingSecureMode())|escape:'quotes':'UTF-8'}
+  {addJsDef favorite_products_url_remove=$link->getModuleLink('favoriteproducts', 'actions', ['process' => 'remove'], Tools::usingSecureMode())|escape:'quotes':'UTF-8'}
+  {if isset($smarty.get.id_product)}
     {addJsDef favorite_products_id_product=$smarty.get.id_product|intval}
-{/if} 
+  {/if}
 {/strip}

--- a/themes/community-theme-16/modules/favoriteproducts/views/templates/hook/my-account.tpl
+++ b/themes/community-theme-16/modules/favoriteproducts/views/templates/hook/my-account.tpl
@@ -24,14 +24,14 @@
 *}
 
 <li class="favoriteproducts">
-    <a
+  <a
     href="{$link->getModuleLink('favoriteproducts', 'account', [], true)|escape:'html':'UTF-8'}"
     title="{l s='My favorite products.' mod='favoriteproducts'}">
-        {if !$in_footer}
-            <i class="icon-heart-empty"></i>
-            <span>{l s='My favorite products' mod='favoriteproducts'}</span>
-        {else}
-            {l s='My favorite products' mod='favoriteproducts'}
-        {/if}
-    </a>
+    {if !$in_footer}
+      <i class="icon-heart-empty"></i>
+      <span>{l s='My favorite products' mod='favoriteproducts'}</span>
+    {else}
+      {l s='My favorite products' mod='favoriteproducts'}
+    {/if}
+  </a>
 </li>

--- a/themes/community-theme-16/modules/homefeatured/homefeatured.tpl
+++ b/themes/community-theme-16/modules/homefeatured/homefeatured.tpl
@@ -23,9 +23,9 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($products) && $products}
-    {include file="$tpl_dir./product-list.tpl" class='homefeatured tab-pane' id='homefeatured'}
+  {include file="$tpl_dir./product-list.tpl" class='homefeatured tab-pane' id='homefeatured'}
 {else}
-<ul id="homefeatured" class="homefeatured tab-pane">
+  <ul id="homefeatured" class="homefeatured tab-pane">
     <li class="alert alert-info">{l s='No featured products at this time.' mod='homefeatured'}</li>
-</ul>
+  </ul>
 {/if}

--- a/themes/community-theme-16/modules/homeslider/header.tpl
+++ b/themes/community-theme-16/modules/homeslider/header.tpl
@@ -1,6 +1,6 @@
 {if isset($homeslider)}
-    {addJsDef homeslider_loop=$homeslider.loop|intval}
-    {addJsDef homeslider_width=$homeslider.width|intval}
-    {addJsDef homeslider_speed=$homeslider.speed|intval}
-    {addJsDef homeslider_pause=$homeslider.pause|intval}
+  {addJsDef homeslider_loop=$homeslider.loop|intval}
+  {addJsDef homeslider_width=$homeslider.width|intval}
+  {addJsDef homeslider_speed=$homeslider.speed|intval}
+  {addJsDef homeslider_pause=$homeslider.pause|intval}
 {/if}

--- a/themes/community-theme-16/modules/homeslider/homeslider.tpl
+++ b/themes/community-theme-16/modules/homeslider/homeslider.tpl
@@ -24,25 +24,25 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if $page_name =='index'}
-<!-- Module HomeSlider -->
-    {if isset($homeslider_slides)}
-        <div id="homepage-slider">
-            {if isset($homeslider_slides.0) && isset($homeslider_slides.0.sizes.1)}{capture name='height'}{$homeslider_slides.0.sizes.1}{/capture}{/if}
-            <ul id="homeslider"{if isset($smarty.capture.height) && $smarty.capture.height} style="max-height:{$smarty.capture.height}px;"{/if}>
-                {foreach from=$homeslider_slides item=slide}
-                    {if $slide.active}
-                        <li class="homeslider-container">
-                            <a href="{$slide.url|escape:'html':'UTF-8'}" title="{$slide.legend|escape:'html':'UTF-8'}">
-                                <img src="{$link->getMediaLink("`$smarty.const._MODULE_DIR_`homeslider/images/`$slide.image|escape:'htmlall':'UTF-8'`")}"{if isset($slide.size) && $slide.size} {$slide.size}{else} width="100%" height="100%"{/if} alt="{$slide.legend|escape:'htmlall':'UTF-8'}" />
-                            </a>
-                            {if isset($slide.description) && trim($slide.description) != ''}
-                                <div class="homeslider-description">{$slide.description}</div>
-                            {/if}
-                        </li>
-                    {/if}
-                {/foreach}
-            </ul>
-        </div>
-    {/if}
-<!-- /Module HomeSlider -->
+  <!-- Module HomeSlider -->
+  {if isset($homeslider_slides)}
+    <div id="homepage-slider">
+      {if isset($homeslider_slides.0) && isset($homeslider_slides.0.sizes.1)}{capture name='height'}{$homeslider_slides.0.sizes.1}{/capture}{/if}
+      <ul id="homeslider"{if isset($smarty.capture.height) && $smarty.capture.height} style="max-height:{$smarty.capture.height}px;"{/if}>
+        {foreach from=$homeslider_slides item=slide}
+          {if $slide.active}
+            <li class="homeslider-container">
+              <a href="{$slide.url|escape:'html':'UTF-8'}" title="{$slide.legend|escape:'html':'UTF-8'}">
+                <img src="{$link->getMediaLink("`$smarty.const._MODULE_DIR_`homeslider/images/`$slide.image|escape:'htmlall':'UTF-8'`")}"{if isset($slide.size) && $slide.size} {$slide.size}{else} width="100%" height="100%"{/if} alt="{$slide.legend|escape:'htmlall':'UTF-8'}" />
+              </a>
+              {if isset($slide.description) && trim($slide.description) != ''}
+                <div class="homeslider-description">{$slide.description}</div>
+              {/if}
+            </li>
+          {/if}
+        {/foreach}
+      </ul>
+    </div>
+  {/if}
+  <!-- /Module HomeSlider -->
 {/if}

--- a/themes/community-theme-16/modules/loyalty/views/templates/front/loyalty.tpl
+++ b/themes/community-theme-16/modules/loyalty/views/templates/front/loyalty.tpl
@@ -28,171 +28,171 @@
 <h1 class="page-heading">{l s='My loyalty points' mod='loyalty'}</h1>
 
 {if $orders}
-<div class="block-center" id="block-history">
+  <div class="block-center" id="block-history">
     {if $orders && count($orders)}
-    <table id="order-list" class="table table-bordered">
+      <table id="order-list" class="table table-bordered">
         <thead>
-            <tr>
-                <th class="first_item">{l s='Order' mod='loyalty'}</th>
-                <th class="item">{l s='Date' mod='loyalty'}</th>
-                <th class="item">{l s='Points' mod='loyalty'}</th>
-                <th class="last_item">{l s='Points Status' mod='loyalty'}</th>
-            </tr>
+        <tr>
+          <th class="first_item">{l s='Order' mod='loyalty'}</th>
+          <th class="item">{l s='Date' mod='loyalty'}</th>
+          <th class="item">{l s='Points' mod='loyalty'}</th>
+          <th class="last_item">{l s='Points Status' mod='loyalty'}</th>
+        </tr>
         </thead>
         <tfoot>
-            <tr class="alternate_item">
-                <td colspan="2" class="history_method bold" style="text-align:center;">{l s='Total points available:' mod='loyalty'}</td>
-                <td class="history_method" style="text-align:left;">{$totalPoints|intval}</td>
-                <td class="history_method">&nbsp;</td>
-            </tr>
+        <tr class="alternate_item">
+          <td colspan="2" class="history_method bold" style="text-align:center;">{l s='Total points available:' mod='loyalty'}</td>
+          <td class="history_method" style="text-align:left;">{$totalPoints|intval}</td>
+          <td class="history_method">&nbsp;</td>
+        </tr>
         </tfoot>
         <tbody>
         {foreach from=$displayorders item='order'}
-            <tr class="alternate_item">
-                <td class="history_link bold">{l s='#' mod='loyalty'}{$order.id|string_format:"%06d"}</td>
-                <td class="history_date">{dateFormat date=$order.date full=1}</td>
-                <td class="history_method">{$order.points|intval}</td>
-                <td class="history_method">{$order.state|escape:'html':'UTF-8'}</td>
-            </tr>
+          <tr class="alternate_item">
+            <td class="history_link bold">{l s='#' mod='loyalty'}{$order.id|string_format:"%06d"}</td>
+            <td class="history_date">{dateFormat date=$order.date full=1}</td>
+            <td class="history_method">{$order.points|intval}</td>
+            <td class="history_method">{$order.state|escape:'html':'UTF-8'}</td>
+          </tr>
         {/foreach}
         </tbody>
-    </table>
-    <div id="block-order-detail" class="unvisible">&nbsp;</div>
+      </table>
+      <div id="block-order-detail" class="unvisible">&nbsp;</div>
     {else}
-        <p class="alert alert-warning">{l s='You have not placed any orders.' mod='loyalty'}</p>
+      <p class="alert alert-warning">{l s='You have not placed any orders.' mod='loyalty'}</p>
     {/if}
-</div>
-<div id="pagination" class="pagination">
+  </div>
+  <div id="pagination" class="pagination">
     {if $nbpagination < $orders|@count}
-        <ul class="pagination">
+      <ul class="pagination">
         {if $page != 1}
-            {assign var='p_previous' value=$page-1}
-            <li id="pagination_previous">
-                <a href="{summarypaginationlink p=$p_previous n=$nbpagination}" title="{l s='Previous' mod='loyalty'}" rel="nofollow">&laquo;&nbsp;{l s='Previous' mod='loyalty'}</a>
-            </li>
+          {assign var='p_previous' value=$page-1}
+          <li id="pagination_previous">
+            <a href="{summarypaginationlink p=$p_previous n=$nbpagination}" title="{l s='Previous' mod='loyalty'}" rel="nofollow">&laquo;&nbsp;{l s='Previous' mod='loyalty'}</a>
+          </li>
         {else}
-            <li id="pagination_previous" class="disabled"><span>&laquo;&nbsp;{l s='Previous' mod='loyalty'}</span></li>
+          <li id="pagination_previous" class="disabled"><span>&laquo;&nbsp;{l s='Previous' mod='loyalty'}</span></li>
         {/if}
         {if $page > 2}
-            <li><a href="{summarypaginationlink p='1' n=$nbpagination}" rel="nofollow">1</a></li>
-            {if $page > 3}
-                <li class="truncate">...</li>
-            {/if}
+          <li><a href="{summarypaginationlink p='1' n=$nbpagination}" rel="nofollow">1</a></li>
+          {if $page > 3}
+            <li class="truncate">...</li>
+          {/if}
         {/if}
         {section name=pagination start=$page-1 loop=$page+2 step=1}
-            {if $page == $smarty.section.pagination.index}
-                <li class="current"><span>{$page|escape:'html':'UTF-8'}</span></li>
-            {elseif $smarty.section.pagination.index > 0 && $orders|@count+$nbpagination > ($smarty.section.pagination.index)*($nbpagination)}
-                <li><a href="{summarypaginationlink p=$smarty.section.pagination.index n=$nbpagination}">{$smarty.section.pagination.index|escape:'html':'UTF-8'}</a></li>
-            {/if}
+          {if $page == $smarty.section.pagination.index}
+            <li class="current"><span>{$page|escape:'html':'UTF-8'}</span></li>
+          {elseif $smarty.section.pagination.index > 0 && $orders|@count+$nbpagination > ($smarty.section.pagination.index)*($nbpagination)}
+            <li><a href="{summarypaginationlink p=$smarty.section.pagination.index n=$nbpagination}">{$smarty.section.pagination.index|escape:'html':'UTF-8'}</a></li>
+          {/if}
         {/section}
         {if $max_page-$page > 1}
-            {if $max_page-$page > 2}
-                <li class="truncate">...</li>
-            {/if}
-            <li><a href="{summarypaginationlink p=$max_page n=$nbpagination}">{$max_page}</a></li>
+          {if $max_page-$page > 2}
+            <li class="truncate">...</li>
+          {/if}
+          <li><a href="{summarypaginationlink p=$max_page n=$nbpagination}">{$max_page}</a></li>
         {/if}
         {if $orders|@count > $page * $nbpagination}
-            {assign var='p_next' value=$page+1}
-            <li id="pagination_next"><a href="{summarypaginationlink p=$p_next n=$nbpagination}" title="{l s='Next' mod='loyalty'}" rel="nofollow">{l s='Next' mod='loyalty'}&nbsp;&raquo;</a></li>
+          {assign var='p_next' value=$page+1}
+          <li id="pagination_next"><a href="{summarypaginationlink p=$p_next n=$nbpagination}" title="{l s='Next' mod='loyalty'}" rel="nofollow">{l s='Next' mod='loyalty'}&nbsp;&raquo;</a></li>
         {else}
-            <li id="pagination_next" class="disabled"><span>{l s='Next' mod='loyalty'}&nbsp;&raquo;</span></li>
+          <li id="pagination_next" class="disabled"><span>{l s='Next' mod='loyalty'}&nbsp;&raquo;</span></li>
         {/if}
-        </ul>
+      </ul>
     {/if}
     {if $orders|@count > 10}
-        <form action="{$pagination_link}" method="get" class="pagination">
-            <p>
-                <input type="submit" class="button_mini" value="{l s='OK'  mod='loyalty'}" />
-                <label for="nb_item">{l s='items:' mod='loyalty'}</label>
-                <select name="n" id="nb_item">
-                {foreach from=$nArray item=nValue}
-                    {if $nValue <= $orders|@count}
-                        <option value="{$nValue|escape:'html':'UTF-8'}" {if $nbpagination == $nValue}selected="selected"{/if}>{$nValue|escape:'html':'UTF-8'}</option>
-                    {/if}
-                {/foreach}
-                </select>
-                <input type="hidden" name="p" value="1" />
-            </p>
-        </form>
+      <form action="{$pagination_link}" method="get" class="pagination">
+        <p>
+          <input type="submit" class="button_mini" value="{l s='OK'  mod='loyalty'}" />
+          <label for="nb_item">{l s='items:' mod='loyalty'}</label>
+          <select name="n" id="nb_item">
+            {foreach from=$nArray item=nValue}
+              {if $nValue <= $orders|@count}
+                <option value="{$nValue|escape:'html':'UTF-8'}" {if $nbpagination == $nValue}selected="selected"{/if}>{$nValue|escape:'html':'UTF-8'}</option>
+              {/if}
+            {/foreach}
+          </select>
+          <input type="hidden" name="p" value="1" />
+        </p>
+      </form>
     {/if}
-    </div>
+  </div>
 
-<p>{l s='Vouchers generated here are usable in the following categories : ' mod='loyalty'}
-{if $categories}{$categories}{else}{l s='All' mod='loyalty'}{/if}</p>
+  <p>{l s='Vouchers generated here are usable in the following categories : ' mod='loyalty'}
+    {if $categories}{$categories}{else}{l s='All' mod='loyalty'}{/if}</p>
 
-{if $transformation_allowed}
-<p class="text-center">
-    <a class="btn btn-default" href="{$link->getModuleLink('loyalty', 'default', ['process' => 'transformpoints'], true)|escape:'html':'UTF-8'}" onclick="return confirm('{l s='Are you sure you want to transform your points into vouchers?' mod='loyalty' js=1}');">{l s='Transform my points into a voucher of' mod='loyalty'} <span class="price">{convertPrice price=$voucher}</span>.</a>
-</p>
-{/if}
+  {if $transformation_allowed}
+    <p class="text-center">
+      <a class="btn btn-default" href="{$link->getModuleLink('loyalty', 'default', ['process' => 'transformpoints'], true)|escape:'html':'UTF-8'}" onclick="return confirm('{l s='Are you sure you want to transform your points into vouchers?' mod='loyalty' js=1}');">{l s='Transform my points into a voucher of' mod='loyalty'} <span class="price">{convertPrice price=$voucher}</span>.</a>
+    </p>
+  {/if}
 
-<h1 class="page-heading">{l s='My vouchers from loyalty points' mod='loyalty'}</h1>
+  <h1 class="page-heading">{l s='My vouchers from loyalty points' mod='loyalty'}</h1>
 
-{if $nbDiscounts}
-<div class="block-center" id="block-history">
-    <table id="order-list" class="table table-bordered">
+  {if $nbDiscounts}
+    <div class="block-center" id="block-history">
+      <table id="order-list" class="table table-bordered">
         <thead>
-            <tr>
-                <th class="first_item">{l s='Created' mod='loyalty'}</th>
-                <th class="item">{l s='Value' mod='loyalty'}</th>
-                <th class="item">{l s='Code' mod='loyalty'}</th>
-                <th class="item">{l s='Valid from' mod='loyalty'}</th>
-                <th class="item">{l s='Valid until' mod='loyalty'}</th>
-                <th class="item">{l s='Status' mod='loyalty'}</th>
-                <th class="last_item">{l s='Details' mod='loyalty'}</th>
-            </tr>
+        <tr>
+          <th class="first_item">{l s='Created' mod='loyalty'}</th>
+          <th class="item">{l s='Value' mod='loyalty'}</th>
+          <th class="item">{l s='Code' mod='loyalty'}</th>
+          <th class="item">{l s='Valid from' mod='loyalty'}</th>
+          <th class="item">{l s='Valid until' mod='loyalty'}</th>
+          <th class="item">{l s='Status' mod='loyalty'}</th>
+          <th class="last_item">{l s='Details' mod='loyalty'}</th>
+        </tr>
         </thead>
         <tbody>
         {foreach from=$discounts item=discount name=myLoop}
-            <tr class="alternate_item">
-                <td class="history_date">{dateFormat date=$discount->date_add}</td>
-                <td class="history_price"><span class="price">{if $discount->reduction_percent > 0}
-                        {$discount->reduction_percent}%
-                    {elseif $discount->reduction_amount}
-                        {displayPrice price=$discount->reduction_amount currency=$discount->reduction_currency}
-                    {else}
-                        {l s='Free shipping' mod='loyalty'}
-                    {/if}</span></td>
-                <td class="history_method bold">{$discount->code}</td>
-                <td class="history_date">{dateFormat date=$discount->date_from}</td>
-                <td class="history_date">{dateFormat date=$discount->date_to}</td>
-                <td class="history_method bold">{if $discount->quantity > 0}{l s='To use' mod='loyalty'}{else}{l s='Used' mod='loyalty'}{/if}</td>
-                <td class="history_method">
-                    <a rel="#order_tip_{$discount->id|intval}" class="cluetip" title="{l s='Generated by these following orders' mod='loyalty'}" href="{$smarty.server.SCRIPT_NAME|escape:'html':'UTF-8'}">{l s='more...' mod='loyalty'}</a>
-                    <div class="hidden" id="order_tip_{$discount->id|intval}">
-                        <ul>
-                        {foreach from=$discount->orders item=myorder name=myLoop}
-                            <li>
-                                {$myorder.id_order|string_format:{l s='Order #%d' mod='loyalty'}}
-                                ({displayPrice price=$myorder.total_paid currency=$myorder.id_currency}) :
-                                {if $myorder.points > 0}{$myorder.points|string_format:{l s='%d points.' mod='loyalty'}}{else}{l s='Cancelled' mod='loyalty'}{/if}
-                            </li>
-                        {/foreach}
-                        </ul>
-                    </div>
-                </td>
-            </tr>
+          <tr class="alternate_item">
+            <td class="history_date">{dateFormat date=$discount->date_add}</td>
+            <td class="history_price"><span class="price">{if $discount->reduction_percent > 0}
+                  {$discount->reduction_percent}%
+              {elseif $discount->reduction_amount}
+                  {displayPrice price=$discount->reduction_amount currency=$discount->reduction_currency}
+              {else}
+                  {l s='Free shipping' mod='loyalty'}
+              {/if}</span></td>
+            <td class="history_method bold">{$discount->code}</td>
+            <td class="history_date">{dateFormat date=$discount->date_from}</td>
+            <td class="history_date">{dateFormat date=$discount->date_to}</td>
+            <td class="history_method bold">{if $discount->quantity > 0}{l s='To use' mod='loyalty'}{else}{l s='Used' mod='loyalty'}{/if}</td>
+            <td class="history_method">
+              <a rel="#order_tip_{$discount->id|intval}" class="cluetip" title="{l s='Generated by these following orders' mod='loyalty'}" href="{$smarty.server.SCRIPT_NAME|escape:'html':'UTF-8'}">{l s='more...' mod='loyalty'}</a>
+              <div class="hidden" id="order_tip_{$discount->id|intval}">
+                <ul>
+                  {foreach from=$discount->orders item=myorder name=myLoop}
+                    <li>
+                      {$myorder.id_order|string_format:{l s='Order #%d' mod='loyalty'}}
+                      ({displayPrice price=$myorder.total_paid currency=$myorder.id_currency}) :
+                      {if $myorder.points > 0}{$myorder.points|string_format:{l s='%d points.' mod='loyalty'}}{else}{l s='Cancelled' mod='loyalty'}{/if}
+                    </li>
+                  {/foreach}
+                </ul>
+              </div>
+            </td>
+          </tr>
         {/foreach}
         </tbody>
-    </table>
-    <div id="block-order-detail" class="unvisible">&nbsp;</div>
-</div>
+      </table>
+      <div id="block-order-detail" class="unvisible">&nbsp;</div>
+    </div>
 
-{if $minimalLoyalty > 0}<p>{l s='The minimum order amount in order to use these vouchers is:' mod='loyalty'} {convertPrice price=$minimalLoyalty}</p>{/if}
+    {if $minimalLoyalty > 0}<p>{l s='The minimum order amount in order to use these vouchers is:' mod='loyalty'} {convertPrice price=$minimalLoyalty}</p>{/if}
 
+  {else}
+    <p class="alert alert-warning">{l s='No vouchers yet.' mod='loyalty'}</p>
+  {/if}
 {else}
-<p class="alert alert-warning">{l s='No vouchers yet.' mod='loyalty'}</p>
-{/if}
-{else}
-<p class="alert alert-warning">{l s='No reward points yet.' mod='loyalty'}</p>
+  <p class="alert alert-warning">{l s='No reward points yet.' mod='loyalty'}</p>
 {/if}
 
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='Back to Your Account' mod='loyalty'}" rel="nofollow"><span><i class="icon-chevron-left"></i>{l s='Back to Your Account' mod='loyalty'}</span></a>
-    </li>
-    <li>
-        <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home' mod='loyalty'}"><span><i class="icon-chevron-left"></i>{l s='Home' mod='loyalty'}</span></a>
-    </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='Back to Your Account' mod='loyalty'}" rel="nofollow"><span><i class="icon-chevron-left"></i>{l s='Back to Your Account' mod='loyalty'}</span></a>
+  </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home' mod='loyalty'}"><span><i class="icon-chevron-left"></i>{l s='Home' mod='loyalty'}</span></a>
+  </li>
 </ul>

--- a/themes/community-theme-16/modules/loyalty/views/templates/hook/my-account.tpl
+++ b/themes/community-theme-16/modules/loyalty/views/templates/hook/my-account.tpl
@@ -25,6 +25,6 @@
 
 <!-- MODULE Loyalty -->
 <li class="loyalty">
-    <a href="{$link->getModuleLink('loyalty', 'default', ['process' => 'summary'], true)|escape:'html':'UTF-8'}" title="{l s='My loyalty points' mod='loyalty'}" rel="nofollow"><i class="icon-flag"></i><span>{l s='My loyalty points' mod='loyalty'}</span></a>
+  <a href="{$link->getModuleLink('loyalty', 'default', ['process' => 'summary'], true)|escape:'html':'UTF-8'}" title="{l s='My loyalty points' mod='loyalty'}" rel="nofollow"><i class="icon-flag"></i><span>{l s='My loyalty points' mod='loyalty'}</span></a>
 </li>
 <!-- END : MODULE Loyalty -->

--- a/themes/community-theme-16/modules/loyalty/views/templates/hook/product.tpl
+++ b/themes/community-theme-16/modules/loyalty/views/templates/hook/product.tpl
@@ -23,19 +23,19 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <p id="loyalty" class="align_justify">
-    {if $points}
-        {l s='By buying this product you can collect up to' mod='loyalty'} <b><span id="loyalty_points">{$points}</span>
-        {if $points > 1}{l s='loyalty points' mod='loyalty'}{else}{l s='loyalty point' mod='loyalty'}{/if}</b>.
-        {l s='Your cart will total' mod='loyalty'} <b><span id="total_loyalty_points">{$total_points}</span>
-        {if $total_points > 1}{l s='loyalty points' mod='loyalty'}{else}{l s='loyalty point' mod='loyalty'}{/if}</b> {l s='that can be converted into a voucher of' mod='loyalty'}
-        <span id="loyalty_price">{convertPrice price=$voucher}</span>.
+  {if $points}
+    {l s='By buying this product you can collect up to' mod='loyalty'} <b><span id="loyalty_points">{$points}</span>
+    {if $points > 1}{l s='loyalty points' mod='loyalty'}{else}{l s='loyalty point' mod='loyalty'}{/if}</b>.
+    {l s='Your cart will total' mod='loyalty'} <b><span id="total_loyalty_points">{$total_points}</span>
+    {if $total_points > 1}{l s='loyalty points' mod='loyalty'}{else}{l s='loyalty point' mod='loyalty'}{/if}</b> {l s='that can be converted into a voucher of' mod='loyalty'}
+    <span id="loyalty_price">{convertPrice price=$voucher}</span>.
+  {else}
+    {if isset($no_pts_discounted) && $no_pts_discounted == 1}
+      {l s='No reward points for this product because there\'s already a discount.' mod='loyalty'}
     {else}
-        {if isset($no_pts_discounted) && $no_pts_discounted == 1}
-            {l s='No reward points for this product because there\'s already a discount.' mod='loyalty'}
-        {else}
-            {l s='No reward points for this product.' mod='loyalty'}
-        {/if}
+      {l s='No reward points for this product.' mod='loyalty'}
     {/if}
+  {/if}
 </p>
 <br class="clear" />
 {addJsDef point_rate=$point_rate}

--- a/themes/community-theme-16/modules/loyalty/views/templates/hook/shopping-cart.tpl
+++ b/themes/community-theme-16/modules/loyalty/views/templates/hook/shopping-cart.tpl
@@ -25,14 +25,14 @@
 
 <!-- MODULE Loyalty -->
 <p id="loyalty">
-    <i class="icon-flag"></i>
-    {if $points > 0}
-        {l s='By checking out this shopping cart you can collect up to' mod='loyalty'} <b>
-        {if $points > 1}{l s='%d loyalty points' sprintf=$points mod='loyalty'}{else}{l s='%d loyalty point' sprintf=$points mod='loyalty'}{/if}</b>
-        {l s='that can be converted into a voucher of' mod='loyalty'} {convertPrice price=$voucher}{if isset($guest_checkout) && $guest_checkout}<sup>*</sup>{/if}.<br />
-        {if isset($guest_checkout) && $guest_checkout}<sup>*</sup> {l s='Not available for Instant checkout order' mod='loyalty'}{/if}
-    {else}
-        {l s='Add some products to your shopping cart to collect some loyalty points.' mod='loyalty'}
-    {/if}
+  <i class="icon-flag"></i>
+  {if $points > 0}
+    {l s='By checking out this shopping cart you can collect up to' mod='loyalty'} <b>
+    {if $points > 1}{l s='%d loyalty points' sprintf=$points mod='loyalty'}{else}{l s='%d loyalty point' sprintf=$points mod='loyalty'}{/if}</b>
+    {l s='that can be converted into a voucher of' mod='loyalty'} {convertPrice price=$voucher}{if isset($guest_checkout) && $guest_checkout}<sup>*</sup>{/if}.<br />
+    {if isset($guest_checkout) && $guest_checkout}<sup>*</sup> {l s='Not available for Instant checkout order' mod='loyalty'}{/if}
+  {else}
+    {l s='Add some products to your shopping cart to collect some loyalty points.' mod='loyalty'}
+  {/if}
 </p>
 <!-- END : MODULE Loyalty -->

--- a/themes/community-theme-16/modules/mailalerts/views/templates/front/mailalerts-account.tpl
+++ b/themes/community-theme-16/modules/mailalerts/views/templates/front/mailalerts-account.tpl
@@ -24,26 +24,26 @@
 *}
 {capture name=path}<a href="{$link->getPageLink('my-account', true)|escape:'html'}" title="{l s='Manage my account' mod='mailalerts'}" rel="nofollow">{l s='My account' mod='mailalerts'}</a><span class="navigation-pipe">{$navigationPipe}</span><span class="navigation_page">{l s='My alerts' mod='mailalerts'}</span>{/capture}
 <div id="mailalerts_block_account" class="block">
-    <h1 class="page-heading">{l s='My alerts' mod='mailalerts'}</h1>
-    {if $mailAlerts}
-        <ul class="products-block">
-            {foreach from=$mailAlerts item=mailAlert name=myLoop}
-            <li class="clearfix{if $smarty.foreach.myLoop.last} last_item{/if}">
-                <a class="products-block-image" href="{$link->getProductLink($mailAlert.id_product, null, null, null, null, $mailAlert.id_shop)}" title="{$mailAlert.name|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($mailAlert.link_rewrite, $mailAlert.cover, 'small_default')|escape:'html'}" alt=""/></a>
-                <div class="product-content">
-                    <span class="remove">
-                        <i class="icon-remove" rel="ajax_id_mailalert_{$mailAlert.id_product}_{$mailAlert.id_product_attribute}"></i>
-                    </span>
-                    <h5><a class="product-name" href="{$link->getProductLink($mailAlert.id_product, null, null, null, null, $mailAlert.id_shop)|escape:'html'}" title="{$mailAlert.name|escape:'html':'UTF-8'}">{$mailAlert.name|escape:'html':'UTF-8'}</a></h5>
-                    <div class="product-description"><small>{$mailAlert.attributes_small|escape:'html':'UTF-8'}</small></div>
-                </div>
-            </li>
-            {/foreach}
-        </ul>
-    {/if}
-    <p id="mailalerts_block_account_warning" class="{if $mailAlerts}hidden{/if} alert alert-warning">{l s='No mail alerts yet.' mod='mailalerts'}</p>
-    <ul class="footer_links clearfix">
-        <li><a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html'}" title="{l s='Back to Your Account' mod='mailalerts'}"><span><i class="icon-chevron-left"></i>{l s='Back to Your Account' mod='mailalerts'}</span></a></li>
+  <h1 class="page-heading">{l s='My alerts' mod='mailalerts'}</h1>
+  {if $mailAlerts}
+    <ul class="products-block">
+      {foreach from=$mailAlerts item=mailAlert name=myLoop}
+        <li class="clearfix{if $smarty.foreach.myLoop.last} last_item{/if}">
+          <a class="products-block-image" href="{$link->getProductLink($mailAlert.id_product, null, null, null, null, $mailAlert.id_shop)}" title="{$mailAlert.name|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($mailAlert.link_rewrite, $mailAlert.cover, 'small_default')|escape:'html'}" alt=""/></a>
+          <div class="product-content">
+            <span class="remove">
+              <i class="icon-remove" rel="ajax_id_mailalert_{$mailAlert.id_product}_{$mailAlert.id_product_attribute}"></i>
+            </span>
+            <h5><a class="product-name" href="{$link->getProductLink($mailAlert.id_product, null, null, null, null, $mailAlert.id_shop)|escape:'html'}" title="{$mailAlert.name|escape:'html':'UTF-8'}">{$mailAlert.name|escape:'html':'UTF-8'}</a></h5>
+            <div class="product-description"><small>{$mailAlert.attributes_small|escape:'html':'UTF-8'}</small></div>
+          </div>
+        </li>
+      {/foreach}
     </ul>
+  {/if}
+  <p id="mailalerts_block_account_warning" class="{if $mailAlerts}hidden{/if} alert alert-warning">{l s='No mail alerts yet.' mod='mailalerts'}</p>
+  <ul class="footer_links clearfix">
+    <li><a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html'}" title="{l s='Back to Your Account' mod='mailalerts'}"><span><i class="icon-chevron-left"></i>{l s='Back to Your Account' mod='mailalerts'}</span></a></li>
+  </ul>
 </div>
 {addJsDef mailalerts_url_remove=$link->getModuleLink('mailalerts', 'actions', ['process' => 'remove'])|escape:'quotes':'UTF-8'}

--- a/themes/community-theme-16/modules/mailalerts/views/templates/hook/my-account.tpl
+++ b/themes/community-theme-16/modules/mailalerts/views/templates/hook/my-account.tpl
@@ -24,8 +24,8 @@
 *}
 
 <li class="mailalerts">
-    <a href="{$link->getModuleLink('mailalerts', 'account', array(), true)|escape:'html'}" title="{l s='My alerts' mod='mailalerts'}" rel="nofollow">
-        <i class="icon-envelope"></i>
-        <span>{l s='My alerts' mod='mailalerts'}</span>
-    </a>
+  <a href="{$link->getModuleLink('mailalerts', 'account', array(), true)|escape:'html'}" title="{l s='My alerts' mod='mailalerts'}" rel="nofollow">
+    <i class="icon-envelope"></i>
+    <span>{l s='My alerts' mod='mailalerts'}</span>
+  </a>
 </li>

--- a/themes/community-theme-16/modules/mailalerts/views/templates/hook/product.tpl
+++ b/themes/community-theme-16/modules/mailalerts/views/templates/hook/product.tpl
@@ -24,21 +24,21 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <!-- MODULE MailAlerts -->
-    {if isset($email) AND $email}
-        <p class="form-group">
-            <input type="text" id="oos_customer_email" name="customer_email" size="20" value="{l s='your@email.com' mod='mailalerts'}" class="mailalerts_oos_email form-control" />
-        </p>
-    {/if}
-    <a href="#" title="{l s='Notify me when available' mod='mailalerts'}" id="mailalert_link" rel="nofollow">{l s='Notify me when available' mod='mailalerts'}</a>
-    <span id="oos_customer_email_result" style="display:none; display: block;"></span>
+{if isset($email) AND $email}
+  <p class="form-group">
+    <input type="text" id="oos_customer_email" name="customer_email" size="20" value="{l s='your@email.com' mod='mailalerts'}" class="mailalerts_oos_email form-control" />
+  </p>
+{/if}
+<a href="#" title="{l s='Notify me when available' mod='mailalerts'}" id="mailalert_link" rel="nofollow">{l s='Notify me when available' mod='mailalerts'}</a>
+<span id="oos_customer_email_result" style="display:none; display: block;"></span>
 {strip}
-{addJsDef oosHookJsCodeFunctions=array('oosHookJsCodeMailAlert')}
-{addJsDef mailalerts_url_check=$link->getModuleLink('mailalerts', 'actions', ['process' => 'check'])}
-{addJsDef mailalerts_url_add=$link->getModuleLink('mailalerts', 'actions', ['process' => 'add'])}
+  {addJsDef oosHookJsCodeFunctions=array('oosHookJsCodeMailAlert')}
+  {addJsDef mailalerts_url_check=$link->getModuleLink('mailalerts', 'actions', ['process' => 'check'])}
+  {addJsDef mailalerts_url_add=$link->getModuleLink('mailalerts', 'actions', ['process' => 'add'])}
 
-{addJsDefL name='mailalerts_placeholder'}{l s='your@email.com' mod='mailalerts' js=1}{/addJsDefL}
-{addJsDefL name='mailalerts_registered'}{l s='Request notification registered' mod='mailalerts' js=1}{/addJsDefL}
-{addJsDefL name='mailalerts_already'}{l s='You already have an alert for this product' mod='mailalerts' js=1}{/addJsDefL}
-{addJsDefL name='mailalerts_invalid'}{l s='Your e-mail address is invalid' mod='mailalerts' js=1}{/addJsDefL}
+  {addJsDefL name='mailalerts_placeholder'}{l s='your@email.com' mod='mailalerts' js=1}{/addJsDefL}
+  {addJsDefL name='mailalerts_registered'}{l s='Request notification registered' mod='mailalerts' js=1}{/addJsDefL}
+  {addJsDefL name='mailalerts_already'}{l s='You already have an alert for this product' mod='mailalerts' js=1}{/addJsDefL}
+  {addJsDefL name='mailalerts_invalid'}{l s='Your e-mail address is invalid' mod='mailalerts' js=1}{/addJsDefL}
 {/strip}
 <!-- END : MODULE MailAlerts -->

--- a/themes/community-theme-16/modules/productcomments/productcomments-extra.tpl
+++ b/themes/community-theme-16/modules/productcomments/productcomments-extra.tpl
@@ -1,4 +1,4 @@
- {*
+{*
 * 2007-2015 PrestaShop
 *
 * NOTICE OF LICENSE
@@ -24,41 +24,41 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if (!$content_only && (($nbComments == 0 && $too_early == false && ($is_logged || $allow_guests)) || ($nbComments != 0)))}
-<div id="product_comments_block_extra" class="no-print" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+  <div id="product_comments_block_extra" class="no-print" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
     {if $nbComments != 0}
-        <div class="comments_note clearfix">
-            <span>{l s='Rating' mod='productcomments'}&nbsp;</span>
-            <div class="star_content clearfix">
-                {section name="i" start=0 loop=5 step=1}
-                    {if $averageTotal le $smarty.section.i.index}
-                        <div class="star"></div>
-                    {else}
-                        <div class="star star_on"></div>
-                    {/if}
-                {/section}
-                <meta itemprop="worstRating" content = "0" />
-                <meta itemprop="ratingValue" content = "{if isset($ratings.avg)}{$ratings.avg|round:1|escape:'html':'UTF-8'}{else}{$averageTotal|round:1|escape:'html':'UTF-8'}{/if}" />
-                <meta itemprop="bestRating" content = "5" />
-            </div>
-        </div> <!-- .comments_note -->
+      <div class="comments_note clearfix">
+        <span>{l s='Rating' mod='productcomments'}&nbsp;</span>
+        <div class="star_content clearfix">
+          {section name="i" start=0 loop=5 step=1}
+            {if $averageTotal le $smarty.section.i.index}
+              <div class="star"></div>
+            {else}
+              <div class="star star_on"></div>
+            {/if}
+          {/section}
+          <meta itemprop="worstRating" content = "0" />
+          <meta itemprop="ratingValue" content = "{if isset($ratings.avg)}{$ratings.avg|round:1|escape:'html':'UTF-8'}{else}{$averageTotal|round:1|escape:'html':'UTF-8'}{/if}" />
+          <meta itemprop="bestRating" content = "5" />
+        </div>
+      </div> <!-- .comments_note -->
     {/if}
 
     <ul class="comments_advices">
-        {if $nbComments != 0}
-            <li>
-                <a href="#idTab5" class="reviews">
-                    {l s='Read reviews' mod='productcomments'} (<span itemprop="reviewCount">{$nbComments}</span>)
-                </a>
-            </li>
-        {/if}
-        {if ($too_early == false AND ($is_logged OR $allow_guests))}
-            <li>
-                <a class="open-comment-form" href="#new_comment_form">
-                    {l s='Write a review' mod='productcomments'}
-                </a>
-            </li>
-        {/if}
+      {if $nbComments != 0}
+        <li>
+          <a href="#idTab5" class="reviews">
+            {l s='Read reviews' mod='productcomments'} (<span itemprop="reviewCount">{$nbComments}</span>)
+          </a>
+        </li>
+      {/if}
+      {if ($too_early == false AND ($is_logged OR $allow_guests))}
+        <li>
+          <a class="open-comment-form" href="#new_comment_form">
+            {l s='Write a review' mod='productcomments'}
+          </a>
+        </li>
+      {/if}
     </ul>
-</div>
+  </div>
 {/if}
 <!--  /Module ProductComments -->

--- a/themes/community-theme-16/modules/productcomments/productcomments.tpl
+++ b/themes/community-theme-16/modules/productcomments/productcomments.tpl
@@ -23,173 +23,173 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div id="idTab5">
-    <div id="product_comments_block_tab">
-        {if $comments}
-            {foreach from=$comments item=comment}
-                {if $comment.content}
-                <div class="comment row" itemprop="review" itemscope itemtype="https://schema.org/Review">
-                    <div class="comment_author col-sm-2">
-                        <span>{l s='Grade' mod='productcomments'}&nbsp;</span>
-                        <div class="star_content clearfix"  itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
-                            {section name="i" start=0 loop=5 step=1}
-                                {if $comment.grade le $smarty.section.i.index}
-                                    <div class="star"></div>
-                                {else}
-                                    <div class="star star_on"></div>
-                                {/if}
-                            {/section}
-                            <meta itemprop="worstRating" content = "0" />
-                            <meta itemprop="ratingValue" content = "{$comment.grade|escape:'html':'UTF-8'}" />
-                            <meta itemprop="bestRating" content = "5" />
-                        </div>
-                        <div class="comment_author_infos">
-                            <strong itemprop="author">{$comment.customer_name|escape:'html':'UTF-8'}</strong>
-                            <meta itemprop="datePublished" content="{$comment.date_add|escape:'html':'UTF-8'|substr:0:10}" />
-                            <em>{dateFormat date=$comment.date_add|escape:'html':'UTF-8' full=0}</em>
-                        </div>
-                    </div> <!-- .comment_author -->
+  <div id="product_comments_block_tab">
+    {if $comments}
+      {foreach from=$comments item=comment}
+        {if $comment.content}
+          <div class="comment row" itemprop="review" itemscope itemtype="https://schema.org/Review">
+            <div class="comment_author col-sm-2">
+              <span>{l s='Grade' mod='productcomments'}&nbsp;</span>
+              <div class="star_content clearfix"  itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
+                {section name="i" start=0 loop=5 step=1}
+                  {if $comment.grade le $smarty.section.i.index}
+                    <div class="star"></div>
+                  {else}
+                    <div class="star star_on"></div>
+                  {/if}
+                {/section}
+                <meta itemprop="worstRating" content = "0" />
+                <meta itemprop="ratingValue" content = "{$comment.grade|escape:'html':'UTF-8'}" />
+                <meta itemprop="bestRating" content = "5" />
+              </div>
+              <div class="comment_author_infos">
+                <strong itemprop="author">{$comment.customer_name|escape:'html':'UTF-8'}</strong>
+                <meta itemprop="datePublished" content="{$comment.date_add|escape:'html':'UTF-8'|substr:0:10}" />
+                <em>{dateFormat date=$comment.date_add|escape:'html':'UTF-8' full=0}</em>
+              </div>
+            </div> <!-- .comment_author -->
 
-                    <div class="comment_details col-sm-10">
-                        <p itemprop="name" class="title_block">
-                            <strong>{$comment.title}</strong>
-                        </p>
-                        <p itemprop="reviewBody">{$comment.content|escape:'html':'UTF-8'|nl2br}</p>
-                        <ul>
-                            {if $comment.total_advice > 0}
-                                <li>
-                                    {l s='%1$d out of %2$d people found this review useful.' sprintf=[$comment.total_useful,$comment.total_advice] mod='productcomments'}
-                                </li>
-                            {/if}
-                            {if $is_logged}
-                                {if !$comment.customer_advice}
-                                <li>
-                                    {l s='Was this comment useful to you?' mod='productcomments'}
-                                    <button class="usefulness_btn btn btn-default button button-small" data-is-usefull="1" data-id-product-comment="{$comment.id_product_comment}">
-                                        <span>{l s='Yes' mod='productcomments'}</span>
-                                    </button>
-                                    <button class="usefulness_btn btn btn-default button button-small" data-is-usefull="0" data-id-product-comment="{$comment.id_product_comment}">
-                                        <span>{l s='No' mod='productcomments'}</span>
-                                    </button>
-                                </li>
-                                {/if}
-                                {if !$comment.customer_report}
-                                <li>
-                                    <span class="report_btn" data-id-product-comment="{$comment.id_product_comment}">
-                                        {l s='Report abuse' mod='productcomments'}
-                                    </span>
-                                </li>
-                                {/if}
-                            {/if}
-                        </ul>
-                    </div><!-- .comment_details -->
-
-                </div> <!-- .comment -->
+            <div class="comment_details col-sm-10">
+              <p itemprop="name" class="title_block">
+                <strong>{$comment.title}</strong>
+              </p>
+              <p itemprop="reviewBody">{$comment.content|escape:'html':'UTF-8'|nl2br}</p>
+              <ul>
+                {if $comment.total_advice > 0}
+                  <li>
+                    {l s='%1$d out of %2$d people found this review useful.' sprintf=[$comment.total_useful,$comment.total_advice] mod='productcomments'}
+                  </li>
                 {/if}
-            {/foreach}
-            {if (!$too_early AND ($is_logged OR $allow_guests))}
-            <p class="align_center">
-                <a id="new_comment_tab_btn" class="btn btn-default button button-small open-comment-form" href="#new_comment_form">
-                    <span>{l s='Write your review!' mod='productcomments'}</span>
-                </a>
-            </p>
-            {/if}
-        {else}
-            {if (!$too_early AND ($is_logged OR $allow_guests))}
-            <p class="align_center">
-                <a id="new_comment_tab_btn" class="btn btn-default button button-small open-comment-form" href="#new_comment_form">
-                    <span>{l s='Be the first to write your review!' mod='productcomments'}</span>
-                </a>
-            </p>
-            {else}
-            <p class="align_center">{l s='No customer reviews for the moment.' mod='productcomments'}</p>
-            {/if}
+                {if $is_logged}
+                  {if !$comment.customer_advice}
+                    <li>
+                      {l s='Was this comment useful to you?' mod='productcomments'}
+                      <button class="usefulness_btn btn btn-default button button-small" data-is-usefull="1" data-id-product-comment="{$comment.id_product_comment}">
+                        <span>{l s='Yes' mod='productcomments'}</span>
+                      </button>
+                      <button class="usefulness_btn btn btn-default button button-small" data-is-usefull="0" data-id-product-comment="{$comment.id_product_comment}">
+                        <span>{l s='No' mod='productcomments'}</span>
+                      </button>
+                    </li>
+                  {/if}
+                  {if !$comment.customer_report}
+                    <li>
+                      <span class="report_btn" data-id-product-comment="{$comment.id_product_comment}">
+                          {l s='Report abuse' mod='productcomments'}
+                      </span>
+                    </li>
+                  {/if}
+                {/if}
+              </ul>
+            </div><!-- .comment_details -->
+
+          </div> <!-- .comment -->
         {/if}
-    </div> <!-- #product_comments_block_tab -->
+      {/foreach}
+      {if (!$too_early AND ($is_logged OR $allow_guests))}
+        <p class="align_center">
+          <a id="new_comment_tab_btn" class="btn btn-default button button-small open-comment-form" href="#new_comment_form">
+            <span>{l s='Write your review!' mod='productcomments'}</span>
+          </a>
+        </p>
+      {/if}
+    {else}
+      {if (!$too_early AND ($is_logged OR $allow_guests))}
+        <p class="align_center">
+          <a id="new_comment_tab_btn" class="btn btn-default button button-small open-comment-form" href="#new_comment_form">
+            <span>{l s='Be the first to write your review!' mod='productcomments'}</span>
+          </a>
+        </p>
+      {else}
+        <p class="align_center">{l s='No customer reviews for the moment.' mod='productcomments'}</p>
+      {/if}
+    {/if}
+  </div> <!-- #product_comments_block_tab -->
 </div>
 
 <!-- Fancybox -->
 <div style="display: none;">
-    <div id="new_comment_form">
-        <form id="id_new_comment_form" action="#">
-            <h2 class="page-subheading">
-                {l s='Write a review' mod='productcomments'}
-            </h2>
-            <div class="row">
-                {if isset($product) && $product}
-                    <div class="product clearfix  col-xs-12 col-sm-6">
-                        <img src="{$productcomment_cover_image}" height="{$mediumSize.height}" width="{$mediumSize.width}" alt="{$product->name|escape:'html':'UTF-8'}" />
-                        <div class="product_desc">
-                            <p class="product_name">
-                                <strong>{$product->name}</strong>
-                            </p>
-                            {$product->description_short}
-                        </div>
-                    </div>
-                {/if}
-                <div class="new_comment_form_content col-xs-12 col-sm-6">
-                    <div id="new_comment_form_error" class="error" style="display: none; padding: 15px 25px">
-                        <ul></ul>
-                    </div>
-                    {if $criterions|@count > 0}
-                        <ul id="criterions_list">
-                        {foreach from=$criterions item='criterion'}
-                            <li>
-                                <label>{$criterion.name|escape:'html':'UTF-8'}:</label>
-                                <div class="star_content">
-                                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="1" />
-                                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="2" />
-                                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="3" />
-                                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="4" checked="checked" />
-                                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="5" />
-                                </div>
-                                <div class="clearfix"></div>
-                            </li>
-                        {/foreach}
-                        </ul>
-                    {/if}
-                    <label for="comment_title">
-                        {l s='Title:' mod='productcomments'} <sup class="required">*</sup>
-                    </label>
-                    <input id="comment_title" name="title" type="text" value=""/>
-                    <label for="content">
-                        {l s='Comment:' mod='productcomments'} <sup class="required">*</sup>
-                    </label>
-                    <textarea id="content" name="content"></textarea>
-                    {if $allow_guests == true && !$is_logged}
-                        <label>
-                            {l s='Your name:' mod='productcomments'} <sup class="required">*</sup>
-                        </label>
-                        <input id="commentCustomerName" name="customer_name" type="text" value=""/>
-                    {/if}
-                    <div id="new_comment_form_footer">
-                        <input id="id_product_comment_send" name="id_product" type="hidden" value='{$id_product_comment_form}' />
-                        <p class="fl required"><sup>*</sup> {l s='Required fields' mod='productcomments'}</p>
-                        <p class="fr">
-                            <button id="submitNewMessage" name="submitMessage" type="submit" class="btn button button-small">
-                                <span>{l s='Submit' mod='productcomments'}</span>
-                            </button>&nbsp;
-                            {l s='or' mod='productcomments'}&nbsp;
-                            <a class="closefb" href="#">
-                                {l s='Cancel' mod='productcomments'}
-                            </a>
-                        </p>
-                        <div class="clearfix"></div>
-                    </div> <!-- #new_comment_form_footer -->
-                </div>
+  <div id="new_comment_form">
+    <form id="id_new_comment_form" action="#">
+      <h2 class="page-subheading">
+        {l s='Write a review' mod='productcomments'}
+      </h2>
+      <div class="row">
+        {if isset($product) && $product}
+          <div class="product clearfix  col-xs-12 col-sm-6">
+            <img src="{$productcomment_cover_image}" height="{$mediumSize.height}" width="{$mediumSize.width}" alt="{$product->name|escape:'html':'UTF-8'}" />
+            <div class="product_desc">
+              <p class="product_name">
+                <strong>{$product->name}</strong>
+              </p>
+              {$product->description_short}
             </div>
-        </form><!-- /end new_comment_form_content -->
-    </div>
+          </div>
+        {/if}
+        <div class="new_comment_form_content col-xs-12 col-sm-6">
+          <div id="new_comment_form_error" class="error" style="display: none; padding: 15px 25px">
+            <ul></ul>
+          </div>
+          {if $criterions|@count > 0}
+            <ul id="criterions_list">
+              {foreach from=$criterions item='criterion'}
+                <li>
+                  <label>{$criterion.name|escape:'html':'UTF-8'}:</label>
+                  <div class="star_content">
+                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="1" />
+                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="2" />
+                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="3" />
+                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="4" checked="checked" />
+                    <input class="star not_uniform" type="radio" name="criterion[{$criterion.id_product_comment_criterion|round}]" value="5" />
+                  </div>
+                  <div class="clearfix"></div>
+                </li>
+              {/foreach}
+            </ul>
+          {/if}
+          <label for="comment_title">
+            {l s='Title:' mod='productcomments'} <sup class="required">*</sup>
+          </label>
+          <input id="comment_title" name="title" type="text" value=""/>
+          <label for="content">
+            {l s='Comment:' mod='productcomments'} <sup class="required">*</sup>
+          </label>
+          <textarea id="content" name="content"></textarea>
+          {if $allow_guests == true && !$is_logged}
+            <label>
+              {l s='Your name:' mod='productcomments'} <sup class="required">*</sup>
+            </label>
+            <input id="commentCustomerName" name="customer_name" type="text" value=""/>
+          {/if}
+          <div id="new_comment_form_footer">
+            <input id="id_product_comment_send" name="id_product" type="hidden" value='{$id_product_comment_form}' />
+            <p class="fl required"><sup>*</sup> {l s='Required fields' mod='productcomments'}</p>
+            <p class="fr">
+              <button id="submitNewMessage" name="submitMessage" type="submit" class="btn button button-small">
+                <span>{l s='Submit' mod='productcomments'}</span>
+              </button>&nbsp;
+              {l s='or' mod='productcomments'}&nbsp;
+              <a class="closefb" href="#">
+                {l s='Cancel' mod='productcomments'}
+              </a>
+            </p>
+            <div class="clearfix"></div>
+          </div> <!-- #new_comment_form_footer -->
+        </div>
+      </div>
+    </form><!-- /end new_comment_form_content -->
+  </div>
 </div>
 <!-- End fancybox -->
 {strip}
-{addJsDef productcomments_controller_url=$productcomments_controller_url|@addcslashes:'\''}
-{addJsDef moderation_active=$moderation_active|boolval}
-{addJsDef productcomments_url_rewrite=$productcomments_url_rewriting_activated|boolval}
-{addJsDef secure_key=$secure_key}
+  {addJsDef productcomments_controller_url=$productcomments_controller_url|@addcslashes:'\''}
+  {addJsDef moderation_active=$moderation_active|boolval}
+  {addJsDef productcomments_url_rewrite=$productcomments_url_rewriting_activated|boolval}
+  {addJsDef secure_key=$secure_key}
 
-{addJsDefL name=confirm_report_message}{l s='Are you sure that you want to report this comment?' mod='productcomments' js=1}{/addJsDefL}
-{addJsDefL name=productcomment_added}{l s='Your comment has been added!' mod='productcomments' js=1}{/addJsDefL}
-{addJsDefL name=productcomment_added_moderation}{l s='Your comment has been added and will be available once approved by a moderator.' mod='productcomments' js=1}{/addJsDefL}
-{addJsDefL name=productcomment_title}{l s='New comment' mod='productcomments' js=1}{/addJsDefL}
-{addJsDefL name=productcomment_ok}{l s='OK' mod='productcomments' js=1}{/addJsDefL}
+  {addJsDefL name=confirm_report_message}{l s='Are you sure that you want to report this comment?' mod='productcomments' js=1}{/addJsDefL}
+  {addJsDefL name=productcomment_added}{l s='Your comment has been added!' mod='productcomments' js=1}{/addJsDefL}
+  {addJsDefL name=productcomment_added_moderation}{l s='Your comment has been added and will be available once approved by a moderator.' mod='productcomments' js=1}{/addJsDefL}
+  {addJsDefL name=productcomment_title}{l s='New comment' mod='productcomments' js=1}{/addJsDefL}
+  {addJsDefL name=productcomment_ok}{l s='OK' mod='productcomments' js=1}{/addJsDefL}
 {/strip}

--- a/themes/community-theme-16/modules/productcomments/productcomments_reviews.tpl
+++ b/themes/community-theme-16/modules/productcomments/productcomments_reviews.tpl
@@ -24,19 +24,19 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($nbComments) && $nbComments > 0}
-    <div class="comments_note" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-        <div class="star_content clearfix">
-            {section name="i" start=0 loop=5 step=1}
-                {if $averageTotal le $smarty.section.i.index}
-                    <div class="star"></div>
-                {else}
-                    <div class="star star_on"></div>
-                {/if}
-            {/section}
-            <meta itemprop="worstRating" content = "0" />
-            <meta itemprop="ratingValue" content = "{if isset($ratings.avg)}{$ratings.avg|round:1|escape:'html':'UTF-8'}{else}{$averageTotal|round:1|escape:'html':'UTF-8'}{/if}" />
-            <meta itemprop="bestRating" content = "5" />
-        </div>
-        <span class="nb-comments"><span itemprop="reviewCount">{$nbComments}</span> {l s='Review(s)' mod='productcomments'}</span>
+  <div class="comments_note" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+    <div class="star_content clearfix">
+      {section name="i" start=0 loop=5 step=1}
+        {if $averageTotal le $smarty.section.i.index}
+          <div class="star"></div>
+        {else}
+          <div class="star star_on"></div>
+        {/if}
+      {/section}
+      <meta itemprop="worstRating" content = "0" />
+      <meta itemprop="ratingValue" content = "{if isset($ratings.avg)}{$ratings.avg|round:1|escape:'html':'UTF-8'}{else}{$averageTotal|round:1|escape:'html':'UTF-8'}{/if}" />
+      <meta itemprop="bestRating" content = "5" />
     </div>
+    <span class="nb-comments"><span itemprop="reviewCount">{$nbComments}</span> {l s='Review(s)' mod='productcomments'}</span>
+  </div>
 {/if}

--- a/themes/community-theme-16/modules/productcomments/products-comparison.tpl
+++ b/themes/community-theme-16/modules/productcomments/products-comparison.tpl
@@ -24,80 +24,80 @@
 *}
 
 <tr class="comparison_header">
-    <td class="feature-name td_empty">
-        <span>{l s='Comments' mod='productcomments'}</span>
-    </td>
-    {foreach from=$list_ids_product item=id_product}
-        <td class="product-{$id_product}"></td>
-    {/foreach}
+  <td class="feature-name td_empty">
+    <span>{l s='Comments' mod='productcomments'}</span>
+  </td>
+  {foreach from=$list_ids_product item=id_product}
+    <td class="product-{$id_product}"></td>
+  {/foreach}
 </tr>
 
 {foreach from=$grades item=grade key=grade_id}
-    <tr>
+  <tr>
     {cycle values='comparison_feature_odd,comparison_feature_even' assign='classname'}
-        <td class="{$classname} feature-name">
-            <strong>{$grade}</strong>
-        </td>
-        {foreach from=$list_ids_product item=id_product}
-            {assign var='tab_grade' value=$product_grades[$grade_id]}
-            <td class="{$classname} comparison_infos ajax_block_product product-{$id_product}" align="center">
-                {if isset($tab_grade[$id_product]) AND $tab_grade[$id_product]}
-                    <div class="product-rating">
-                        {section loop=6 step=1 start=1 name=average}
-                            <input class="auto-submit-star not_uniform" disabled="disabled" type="radio" name="{$grade_id}_{$id_product}_{$smarty.section.average.index}" {if isset($tab_grade[$id_product]) AND $tab_grade[$id_product]|round neq 0 and $smarty.section.average.index eq $tab_grade[$id_product]|round}checked="checked"{/if} />
-                        {/section}
-                    </div>
-                {else}
-                    -
-                {/if}
-            </td>
-        {/foreach}
-    </tr>
+    <td class="{$classname} feature-name">
+      <strong>{$grade}</strong>
+    </td>
+    {foreach from=$list_ids_product item=id_product}
+      {assign var='tab_grade' value=$product_grades[$grade_id]}
+      <td class="{$classname} comparison_infos ajax_block_product product-{$id_product}" align="center">
+        {if isset($tab_grade[$id_product]) AND $tab_grade[$id_product]}
+          <div class="product-rating">
+            {section loop=6 step=1 start=1 name=average}
+              <input class="auto-submit-star not_uniform" disabled="disabled" type="radio" name="{$grade_id}_{$id_product}_{$smarty.section.average.index}" {if isset($tab_grade[$id_product]) AND $tab_grade[$id_product]|round neq 0 and $smarty.section.average.index eq $tab_grade[$id_product]|round}checked="checked"{/if} />
+            {/section}
+          </div>
+        {else}
+          -
+        {/if}
+      </td>
+    {/foreach}
+  </tr>
 {/foreach}
 
 {cycle values='comparison_feature_odd,comparison_feature_even' assign='classname'}
 <tr>
-    <td  class="{$classname} feature-name">
-        <strong>{l s='Average' mod='productcomments'}</strong>
+  <td  class="{$classname} feature-name">
+    <strong>{l s='Average' mod='productcomments'}</strong>
+  </td>
+  {foreach from=$list_ids_product item=id_product}
+    <td class="{$classname} comparison_infos product-{$id_product}" align="center" >
+      {if isset($list_product_average[$id_product]) AND $list_product_average[$id_product]}
+        <div class="product-rating">
+          {section loop=6 step=1 start=1 name=average}
+            <input class="auto-submit-star not_uniform" disabled="disabled" type="radio" name="average_{$id_product}" {if $list_product_average[$id_product]|round neq 0 and $smarty.section.average.index eq $list_product_average[$id_product]|round}checked="checked"{/if} />
+          {/section}
+        </div>
+      {else}
+        -
+      {/if}
     </td>
-    {foreach from=$list_ids_product item=id_product}
-        <td class="{$classname} comparison_infos product-{$id_product}" align="center" >
-            {if isset($list_product_average[$id_product]) AND $list_product_average[$id_product]}
-                <div class="product-rating">
-                    {section loop=6 step=1 start=1 name=average}
-                        <input class="auto-submit-star not_uniform" disabled="disabled" type="radio" name="average_{$id_product}" {if $list_product_average[$id_product]|round neq 0 and $smarty.section.average.index eq $list_product_average[$id_product]|round}checked="checked"{/if} />
-                    {/section}
-                </div>
-            {else}
-                -
-            {/if}
-        </td>
-    {/foreach}
+  {/foreach}
 </tr>
 
 <tr>
-<td class="{$classname} comparison_infos feature-name">&nbsp;</td>
-    {foreach from=$list_ids_product item=id_product}
-        <td class="{$classname} comparison_infos product-{$id_product}" align="center" >
-            {if isset($product_comments[$id_product]) AND $product_comments[$id_product]}
-                <a class="btn btn-default button button-small" href="#" data-id-product-comment="{$id_product|intval}" rel="#comments_{$id_product|intval}">
-                    <span>
-                        {l s='View comments' mod='productcomments'}<i class="icon-chevron-right right"></i>
-                    </span>
-                </a>
-                <div style="display:none" id="comments_{$id_product}">
-                    {foreach from=$product_comments[$id_product] item=comment}
-                        <div class="well well-sm">
-                            <strong>{$comment.customer_name|escape:'html':'UTF-8'} </strong>
-                            <small class="date"> {dateFormat date=$comment.date_add|escape:'html':'UTF-8' full=0}</small>
-                            <div class="comment_title">{$comment.title|escape:'html':'UTF-8'|nl2br}</div>
-                            <div class="comment_content">{$comment.content|escape:'html':'UTF-8'|nl2br}</div>
-                        </div>
-                    {/foreach}
-                </div>
-            {else}
-                -
-            {/if}
-        </td>
-    {/foreach}
+  <td class="{$classname} comparison_infos feature-name">&nbsp;</td>
+  {foreach from=$list_ids_product item=id_product}
+    <td class="{$classname} comparison_infos product-{$id_product}" align="center" >
+      {if isset($product_comments[$id_product]) AND $product_comments[$id_product]}
+        <a class="btn btn-default button button-small" href="#" data-id-product-comment="{$id_product|intval}" rel="#comments_{$id_product|intval}">
+          <span>
+              {l s='View comments' mod='productcomments'}<i class="icon-chevron-right right"></i>
+          </span>
+        </a>
+        <div style="display:none" id="comments_{$id_product}">
+          {foreach from=$product_comments[$id_product] item=comment}
+            <div class="well well-sm">
+              <strong>{$comment.customer_name|escape:'html':'UTF-8'} </strong>
+              <small class="date"> {dateFormat date=$comment.date_add|escape:'html':'UTF-8' full=0}</small>
+              <div class="comment_title">{$comment.title|escape:'html':'UTF-8'|nl2br}</div>
+              <div class="comment_content">{$comment.content|escape:'html':'UTF-8'|nl2br}</div>
+            </div>
+          {/foreach}
+        </div>
+      {else}
+        -
+      {/if}
+    </td>
+  {/foreach}
 </tr>

--- a/themes/community-theme-16/modules/productscategory/productscategory.tpl
+++ b/themes/community-theme-16/modules/productscategory/productscategory.tpl
@@ -23,52 +23,52 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if count($categoryProducts) > 0 && $categoryProducts !== false}
-<section class="page-product-box blockproductscategory">
+  <section class="page-product-box blockproductscategory">
     <h3 class="productscategory_h3 page-product-heading">
-        {if $categoryProducts|@count == 1}
-            {l s='%s other product in the same category:' sprintf=[$categoryProducts|@count] mod='productscategory'}
-        {else}
-            {l s='%s other products in the same category:' sprintf=[$categoryProducts|@count] mod='productscategory'}
-        {/if}
+      {if $categoryProducts|@count == 1}
+        {l s='%s other product in the same category:' sprintf=[$categoryProducts|@count] mod='productscategory'}
+      {else}
+        {l s='%s other products in the same category:' sprintf=[$categoryProducts|@count] mod='productscategory'}
+      {/if}
     </h3>
     <div id="productscategory_list" class="clearfix">
-        <ul id="bxslider1" class="bxslider clearfix">
+      <ul id="bxslider1" class="bxslider clearfix">
         {foreach from=$categoryProducts item='categoryProduct' name=categoryProduct}
-            <li class="product-box item">
-                <a href="{$link->getProductLink($categoryProduct.id_product, $categoryProduct.link_rewrite, $categoryProduct.category, $categoryProduct.ean13)}" class="lnk_img product-image" title="{$categoryProduct.name|htmlspecialchars}"><img src="{$link->getImageLink($categoryProduct.link_rewrite, $categoryProduct.id_image, 'home_default')|escape:'html':'UTF-8'}" alt="{$categoryProduct.name|htmlspecialchars}" /></a>
-                <h5 itemprop="name" class="product-name">
-                    <a href="{$link->getProductLink($categoryProduct.id_product, $categoryProduct.link_rewrite, $categoryProduct.category, $categoryProduct.ean13)|escape:'html':'UTF-8'}" title="{$categoryProduct.name|htmlspecialchars}">{$categoryProduct.name|truncate:14:'...'|escape:'html':'UTF-8'}</a>
-                </h5>
-                {if $ProdDisplayPrice && $categoryProduct.show_price == 1 && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
-                    <p class="price_display">
-                    {if isset($categoryProduct.specific_prices) && $categoryProduct.specific_prices
-                    && ($categoryProduct.displayed_price|number_format:2 !== $categoryProduct.price_without_reduction|number_format:2)}
+          <li class="product-box item">
+            <a href="{$link->getProductLink($categoryProduct.id_product, $categoryProduct.link_rewrite, $categoryProduct.category, $categoryProduct.ean13)}" class="lnk_img product-image" title="{$categoryProduct.name|htmlspecialchars}"><img src="{$link->getImageLink($categoryProduct.link_rewrite, $categoryProduct.id_image, 'home_default')|escape:'html':'UTF-8'}" alt="{$categoryProduct.name|htmlspecialchars}" /></a>
+            <h5 itemprop="name" class="product-name">
+              <a href="{$link->getProductLink($categoryProduct.id_product, $categoryProduct.link_rewrite, $categoryProduct.category, $categoryProduct.ean13)|escape:'html':'UTF-8'}" title="{$categoryProduct.name|htmlspecialchars}">{$categoryProduct.name|truncate:14:'...'|escape:'html':'UTF-8'}</a>
+            </h5>
+            {if $ProdDisplayPrice && $categoryProduct.show_price == 1 && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
+              <p class="price_display">
+                {if isset($categoryProduct.specific_prices) && $categoryProduct.specific_prices
+                && ($categoryProduct.displayed_price|number_format:2 !== $categoryProduct.price_without_reduction|number_format:2)}
 
-                        <span class="price special-price">{convertPrice price=$categoryProduct.displayed_price}</span>
-                        {if $categoryProduct.specific_prices.reduction && $categoryProduct.specific_prices.reduction_type == 'percentage'}
-                            <span class="price-percent-reduction small">-{$categoryProduct.specific_prices.reduction * 100}%</span>
-                        {/if}
-                        <span class="old-price">{displayWtPrice p=$categoryProduct.price_without_reduction}</span>
+                  <span class="price special-price">{convertPrice price=$categoryProduct.displayed_price}</span>
+                  {if $categoryProduct.specific_prices.reduction && $categoryProduct.specific_prices.reduction_type == 'percentage'}
+                    <span class="price-percent-reduction small">-{$categoryProduct.specific_prices.reduction * 100}%</span>
+                  {/if}
+                  <span class="old-price">{displayWtPrice p=$categoryProduct.price_without_reduction}</span>
 
-                    {else}
-                        <span class="price">{convertPrice price=$categoryProduct.displayed_price}</span>
-                    {/if}
-                    </p>
                 {else}
-                <br />
+                  <span class="price">{convertPrice price=$categoryProduct.displayed_price}</span>
                 {/if}
-                <div class="clearfix" style="margin-top:5px">
-                    {if !$PS_CATALOG_MODE && ($categoryProduct.allow_oosp || $categoryProduct.quantity > 0)}
-                        <div class="no-print">
-                            <a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$categoryProduct.id_product|intval}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" data-id-product="{$categoryProduct.id_product|intval}" title="{l s='Add to cart' mod='productscategory'}">
-                                <span>{l s='Add to cart' mod='productscategory'}</span>
-                            </a>
-                        </div>
-                    {/if}
+              </p>
+            {else}
+              <br />
+            {/if}
+            <div class="clearfix" style="margin-top:5px">
+              {if !$PS_CATALOG_MODE && ($categoryProduct.allow_oosp || $categoryProduct.quantity > 0)}
+                <div class="no-print">
+                  <a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$categoryProduct.id_product|intval}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" data-id-product="{$categoryProduct.id_product|intval}" title="{l s='Add to cart' mod='productscategory'}">
+                    <span>{l s='Add to cart' mod='productscategory'}</span>
+                  </a>
                 </div>
-            </li>
+              {/if}
+            </div>
+          </li>
         {/foreach}
-        </ul>
+      </ul>
     </div>
-</section>
+  </section>
 {/if}

--- a/themes/community-theme-16/modules/referralprogram/views/templates/front/program.tpl
+++ b/themes/community-theme-16/modules/referralprogram/views/templates/front/program.tpl
@@ -27,196 +27,196 @@
 <h1 class="page-heading">{l s='Referral program' mod='referralprogram'}</h1>
 
 {if $error}
-    <p class="alert alert-danger">
-        {if $error == 'conditions not valided'}
-            {l s='You need to agree to the conditions of the referral program!' mod='referralprogram'}
-        {elseif $error == 'email invalid'}
-            {l s='At least one e-mail address is invalid!' mod='referralprogram'}
-        {elseif $error == 'name invalid'}
-            {l s='At least one first name or last name is invalid!' mod='referralprogram'}
-        {elseif $error == 'email exists'}
-            {l s='Someone with this e-mail address has already been sponsored!' mod='referralprogram'}: {foreach from=$mails_exists item=mail}{$mail} {/foreach}
-        {elseif $error == 'no revive checked'}
-            {l s='Please mark at least one checkbox' mod='referralprogram'}
-        {elseif $error == 'cannot add friends'}
-            {l s='Cannot add friends to database' mod='referralprogram'}
-        {/if}
-    </p>
+  <p class="alert alert-danger">
+    {if $error == 'conditions not valided'}
+      {l s='You need to agree to the conditions of the referral program!' mod='referralprogram'}
+    {elseif $error == 'email invalid'}
+      {l s='At least one e-mail address is invalid!' mod='referralprogram'}
+    {elseif $error == 'name invalid'}
+      {l s='At least one first name or last name is invalid!' mod='referralprogram'}
+    {elseif $error == 'email exists'}
+      {l s='Someone with this e-mail address has already been sponsored!' mod='referralprogram'}: {foreach from=$mails_exists item=mail}{$mail} {/foreach}
+    {elseif $error == 'no revive checked'}
+      {l s='Please mark at least one checkbox' mod='referralprogram'}
+    {elseif $error == 'cannot add friends'}
+      {l s='Cannot add friends to database' mod='referralprogram'}
+    {/if}
+  </p>
 {/if}
 
 {if $invitation_sent}
-    <p class="alert alert-success">
+  <p class="alert alert-success">
     {if $nbInvitation > 1}
-        {l s='E-mails have been sent to your friends!' mod='referralprogram'}
+      {l s='E-mails have been sent to your friends!' mod='referralprogram'}
     {else}
-        {l s='An e-mail has been sent to your friend!' mod='referralprogram'}
+      {l s='An e-mail has been sent to your friend!' mod='referralprogram'}
     {/if}
-    </p>
+  </p>
 {/if}
 
 {if $revive_sent}
-    <p class="alert alert-success">
+  <p class="alert alert-success">
     {if $nbRevive > 1}
-        {l s='Reminder e-mails have been sent to your friends!' mod='referralprogram'}
+      {l s='Reminder e-mails have been sent to your friends!' mod='referralprogram'}
     {else}
-        {l s='A reminder e-mail has been sent to your friend!' mod='referralprogram'}
+      {l s='A reminder e-mail has been sent to your friend!' mod='referralprogram'}
     {/if}
-    </p>
+  </p>
 {/if}
 <ul class="nav nav-tabs" id="idTabs">
-    <li class="active"><a data-toggle="tab" href="#idTab1" class="tab-pane {if $activeTab eq 'sponsor'} active{/if}" title="{l s='Sponsor my friends' mod='referralprogram'}" rel="nofollow">{l s='Sponsor my friends' mod='referralprogram'}</a></li>
-    <li><a data-toggle="tab" href="#idTab2"  class="tab-pane {if $activeTab eq 'pending'} selected{/if}" title="{l s='List of pending friends' mod='referralprogram'}" rel="nofollow">{l s='Pending friends' mod='referralprogram'}</a></li>
-    <li><a data-toggle="tab" href="#idTab3" class="tab-pane {if $activeTab eq 'subscribed'} selected{/if}" title="{l s='List of friends I sponsored' mod='referralprogram'}" rel="nofollow">{l s='Friends I sponsored' mod='referralprogram'}</a></li>
+  <li class="active"><a data-toggle="tab" href="#idTab1" class="tab-pane {if $activeTab eq 'sponsor'} active{/if}" title="{l s='Sponsor my friends' mod='referralprogram'}" rel="nofollow">{l s='Sponsor my friends' mod='referralprogram'}</a></li>
+  <li><a data-toggle="tab" href="#idTab2"  class="tab-pane {if $activeTab eq 'pending'} selected{/if}" title="{l s='List of pending friends' mod='referralprogram'}" rel="nofollow">{l s='Pending friends' mod='referralprogram'}</a></li>
+  <li><a data-toggle="tab" href="#idTab3" class="tab-pane {if $activeTab eq 'subscribed'} selected{/if}" title="{l s='List of friends I sponsored' mod='referralprogram'}" rel="nofollow">{l s='Friends I sponsored' mod='referralprogram'}</a></li>
 </ul>
 <div class="sheets tab-content">
 
-    <div id="idTab1" class="tab-pane active">
-        <p class="bold">
-            <strong>{l s='Get a discount of %1$s for you and your friends by recommending this Website.' sprintf=[$discount] mod='referralprogram'}</strong>
-        </p>
-        {if $canSendInvitations}
-            <p>
-                {l s='It\'s quick and it\'s easy. Just fill in the first name, last name, and e-mail address(es) of your friend(s) in the fields below.' mod='referralprogram'}
-                {if $orderQuantity > 1}
-                    {l s='When one of them makes at least %d orders, ' sprintf=$orderQuantity mod='referralprogram'}
-                {else}
-                    {l s='When one of them makes at least %d order, ' sprintf=$orderQuantity mod='referralprogram'}
-                {/if},
-                {l s='he or she will receive a %1$s voucher and you will receive your own voucher worth %1$s.' sprintf=[$discount] mod='referralprogram'}
-            </p>
-            <form method="post" action="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" class="std">
-                <table class="table table-bordered">
-                <thead>
-                    <tr>
-                        <th class="first_item">&nbsp;</th>
-                        <th class="item">{l s='Last name' mod='referralprogram'}</th>
-                        <th class="item">{l s='First name' mod='referralprogram'}</th>
-                        <th class="last_item">{l s='E-mail' mod='referralprogram'}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {section name=friends start=0 loop=$nbFriends step=1}
-                    <tr class="{if $smarty.section.friends.index % 2}item{else}alternate_item{/if}">
-                        <td class="align_right">{$smarty.section.friends.iteration}</td>
-                        <td><input type="text" class="form-control" name="friendsLastName[{$smarty.section.friends.index}]" size="14" value="{if isset($smarty.post.friendsLastName[$smarty.section.friends.index])}{$smarty.post.friendsLastName[$smarty.section.friends.index]|escape:'html':'UTF-8'}{/if}" /></td>
-                        <td><input type="text" class="form-control" name="friendsFirstName[{$smarty.section.friends.index}]" size="14" value="{if isset($smarty.post.friendsFirstName[$smarty.section.friends.index])}{$smarty.post.friendsFirstName[$smarty.section.friends.index]|escape:'html':'UTF-8'}{/if}" /></td>
-                        <td><input type="text" class="form-control" name="friendsEmail[{$smarty.section.friends.index}]" size="20" value="{if isset($smarty.post.friendsEmail[$smarty.section.friends.index])}{$smarty.post.friendsEmail[$smarty.section.friends.index]|escape:'html':'UTF-8'}{/if}" /></td>
-                    </tr>
-                    {/section}
-                </tbody>
-                </table>
-                <p class="bold">
-                    <strong>{l s='Important: Your friends\' e-mail addresses will only be used in the referral program. They will never be used for other purposes.' mod='referralprogram'}</strong>
-                </p>
-                <p class="checkbox">
-                    <input type="checkbox" name="conditionsValided" id="conditionsValided" value="1" {if isset($smarty.post.conditionsValided) AND $smarty.post.conditionsValided eq 1}checked="checked"{/if} />
-                    <label for="conditionsValided">{l s='I agree to the terms of service and adhere to them unconditionally.' mod='referralprogram'}</label>
-                    <a href="{$link->getModuleLink('referralprogram', 'rules', ['height' => '500', 'width' => '400'], true)|escape:'html':'UTF-8'}" class="thickbox" title="{l s='Conditions of the referral program' mod='referralprogram'}" rel="nofollow">{l s='Read conditions.' mod='referralprogram'}</a>
-                </p>
-                <p class="see_email">
-                    {l s='Preview' mod='referralprogram'}
-                    {assign var="file" value="{$lang_iso}/referralprogram-invitation.html"}
-                    <a href="{$link->getModuleLink('referralprogram', 'email', ['height' => '500', 'width' => '600', 'mail' => {$file}], true)|escape:'html':'UTF-8'}" class="thickbox" title="{l s='Invitation e-mail' mod='referralprogram'}" rel="nofollow">{l s='the default e-mail' mod='referralprogram'}</a> {l s='that will be sent to your friend(s).' mod='referralprogram'}
-                </p>
-                <p class="submit">
-                    <button type="submit" id="submitSponsorFriends" name="submitSponsorFriends" class="btn btn-default button button-medium"><span>{l s='Validate' mod='referralprogram'}<i class="icon-chevron-right right"></i></span></button>
-                </p>
-            </form>
+  <div id="idTab1" class="tab-pane active">
+    <p class="bold">
+      <strong>{l s='Get a discount of %1$s for you and your friends by recommending this Website.' sprintf=[$discount] mod='referralprogram'}</strong>
+    </p>
+    {if $canSendInvitations}
+      <p>
+        {l s='It\'s quick and it\'s easy. Just fill in the first name, last name, and e-mail address(es) of your friend(s) in the fields below.' mod='referralprogram'}
+        {if $orderQuantity > 1}
+          {l s='When one of them makes at least %d orders, ' sprintf=$orderQuantity mod='referralprogram'}
         {else}
-            <p class="alert alert-warning">
-                {l s='To become a sponsor, you need to have completed at least' mod='referralprogram'} {$orderQuantity} {if $orderQuantity > 1}{l s='orders' mod='referralprogram'}{else}{l s='order' mod='referralprogram'}{/if}.
-            </p>
-        {/if}
-    </div>
-
-    <div id="idTab2" class="tab-pane">
-    {if $pendingFriends AND $pendingFriends|@count > 0}
-        <p>
-            {l s='These friends have not yet placed an order on this Website since you sponsored them, but you can try again! To do so, mark the checkboxes of the friend(s) you want to remind, then click on the button "Remind my friend(s)"' mod='referralprogram'}
-        </p>
-        <form method="post" action="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" class="std">
-            <table class="table table-bordered">
-            <thead>
-                <tr>
-                    <th class="first_item">&nbsp;</th>
-                    <th class="item">{l s='Last name' mod='referralprogram'}</th>
-                    <th class="item">{l s='First name' mod='referralprogram'}</th>
-                    <th class="item">{l s='E-mail' mod='referralprogram'}</th>
-                    <th class="last_item"><b>{l s='Last invitation' mod='referralprogram'}</b></th>
-                </tr>
-            </thead>
-            <tbody>
-            {foreach from=$pendingFriends item=pendingFriend name=myLoop}
-                <tr>
-                    <td>
-                        <input type="checkbox" name="friendChecked[{$pendingFriend.id_referralprogram}]" id="friendChecked[{$pendingFriend.id_referralprogram}]" value="1" />
-                    </td>
-                    <td>
-                        <label for="friendChecked[{$pendingFriend.id_referralprogram}]">{$pendingFriend.lastname|substr:0:22}</label>
-                    </td>
-                    <td>{$pendingFriend.firstname|substr:0:22}</td>
-                    <td>{$pendingFriend.email}</td>
-                    <td>{dateFormat date=$pendingFriend.date_upd full=1}</td>
-                </tr>
-            {/foreach}
-            </tbody>
-            </table>
-            <p class="submit">
-                <button type="submit" name="revive" id="revive" class="button_large btn btn-default">{l s='Remind my friend(s)' mod='referralprogram'}</button>
-            </p>
-        </form>
-        {else}
-            <p class="alert alert-warning">
-                {if $subscribeFriends AND $subscribeFriends|@count > 0}
-                    {l s='You have no pending invitations.' mod='referralprogram'}
-                {else}
-                    {l s='You have not sponsored any friends yet.' mod='referralprogram'}
-                {/if}
-            </p>
-        {/if}
-    </div>
-
-    <div id="idTab3" class="tab-pane">
-    {if $subscribeFriends AND $subscribeFriends|@count > 0}
-        <p>
-            {l s='Here are sponsored friends who have accepted your invitation:' mod='referralprogram'}
-        </p>
+          {l s='When one of them makes at least %d order, ' sprintf=$orderQuantity mod='referralprogram'}
+        {/if},
+        {l s='he or she will receive a %1$s voucher and you will receive your own voucher worth %1$s.' sprintf=[$discount] mod='referralprogram'}
+      </p>
+      <form method="post" action="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" class="std">
         <table class="table table-bordered">
-        <thead>
-            <tr>
-                <th class="first_item">&nbsp;</th>
-                <th class="item">{l s='Last name' mod='referralprogram'}</th>
-                <th class="item">{l s='First name' mod='referralprogram'}</th>
-                <th class="item">{l s='E-mail' mod='referralprogram'}</th>
-                <th class="last_item">{l s='Inscription date' mod='referralprogram'}</th>
+          <thead>
+          <tr>
+            <th class="first_item">&nbsp;</th>
+            <th class="item">{l s='Last name' mod='referralprogram'}</th>
+            <th class="item">{l s='First name' mod='referralprogram'}</th>
+            <th class="last_item">{l s='E-mail' mod='referralprogram'}</th>
+          </tr>
+          </thead>
+          <tbody>
+          {section name=friends start=0 loop=$nbFriends step=1}
+            <tr class="{if $smarty.section.friends.index % 2}item{else}alternate_item{/if}">
+              <td class="align_right">{$smarty.section.friends.iteration}</td>
+              <td><input type="text" class="form-control" name="friendsLastName[{$smarty.section.friends.index}]" size="14" value="{if isset($smarty.post.friendsLastName[$smarty.section.friends.index])}{$smarty.post.friendsLastName[$smarty.section.friends.index]|escape:'html':'UTF-8'}{/if}" /></td>
+              <td><input type="text" class="form-control" name="friendsFirstName[{$smarty.section.friends.index}]" size="14" value="{if isset($smarty.post.friendsFirstName[$smarty.section.friends.index])}{$smarty.post.friendsFirstName[$smarty.section.friends.index]|escape:'html':'UTF-8'}{/if}" /></td>
+              <td><input type="text" class="form-control" name="friendsEmail[{$smarty.section.friends.index}]" size="20" value="{if isset($smarty.post.friendsEmail[$smarty.section.friends.index])}{$smarty.post.friendsEmail[$smarty.section.friends.index]|escape:'html':'UTF-8'}{/if}" /></td>
             </tr>
+          {/section}
+          </tbody>
+        </table>
+        <p class="bold">
+          <strong>{l s='Important: Your friends\' e-mail addresses will only be used in the referral program. They will never be used for other purposes.' mod='referralprogram'}</strong>
+        </p>
+        <p class="checkbox">
+          <input type="checkbox" name="conditionsValided" id="conditionsValided" value="1" {if isset($smarty.post.conditionsValided) AND $smarty.post.conditionsValided eq 1}checked="checked"{/if} />
+          <label for="conditionsValided">{l s='I agree to the terms of service and adhere to them unconditionally.' mod='referralprogram'}</label>
+          <a href="{$link->getModuleLink('referralprogram', 'rules', ['height' => '500', 'width' => '400'], true)|escape:'html':'UTF-8'}" class="thickbox" title="{l s='Conditions of the referral program' mod='referralprogram'}" rel="nofollow">{l s='Read conditions.' mod='referralprogram'}</a>
+        </p>
+        <p class="see_email">
+          {l s='Preview' mod='referralprogram'}
+          {assign var="file" value="{$lang_iso}/referralprogram-invitation.html"}
+          <a href="{$link->getModuleLink('referralprogram', 'email', ['height' => '500', 'width' => '600', 'mail' => {$file}], true)|escape:'html':'UTF-8'}" class="thickbox" title="{l s='Invitation e-mail' mod='referralprogram'}" rel="nofollow">{l s='the default e-mail' mod='referralprogram'}</a> {l s='that will be sent to your friend(s).' mod='referralprogram'}
+        </p>
+        <p class="submit">
+          <button type="submit" id="submitSponsorFriends" name="submitSponsorFriends" class="btn btn-default button button-medium"><span>{l s='Validate' mod='referralprogram'}<i class="icon-chevron-right right"></i></span></button>
+        </p>
+      </form>
+    {else}
+      <p class="alert alert-warning">
+        {l s='To become a sponsor, you need to have completed at least' mod='referralprogram'} {$orderQuantity} {if $orderQuantity > 1}{l s='orders' mod='referralprogram'}{else}{l s='order' mod='referralprogram'}{/if}.
+      </p>
+    {/if}
+  </div>
+
+  <div id="idTab2" class="tab-pane">
+    {if $pendingFriends AND $pendingFriends|@count > 0}
+      <p>
+        {l s='These friends have not yet placed an order on this Website since you sponsored them, but you can try again! To do so, mark the checkboxes of the friend(s) you want to remind, then click on the button "Remind my friend(s)"' mod='referralprogram'}
+      </p>
+      <form method="post" action="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" class="std">
+        <table class="table table-bordered">
+          <thead>
+          <tr>
+            <th class="first_item">&nbsp;</th>
+            <th class="item">{l s='Last name' mod='referralprogram'}</th>
+            <th class="item">{l s='First name' mod='referralprogram'}</th>
+            <th class="item">{l s='E-mail' mod='referralprogram'}</th>
+            <th class="last_item"><b>{l s='Last invitation' mod='referralprogram'}</b></th>
+          </tr>
+          </thead>
+          <tbody>
+          {foreach from=$pendingFriends item=pendingFriend name=myLoop}
+            <tr>
+              <td>
+                <input type="checkbox" name="friendChecked[{$pendingFriend.id_referralprogram}]" id="friendChecked[{$pendingFriend.id_referralprogram}]" value="1" />
+              </td>
+              <td>
+                <label for="friendChecked[{$pendingFriend.id_referralprogram}]">{$pendingFriend.lastname|substr:0:22}</label>
+              </td>
+              <td>{$pendingFriend.firstname|substr:0:22}</td>
+              <td>{$pendingFriend.email}</td>
+              <td>{dateFormat date=$pendingFriend.date_upd full=1}</td>
+            </tr>
+          {/foreach}
+          </tbody>
+        </table>
+        <p class="submit">
+          <button type="submit" name="revive" id="revive" class="button_large btn btn-default">{l s='Remind my friend(s)' mod='referralprogram'}</button>
+        </p>
+      </form>
+    {else}
+      <p class="alert alert-warning">
+        {if $subscribeFriends AND $subscribeFriends|@count > 0}
+          {l s='You have no pending invitations.' mod='referralprogram'}
+        {else}
+          {l s='You have not sponsored any friends yet.' mod='referralprogram'}
+        {/if}
+      </p>
+    {/if}
+  </div>
+
+  <div id="idTab3" class="tab-pane">
+    {if $subscribeFriends AND $subscribeFriends|@count > 0}
+      <p>
+        {l s='Here are sponsored friends who have accepted your invitation:' mod='referralprogram'}
+      </p>
+      <table class="table table-bordered">
+        <thead>
+        <tr>
+          <th class="first_item">&nbsp;</th>
+          <th class="item">{l s='Last name' mod='referralprogram'}</th>
+          <th class="item">{l s='First name' mod='referralprogram'}</th>
+          <th class="item">{l s='E-mail' mod='referralprogram'}</th>
+          <th class="last_item">{l s='Inscription date' mod='referralprogram'}</th>
+        </tr>
         </thead>
         <tbody>
-            {foreach from=$subscribeFriends item=subscribeFriend name=myLoop}
-            <tr>
-                <td>{$smarty.foreach.myLoop.iteration}.</td>
-                <td>{$subscribeFriend.lastname|substr:0:22}</td>
-                <td>{$subscribeFriend.firstname|substr:0:22}</td>
-                <td>{$subscribeFriend.email}</td>
-                <td>{dateFormat date=$subscribeFriend.date_upd full=1}</td>
-            </tr>
-            {/foreach}
+        {foreach from=$subscribeFriends item=subscribeFriend name=myLoop}
+          <tr>
+            <td>{$smarty.foreach.myLoop.iteration}.</td>
+            <td>{$subscribeFriend.lastname|substr:0:22}</td>
+            <td>{$subscribeFriend.firstname|substr:0:22}</td>
+            <td>{$subscribeFriend.email}</td>
+            <td>{dateFormat date=$subscribeFriend.date_upd full=1}</td>
+          </tr>
+        {/foreach}
         </tbody>
-        </table>
+      </table>
     {else}
-        <p class="alert alert-warning">
-            {l s='No sponsored friends have accepted your invitation yet.' mod='referralprogram'}
-        </p>
+      <p class="alert alert-warning">
+        {l s='No sponsored friends have accepted your invitation yet.' mod='referralprogram'}
+      </p>
     {/if}
-    </div>
+  </div>
 </div>
 
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='Back to Your Account' mod='referralprogram'}" rel="nofollow">
-        <span><i class="icon-chevron-left"></i> {l s='Back to Your Account' mod='referralprogram'}</span></a>
-    </li>
-    <li><a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home' mod='referralprogram'}"><span><i class="icon-chevron-left"></i>{l s='Home' mod='referralprogram'}</span></a></li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" title="{l s='Back to Your Account' mod='referralprogram'}" rel="nofollow">
+      <span><i class="icon-chevron-left"></i> {l s='Back to Your Account' mod='referralprogram'}</span></a>
+  </li>
+  <li><a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home' mod='referralprogram'}"><span><i class="icon-chevron-left"></i>{l s='Home' mod='referralprogram'}</span></a></li>
 </ul>
 {addJsDefL name=ThickboxI18nClose}{l s='Close' mod='referralprogram' js=1}{/addJsDefL}
 {addJsDefL name=ThickboxI18nOrEscKey}{l s='or Esc key' mod='referralprogram' js=1}{/addJsDefL}

--- a/themes/community-theme-16/modules/referralprogram/views/templates/front/rules.tpl
+++ b/themes/community-theme-16/modules/referralprogram/views/templates/front/rules.tpl
@@ -26,7 +26,7 @@
 <h3>{l s='Referral program rules' mod='referralprogram'}</h3>
 
 {if isset($xml)}
-<div id="referralprogram_rules">
+  <div id="referralprogram_rules">
     {if isset($xml->body->$paragraph)}<div class="rte">{$xml->body->$paragraph|replace:"\'":"'"|replace:'\"':'"'}</div>{/if}
-</div>
+  </div>
 {/if}

--- a/themes/community-theme-16/modules/referralprogram/views/templates/hook/authentication.tpl
+++ b/themes/community-theme-16/modules/referralprogram/views/templates/hook/authentication.tpl
@@ -25,10 +25,10 @@
 
 <!-- MODULE ReferralProgram -->
 <fieldset class="account_creation">
-    <h3 class="page-subheading">{l s='Referral program' mod='referralprogram'}</h3>
-    <p class="form-group">
-        <label for="referralprogram">{l s='E-mail address of your sponsor' mod='referralprogram'}</label>
-        <input class="form-control" type="text" size="52" maxlength="128" id="referralprogram" name="referralprogram" value="{if isset($smarty.post.referralprogram)}{$smarty.post.referralprogram|escape:'html':'UTF-8'}{/if}" />
-    </p>
+  <h3 class="page-subheading">{l s='Referral program' mod='referralprogram'}</h3>
+  <p class="form-group">
+    <label for="referralprogram">{l s='E-mail address of your sponsor' mod='referralprogram'}</label>
+    <input class="form-control" type="text" size="52" maxlength="128" id="referralprogram" name="referralprogram" value="{if isset($smarty.post.referralprogram)}{$smarty.post.referralprogram|escape:'html':'UTF-8'}{/if}" />
+  </p>
 </fieldset>
 <!-- END : MODULE ReferralProgram -->

--- a/themes/community-theme-16/modules/referralprogram/views/templates/hook/my-account.tpl
+++ b/themes/community-theme-16/modules/referralprogram/views/templates/hook/my-account.tpl
@@ -25,6 +25,6 @@
 
 <!-- MODULE ReferralProgram -->
 <li class="referralprogram">
-    <a href="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" title="{l s='Referral program' mod='referralprogram'}" rel="nofollow"><i class="icon-cogs"></i><span>{l s='Referral program' mod='referralprogram'}</span></a>
+  <a href="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" title="{l s='Referral program' mod='referralprogram'}" rel="nofollow"><i class="icon-cogs"></i><span>{l s='Referral program' mod='referralprogram'}</span></a>
 </li>
 <!-- END : MODULE ReferralProgram -->

--- a/themes/community-theme-16/modules/referralprogram/views/templates/hook/order-confirmation.tpl
+++ b/themes/community-theme-16/modules/referralprogram/views/templates/hook/order-confirmation.tpl
@@ -24,6 +24,6 @@
 *}
 
 <p class="success">
-    {l s='Thanks to your order, your sponsor %1$s %2$s will earn a voucher worth %3$d off when this order is confirmed.' sprintf=[$sponsor_firstname,$sponsor_lastname,$discount] mod='referralprogram'}
+  {l s='Thanks to your order, your sponsor %1$s %2$s will earn a voucher worth %3$d off when this order is confirmed.' sprintf=[$sponsor_firstname,$sponsor_lastname,$discount] mod='referralprogram'}
 </p>
 <br/>

--- a/themes/community-theme-16/modules/referralprogram/views/templates/hook/shopping-cart.tpl
+++ b/themes/community-theme-16/modules/referralprogram/views/templates/hook/shopping-cart.tpl
@@ -25,10 +25,10 @@
 
 <!-- MODULE ReferralProgram -->
 <p id="referralprogram">
-    <i class="icon-flag"></i>
-    {l s='You have earned a voucher worth %s thanks to your sponsor!' sprintf=$discount_display mod='referralprogram'}
-    {l s='Enter voucher name %s to receive the reduction on this order.' sprintf=$discount->name mod='referralprogram'}
-    <a href="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" title="{l s='Referral program' mod='referralprogram'}" rel="nofollow">{l s='View your referral program.' mod='referralprogram'}</a>
+  <i class="icon-flag"></i>
+  {l s='You have earned a voucher worth %s thanks to your sponsor!' sprintf=$discount_display mod='referralprogram'}
+  {l s='Enter voucher name %s to receive the reduction on this order.' sprintf=$discount->name mod='referralprogram'}
+  <a href="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html':'UTF-8'}" title="{l s='Referral program' mod='referralprogram'}" rel="nofollow">{l s='View your referral program.' mod='referralprogram'}</a>
 </p>
 <br />
 <!-- END : MODULE ReferralProgram -->

--- a/themes/community-theme-16/modules/sendtoafriend/sendtoafriend-extra.tpl
+++ b/themes/community-theme-16/modules/sendtoafriend/sendtoafriend-extra.tpl
@@ -24,60 +24,60 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <li class="sendtofriend">
-    <a id="send_friend_button" href="#send_friend_form">
+  <a id="send_friend_button" href="#send_friend_form">
+    {l s='Send to a friend' mod='sendtoafriend'}
+  </a>
+  <div style="display: none;">
+    <div id="send_friend_form">
+      <h2  class="page-subheading">
         {l s='Send to a friend' mod='sendtoafriend'}
-    </a>
-    <div style="display: none;">
-        <div id="send_friend_form">
-            <h2  class="page-subheading">
-                {l s='Send to a friend' mod='sendtoafriend'}
-            </h2>
-            <div class="row">
-                <div class="product clearfix col-xs-12 col-sm-6">
-                    <img src="{$link->getImageLink($stf_product->link_rewrite, $stf_product_cover, 'home_default')|escape:'html':'UTF-8'}" height="{$homeSize.height}" width="{$homeSize.width}" alt="{$stf_product->name|escape:'html':'UTF-8'}" />
-                    <div class="product_desc">
-                        <p class="product_name">
-                            <strong>{$stf_product->name}</strong>
-                        </p>
-                        {$stf_product->description_short}
-                    </div>
-                </div><!-- .product -->
-                <div class="send_friend_form_content col-xs-12 col-sm-6" id="send_friend_form_content">
-                    <div id="send_friend_form_error"></div>
-                    <div id="send_friend_form_success"></div>
-                    <div class="form_container">
-                        <p class="intro_form">
-                            {l s='Recipient' mod='sendtoafriend'} :
-                        </p>
-                        <p class="text">
-                            <label for="friend_name">
-                                {l s='Name of your friend' mod='sendtoafriend'} <sup class="required">*</sup> :
-                            </label>
-                            <input id="friend_name" name="friend_name" type="text" value=""/>
-                        </p>
-                        <p class="text">
-                            <label for="friend_email">
-                                {l s='E-mail address of your friend' mod='sendtoafriend'} <sup class="required">*</sup> :
-                            </label>
-                            <input id="friend_email" name="friend_email" type="text" value=""/>
-                        </p>
-                        <p class="txt_required">
-                            <sup class="required">*</sup> {l s='Required fields' mod='sendtoafriend'}
-                        </p>
-                    </div>
-                    <p class="submit">
-                        <button id="sendEmail" class="btn button button-small" name="sendEmail" type="submit">
-                            <span>{l s='Send' mod='sendtoafriend'}</span>
-                        </button>&nbsp;
-                        {l s='or' mod='sendtoafriend'}&nbsp;
-                        <a class="closefb" href="#">
-                            {l s='Cancel' mod='sendtoafriend'}
-                        </a>
-                    </p>
-                </div> <!-- .send_friend_form_content -->
-            </div>
-        </div>
+      </h2>
+      <div class="row">
+        <div class="product clearfix col-xs-12 col-sm-6">
+          <img src="{$link->getImageLink($stf_product->link_rewrite, $stf_product_cover, 'home_default')|escape:'html':'UTF-8'}" height="{$homeSize.height}" width="{$homeSize.width}" alt="{$stf_product->name|escape:'html':'UTF-8'}" />
+          <div class="product_desc">
+            <p class="product_name">
+              <strong>{$stf_product->name}</strong>
+            </p>
+            {$stf_product->description_short}
+          </div>
+        </div><!-- .product -->
+        <div class="send_friend_form_content col-xs-12 col-sm-6" id="send_friend_form_content">
+          <div id="send_friend_form_error"></div>
+          <div id="send_friend_form_success"></div>
+          <div class="form_container">
+            <p class="intro_form">
+              {l s='Recipient' mod='sendtoafriend'} :
+            </p>
+            <p class="text">
+              <label for="friend_name">
+                {l s='Name of your friend' mod='sendtoafriend'} <sup class="required">*</sup> :
+              </label>
+              <input id="friend_name" name="friend_name" type="text" value=""/>
+            </p>
+            <p class="text">
+              <label for="friend_email">
+                {l s='E-mail address of your friend' mod='sendtoafriend'} <sup class="required">*</sup> :
+              </label>
+              <input id="friend_email" name="friend_email" type="text" value=""/>
+            </p>
+            <p class="txt_required">
+              <sup class="required">*</sup> {l s='Required fields' mod='sendtoafriend'}
+            </p>
+          </div>
+          <p class="submit">
+            <button id="sendEmail" class="btn button button-small" name="sendEmail" type="submit">
+              <span>{l s='Send' mod='sendtoafriend'}</span>
+            </button>&nbsp;
+            {l s='or' mod='sendtoafriend'}&nbsp;
+            <a class="closefb" href="#">
+              {l s='Cancel' mod='sendtoafriend'}
+            </a>
+          </p>
+        </div> <!-- .send_friend_form_content -->
+      </div>
     </div>
+  </div>
 </li>
 {addJsDef stf_secure_key=$stf_secure_key}
 {addJsDefL name=stf_msg_success}{l s='Your e-mail has been sent successfully' mod='sendtoafriend' js=1}{/addJsDefL}

--- a/themes/community-theme-16/my-account.tpl
+++ b/themes/community-theme-16/my-account.tpl
@@ -27,37 +27,37 @@
 
 <h1 class="page-heading">{l s='My account'}</h1>
 {if isset($account_created)}
-    <p class="alert alert-success">
-        {l s='Your account has been created.'}
-    </p>
+  <p class="alert alert-success">
+    {l s='Your account has been created.'}
+  </p>
 {/if}
 <p class="info-account">{l s='Welcome to your account. Here you can manage all of your personal information and orders.'}</p>
 <div class="row addresses-lists">
+  <div class="col-xs-12 col-sm-6 col-lg-4">
+    <ul class="myaccount-link-list">
+      {if $has_customer_an_address}
+        <li><a href="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}" title="{l s='Add my first address'}"><i class="icon-building"></i><span>{l s='Add my first address'}</span></a></li>
+      {/if}
+      <li><a href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Orders'}"><i class="icon-list-ol"></i><span>{l s='Order history and details'}</span></a></li>
+      {if $returnAllowed}
+        <li><a href="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" title="{l s='Merchandise returns'}"><i class="icon-refresh"></i><span>{l s='My merchandise returns'}</span></a></li>
+      {/if}
+      <li><a href="{$link->getPageLink('order-slip', true)|escape:'html':'UTF-8'}" title="{l s='Credit slips'}"><i class="icon-file-o"></i><span>{l s='My credit slips'}</span></a></li>
+      <li><a href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" title="{l s='Addresses'}"><i class="icon-building"></i><span>{l s='My addresses'}</span></a></li>
+      <li><a href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" title="{l s='Information'}"><i class="icon-user"></i><span>{l s='My personal information'}</span></a></li>
+    </ul>
+  </div>
+  {if $voucherAllowed || isset($HOOK_CUSTOMER_ACCOUNT) && $HOOK_CUSTOMER_ACCOUNT !=''}
     <div class="col-xs-12 col-sm-6 col-lg-4">
-        <ul class="myaccount-link-list">
-            {if $has_customer_an_address}
-            <li><a href="{$link->getPageLink('address', true)|escape:'html':'UTF-8'}" title="{l s='Add my first address'}"><i class="icon-building"></i><span>{l s='Add my first address'}</span></a></li>
-            {/if}
-            <li><a href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Orders'}"><i class="icon-list-ol"></i><span>{l s='Order history and details'}</span></a></li>
-            {if $returnAllowed}
-                <li><a href="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" title="{l s='Merchandise returns'}"><i class="icon-refresh"></i><span>{l s='My merchandise returns'}</span></a></li>
-            {/if}
-            <li><a href="{$link->getPageLink('order-slip', true)|escape:'html':'UTF-8'}" title="{l s='Credit slips'}"><i class="icon-file-o"></i><span>{l s='My credit slips'}</span></a></li>
-            <li><a href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" title="{l s='Addresses'}"><i class="icon-building"></i><span>{l s='My addresses'}</span></a></li>
-            <li><a href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" title="{l s='Information'}"><i class="icon-user"></i><span>{l s='My personal information'}</span></a></li>
-        </ul>
+      <ul class="myaccount-link-list">
+        {if $voucherAllowed}
+          <li><a href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" title="{l s='Vouchers'}"><i class="icon-barcode"></i><span>{l s='My vouchers'}</span></a></li>
+        {/if}
+        {$HOOK_CUSTOMER_ACCOUNT}
+      </ul>
     </div>
-{if $voucherAllowed || isset($HOOK_CUSTOMER_ACCOUNT) && $HOOK_CUSTOMER_ACCOUNT !=''}
-    <div class="col-xs-12 col-sm-6 col-lg-4">
-        <ul class="myaccount-link-list">
-            {if $voucherAllowed}
-                <li><a href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" title="{l s='Vouchers'}"><i class="icon-barcode"></i><span>{l s='My vouchers'}</span></a></li>
-            {/if}
-            {$HOOK_CUSTOMER_ACCOUNT}
-        </ul>
-    </div>
-{/if}
+  {/if}
 </div>
 <ul class="footer_links clearfix">
-<li><a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home'}"><span><i class="icon-chevron-left"></i> {l s='Home'}</span></a></li>
+  <li><a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" title="{l s='Home'}"><span><i class="icon-chevron-left"></i> {l s='Home'}</span></a></li>
 </ul>

--- a/themes/community-theme-16/nbr-product-page.tpl
+++ b/themes/community-theme-16/nbr-product-page.tpl
@@ -24,51 +24,51 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($p) AND $p}
-    {if isset($smarty.get.id_category) && $smarty.get.id_category && isset($category)}
-        {assign var='requestPage' value=$link->getPaginationLink('category', $category, false, false, true, false)}
-        {assign var='requestNb' value=$link->getPaginationLink('category', $category, true, false, false, true)}
-    {elseif isset($smarty.get.id_manufacturer) && $smarty.get.id_manufacturer && isset($manufacturer)}
-        {assign var='requestPage' value=$link->getPaginationLink('manufacturer', $manufacturer, false, false, true, false)}
-        {assign var='requestNb' value=$link->getPaginationLink('manufacturer', $manufacturer, true, false, false, true)}
-    {elseif isset($smarty.get.id_supplier) && $smarty.get.id_supplier && isset($supplier)}
-        {assign var='requestPage' value=$link->getPaginationLink('supplier', $supplier, false, false, true, false)}
-        {assign var='requestNb' value=$link->getPaginationLink('supplier', $supplier, true, false, false, true)}
-    {else}
-        {assign var='requestPage' value=$link->getPaginationLink(false, false, false, false, true, false)}
-        {assign var='requestNb' value=$link->getPaginationLink(false, false, true, false, false, true)}
-    {/if}
-    <!-- nbr product/page -->
-    {if $nb_products > $nArray[0]}
-        <form action="{if !is_array($requestNb)}{$requestNb|escape:'html':'UTF-8'}{else}{$requestNb.requestUrl|escape:'html':'UTF-8'}{/if}" method="get" class="nbrItemPage">
-            <div class="clearfix selector1">
-                {if isset($search_query) AND $search_query}
-                    <input type="hidden" name="search_query" value="{$search_query|escape:'html':'UTF-8'}" />
-                {/if}
-                {if isset($tag) AND $tag AND !is_array($tag)}
-                    <input type="hidden" name="tag" value="{$tag|escape:'html':'UTF-8'}" />
-                {/if}
-                <label for="nb_item{if isset($paginationId)}_{$paginationId}{/if}">
-                    {l s='Show'}
-                </label>
-                {if is_array($requestNb)}
-                    {foreach from=$requestNb item=requestValue key=requestKey}
-                        {if $requestKey != 'requestUrl'}
-                            <input type="hidden" name="{$requestKey|escape:'html':'UTF-8'}" value="{$requestValue|escape:'html':'UTF-8'}" />
-                        {/if}
-                    {/foreach}
-                {/if}
-                <select name="n" id="nb_item{if isset($paginationId)}_{$paginationId}{/if}" class="form-control">
-                    {assign var="lastnValue" value="0"}
-                    {foreach from=$nArray item=nValue}
-                        {if $lastnValue <= $nb_products}
-                            <option value="{$nValue|escape:'html':'UTF-8'}" {if $n == $nValue}selected="selected"{/if}>{$nValue|escape:'html':'UTF-8'}</option>
-                        {/if}
-                        {assign var="lastnValue" value=$nValue}
-                    {/foreach}
-                </select>
-                <span>{l s='per page'}</span>
-            </div>
-        </form>
-    {/if}
-    <!-- /nbr product/page -->
+  {if isset($smarty.get.id_category) && $smarty.get.id_category && isset($category)}
+    {assign var='requestPage' value=$link->getPaginationLink('category', $category, false, false, true, false)}
+    {assign var='requestNb' value=$link->getPaginationLink('category', $category, true, false, false, true)}
+  {elseif isset($smarty.get.id_manufacturer) && $smarty.get.id_manufacturer && isset($manufacturer)}
+    {assign var='requestPage' value=$link->getPaginationLink('manufacturer', $manufacturer, false, false, true, false)}
+    {assign var='requestNb' value=$link->getPaginationLink('manufacturer', $manufacturer, true, false, false, true)}
+  {elseif isset($smarty.get.id_supplier) && $smarty.get.id_supplier && isset($supplier)}
+    {assign var='requestPage' value=$link->getPaginationLink('supplier', $supplier, false, false, true, false)}
+    {assign var='requestNb' value=$link->getPaginationLink('supplier', $supplier, true, false, false, true)}
+  {else}
+    {assign var='requestPage' value=$link->getPaginationLink(false, false, false, false, true, false)}
+    {assign var='requestNb' value=$link->getPaginationLink(false, false, true, false, false, true)}
+  {/if}
+  <!-- nbr product/page -->
+  {if $nb_products > $nArray[0]}
+    <form action="{if !is_array($requestNb)}{$requestNb|escape:'html':'UTF-8'}{else}{$requestNb.requestUrl|escape:'html':'UTF-8'}{/if}" method="get" class="nbrItemPage">
+      <div class="clearfix selector1">
+        {if isset($search_query) AND $search_query}
+          <input type="hidden" name="search_query" value="{$search_query|escape:'html':'UTF-8'}" />
+        {/if}
+        {if isset($tag) AND $tag AND !is_array($tag)}
+          <input type="hidden" name="tag" value="{$tag|escape:'html':'UTF-8'}" />
+        {/if}
+        <label for="nb_item{if isset($paginationId)}_{$paginationId}{/if}">
+          {l s='Show'}
+        </label>
+        {if is_array($requestNb)}
+          {foreach from=$requestNb item=requestValue key=requestKey}
+            {if $requestKey != 'requestUrl'}
+              <input type="hidden" name="{$requestKey|escape:'html':'UTF-8'}" value="{$requestValue|escape:'html':'UTF-8'}" />
+            {/if}
+          {/foreach}
+        {/if}
+        <select name="n" id="nb_item{if isset($paginationId)}_{$paginationId}{/if}" class="form-control">
+          {assign var="lastnValue" value="0"}
+          {foreach from=$nArray item=nValue}
+            {if $lastnValue <= $nb_products}
+              <option value="{$nValue|escape:'html':'UTF-8'}" {if $n == $nValue}selected="selected"{/if}>{$nValue|escape:'html':'UTF-8'}</option>
+            {/if}
+            {assign var="lastnValue" value=$nValue}
+          {/foreach}
+        </select>
+        <span>{l s='per page'}</span>
+      </div>
+    </form>
+  {/if}
+  <!-- /nbr product/page -->
 {/if}

--- a/themes/community-theme-16/new-products.tpl
+++ b/themes/community-theme-16/new-products.tpl
@@ -28,25 +28,25 @@
 <h1 class="page-heading product-listing">{l s='New products'}</h1>
 
 {if $products}
-    <div class="content_sortPagiBar">
-        <div class="sortPagiBar clearfix">
-            {include file="./product-sort.tpl"}
-            {include file="./nbr-product-page.tpl"}
-        </div>
-        <div class="top-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {include file="$tpl_dir./pagination.tpl" no_follow=1}
-        </div>
+  <div class="content_sortPagiBar">
+    <div class="sortPagiBar clearfix">
+      {include file="./product-sort.tpl"}
+      {include file="./nbr-product-page.tpl"}
     </div>
-
-    {include file="./product-list.tpl" products=$products}
-
-    <div class="content_sortPagiBar">
-        <div class="bottom-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {include file="./pagination.tpl" no_follow=1 paginationId='bottom'}
-        </div>
+    <div class="top-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {include file="$tpl_dir./pagination.tpl" no_follow=1}
     </div>
-    {else}
-    <p class="alert alert-warning">{l s='No new products.'}</p>
+  </div>
+
+  {include file="./product-list.tpl" products=$products}
+
+  <div class="content_sortPagiBar">
+    <div class="bottom-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {include file="./pagination.tpl" no_follow=1 paginationId='bottom'}
+    </div>
+  </div>
+{else}
+  <p class="alert alert-warning">{l s='No new products.'}</p>
 {/if}

--- a/themes/community-theme-16/order-address-advanced.tpl
+++ b/themes/community-theme-16/order-address-advanced.tpl
@@ -24,78 +24,78 @@
 *}
 {assign var='have_non_virtual_products' value=false}
 {foreach $products as $product}
-    {if $product.is_virtual == 0}
-        {assign var='have_non_virtual_products' value=true}
-        {break}
-    {/if}
+  {if $product.is_virtual == 0}
+    {assign var='have_non_virtual_products' value=true}
+    {break}
+  {/if}
 {/foreach}
 <h2>{l s='Address(es) Details'}</h2>
 {if ((!empty($delivery_option) AND (!isset($isVirtualCart) || !$isVirtualCart)) OR $delivery->id OR $invoice->id)}
-    <div class="order_delivery clearfix row">
-        {if !isset($formattedAddresses) || (count($formattedAddresses.invoice) == 0 && count($formattedAddresses.delivery) == 0) || (count($formattedAddresses.invoice.formated) == 0 && count($formattedAddresses.delivery.formated) == 0)}
-            {if $delivery->id}
-                <div class="col-xs-12 col-sm-6"{if !$have_non_virtual_products} style="display: none;"{/if}>
-                    <ul id="delivery_address" class="address item box">
-                        <li><h3 class="page-subheading">{l s='Delivery address'}&nbsp;<span class="address_alias">({$delivery->alias})</span></h3></li>
-                        {if $delivery->company}<li class="address_company">{$delivery->company|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_name">{$delivery->firstname|escape:'html':'UTF-8'} {$delivery->lastname|escape:'html':'UTF-8'}</li>
-                        <li class="address_address1">{$delivery->address1|escape:'html':'UTF-8'}</li>
-                        {if $delivery->address2}<li class="address_address2">{$delivery->address2|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_city">{$delivery->postcode|escape:'html':'UTF-8'} {$delivery->city|escape:'html':'UTF-8'}</li>
-                        <li class="address_country">{$delivery->country|escape:'html':'UTF-8'} {if $delivery->id_state }({$delivery_state->name|escape:'html':'UTF-8'}){/if}</li>
-                    </ul>
-                </div>
-            {/if}
-            {if $invoice->id}
-                <div class="col-xs-12 col-sm-6">
-                    <ul id="invoice_address" class="address alternate_item box">
-                        <li><h3 class="page-subheading">{l s='Invoice address'}&nbsp;<span class="address_alias">({$invoice->alias})</span></h3></li>
-                        {if $invoice->company}<li class="address_company">{$invoice->company|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_name">{$invoice->firstname|escape:'html':'UTF-8'} {$invoice->lastname|escape:'html':'UTF-8'}</li>
-                        <li class="address_address1">{$invoice->address1|escape:'html':'UTF-8'}</li>
-                        {if $invoice->address2}<li class="address_address2">{$invoice->address2|escape:'html':'UTF-8'}</li>{/if}
-                        <li class="address_city">{$invoice->postcode|escape:'html':'UTF-8'} {$invoice->city|escape:'html':'UTF-8'}</li>
-                        <li class="address_country">{$invoice->country|escape:'html':'UTF-8'} {if $invoice->id_state}({$invoice->name|escape:'html':'UTF-8'}){/if}</li>
-                    </ul>
-                </div>
-            {/if}
-        {else}
-            {foreach from=$formattedAddresses key=k item=address}
-                <div class="col-xs-12 col-sm-6"{if $k == 'delivery' && !$have_non_virtual_products} style="display: none;"{/if}>
-                    <ul class="address {if $address@last}last_item{elseif $address@first}first_item{/if} {if $address@index % 2}alternate_item{else}item{/if} box">
-                        <li>
-                            <h3 class="page-subheading">
-                                {if $k eq 'invoice'}
-                                    {l s='Invoice address'}
-                                {elseif $k eq 'delivery' && $delivery->id}
-                                    {l s='Delivery address'}
-                                {/if}
-                                {if isset($address.object.alias)}
-                                    <span class="address_alias">({$address.object.alias})</span>
-                                {/if}
-                            </h3>
-                        </li>
-                        {foreach $address.ordered as $pattern}
-                            {assign var=addressKey value=" "|explode:$pattern}
-                            {assign var=addedli value=false}
-                            {foreach from=$addressKey item=key name=foo}
-                                {$key_str = $key|regex_replace:AddressFormat::_CLEANING_REGEX_:""}
-                                {if isset($address.formated[$key_str]) && !empty($address.formated[$key_str])}
-                                    {if (!$addedli)}
-                                        {$addedli = true}
-                                        <li><span class="{if isset($addresses_style[$key_str])}{$addresses_style[$key_str]}{/if}">
-                                    {/if}
-                                    {$address.formated[$key_str]|escape:'html':'UTF-8'}
-                                {/if}
-                                {if ($smarty.foreach.foo.last && $addedli)}
-                                    </span></li>
-                                {/if}
-                            {/foreach}
-                        {/foreach}
-                    </ul>
-                </div>
+  <div class="order_delivery clearfix row">
+    {if !isset($formattedAddresses) || (count($formattedAddresses.invoice) == 0 && count($formattedAddresses.delivery) == 0) || (count($formattedAddresses.invoice.formated) == 0 && count($formattedAddresses.delivery.formated) == 0)}
+      {if $delivery->id}
+        <div class="col-xs-12 col-sm-6"{if !$have_non_virtual_products} style="display: none;"{/if}>
+          <ul id="delivery_address" class="address item box">
+            <li><h3 class="page-subheading">{l s='Delivery address'}&nbsp;<span class="address_alias">({$delivery->alias})</span></h3></li>
+            {if $delivery->company}<li class="address_company">{$delivery->company|escape:'html':'UTF-8'}</li>{/if}
+            <li class="address_name">{$delivery->firstname|escape:'html':'UTF-8'} {$delivery->lastname|escape:'html':'UTF-8'}</li>
+            <li class="address_address1">{$delivery->address1|escape:'html':'UTF-8'}</li>
+            {if $delivery->address2}<li class="address_address2">{$delivery->address2|escape:'html':'UTF-8'}</li>{/if}
+            <li class="address_city">{$delivery->postcode|escape:'html':'UTF-8'} {$delivery->city|escape:'html':'UTF-8'}</li>
+            <li class="address_country">{$delivery->country|escape:'html':'UTF-8'} {if $delivery->id_state }({$delivery_state->name|escape:'html':'UTF-8'}){/if}</li>
+          </ul>
+        </div>
+      {/if}
+      {if $invoice->id}
+        <div class="col-xs-12 col-sm-6">
+          <ul id="invoice_address" class="address alternate_item box">
+            <li><h3 class="page-subheading">{l s='Invoice address'}&nbsp;<span class="address_alias">({$invoice->alias})</span></h3></li>
+            {if $invoice->company}<li class="address_company">{$invoice->company|escape:'html':'UTF-8'}</li>{/if}
+            <li class="address_name">{$invoice->firstname|escape:'html':'UTF-8'} {$invoice->lastname|escape:'html':'UTF-8'}</li>
+            <li class="address_address1">{$invoice->address1|escape:'html':'UTF-8'}</li>
+            {if $invoice->address2}<li class="address_address2">{$invoice->address2|escape:'html':'UTF-8'}</li>{/if}
+            <li class="address_city">{$invoice->postcode|escape:'html':'UTF-8'} {$invoice->city|escape:'html':'UTF-8'}</li>
+            <li class="address_country">{$invoice->country|escape:'html':'UTF-8'} {if $invoice->id_state}({$invoice->name|escape:'html':'UTF-8'}){/if}</li>
+          </ul>
+        </div>
+      {/if}
+    {else}
+      {foreach from=$formattedAddresses key=k item=address}
+        <div class="col-xs-12 col-sm-6"{if $k == 'delivery' && !$have_non_virtual_products} style="display: none;"{/if}>
+          <ul class="address {if $address@last}last_item{elseif $address@first}first_item{/if} {if $address@index % 2}alternate_item{else}item{/if} box">
+            <li>
+              <h3 class="page-subheading">
+                {if $k eq 'invoice'}
+                  {l s='Invoice address'}
+                {elseif $k eq 'delivery' && $delivery->id}
+                  {l s='Delivery address'}
+                {/if}
+                {if isset($address.object.alias)}
+                  <span class="address_alias">({$address.object.alias})</span>
+                {/if}
+              </h3>
+            </li>
+            {foreach $address.ordered as $pattern}
+              {assign var=addressKey value=" "|explode:$pattern}
+              {assign var=addedli value=false}
+              {foreach from=$addressKey item=key name=foo}
+                {$key_str = $key|regex_replace:AddressFormat::_CLEANING_REGEX_:""}
+                {if isset($address.formated[$key_str]) && !empty($address.formated[$key_str])}
+                  {if (!$addedli)}
+                    {$addedli = true}
+                    <li><span class="{if isset($addresses_style[$key_str])}{$addresses_style[$key_str]}{/if}">
+                  {/if}
+                  {$address.formated[$key_str]|escape:'html':'UTF-8'}
+                {/if}
+                {if ($smarty.foreach.foo.last && $addedli)}
+                  </span></li>
+                {/if}
+              {/foreach}
             {/foreach}
-        {/if}
-    </div>
+          </ul>
+        </div>
+      {/foreach}
+    {/if}
+  </div>
 {/if}
 

--- a/themes/community-theme-16/order-address-multishipping-products.tpl
+++ b/themes/community-theme-16/order-address-multishipping-products.tpl
@@ -25,28 +25,28 @@
 *}
 <p class="info-title">{l s='Choose the delivery addresses'}</p>
 <div id="order-detail-content" class="table_block table-responsive">
-    <table id="cart_summary" class="table table-bordered multishipping-cart">
-        <thead>
-            <tr>
-                <th class="cart_product first_item">{l s='Product'}</th>
-                <th class="cart_description item">{l s='Description'}</th>
-                <th class="cart_ref item">{l s='Ref.'}</th>
-                <th class="cart_avail item">{l s='Avail.'}</th>
-                <th class="cart_quantity item">{l s='Qty'}</th>
-                <th class="shipping_address last_item">{l s='Shipping address'}</th>
-            </tr>
-        </thead>
-        <tbody>
-        {foreach $product_list as $product}
-            {assign var='productId' value=$product.id_product}
-            {assign var='productAttributeId' value=$product.id_product_attribute}
-            {assign var='quantityDisplayed' value=0}
-            {assign var='odd' value=$product@iteration%2}
-            {* Display the product line *}
-            {include file="$tpl_dir./order-address-product-line.tpl" productLast=$product@last productFirst=$product@first}
-        {/foreach}
-        </tbody>
-    </table>
+  <table id="cart_summary" class="table table-bordered multishipping-cart">
+    <thead>
+    <tr>
+      <th class="cart_product first_item">{l s='Product'}</th>
+      <th class="cart_description item">{l s='Description'}</th>
+      <th class="cart_ref item">{l s='Ref.'}</th>
+      <th class="cart_avail item">{l s='Avail.'}</th>
+      <th class="cart_quantity item">{l s='Qty'}</th>
+      <th class="shipping_address last_item">{l s='Shipping address'}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {foreach $product_list as $product}
+      {assign var='productId' value=$product.id_product}
+      {assign var='productAttributeId' value=$product.id_product_attribute}
+      {assign var='quantityDisplayed' value=0}
+      {assign var='odd' value=$product@iteration%2}
+      {* Display the product line *}
+      {include file="$tpl_dir./order-address-product-line.tpl" productLast=$product@last productFirst=$product@first}
+    {/foreach}
+    </tbody>
+  </table>
 </div>
 {addJsDefL name=CloseTxt}{l s='Submit' js=1}{/addJsDefL}
 {addJsDefL name=QtyChanged}{l s='Some product quantities have changed. Please check them' js=1}{/addJsDefL}

--- a/themes/community-theme-16/order-address-multishipping.tpl
+++ b/themes/community-theme-16/order-address-multishipping.tpl
@@ -24,89 +24,89 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !$opc}
-    {assign var='current_step' value='address'}
-    {capture name=path}{l s='Addresses'}{/capture}
-    {assign var="back_order_page" value="order.php"}
-    <h1 class="page-heading">{l s='Addresses'}</h1>
-    {include file="$tpl_dir./order-steps.tpl"}
-    {include file="$tpl_dir./errors.tpl"}
-    {include file="$tpl_dir./order-address-multishipping-products.tpl"}
-        <form action="{$link->getPageLink('order', true, NULL, 'multi-shipping=1')|escape:'html':'UTF-8'}" method="post">
+  {assign var='current_step' value='address'}
+  {capture name=path}{l s='Addresses'}{/capture}
+  {assign var="back_order_page" value="order.php"}
+  <h1 class="page-heading">{l s='Addresses'}</h1>
+  {include file="$tpl_dir./order-steps.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
+  {include file="$tpl_dir./order-address-multishipping-products.tpl"}
+  <form action="{$link->getPageLink('order', true, NULL, 'multi-shipping=1')|escape:'html':'UTF-8'}" method="post">
 {else}
-    {assign var="back_order_page" value="order-opc.php"}
-    <h1 class="page-heading step-num"><span>1</span> {l s='Addresses'}</h1>
-    <div id="opc_account" class="opc-main-block">
-        <div id="opc_account-overlay" class="opc-overlay" style="display: none;"></div>
+  {assign var="back_order_page" value="order-opc.php"}
+  <h1 class="page-heading step-num"><span>1</span> {l s='Addresses'}</h1>
+  <div id="opc_account" class="opc-main-block">
+    <div id="opc_account-overlay" class="opc-overlay" style="display: none;"></div>
 {/if}
 <div class="addresses clearfix">
-    <input type="hidden" name="id_address_delivery" id="id_address_delivery" value="{$cart->id_address_delivery}"/>
-    <p id="address_invoice_form" class="select" {if $cart->id_address_invoice == $cart->id_address_delivery}style="display: none;"{/if}>
+  <input type="hidden" name="id_address_delivery" id="id_address_delivery" value="{$cart->id_address_delivery}"/>
+  <p id="address_invoice_form" class="select" {if $cart->id_address_invoice == $cart->id_address_delivery}style="display: none;"{/if}>
 
-    {if $addresses|@count >= 1}
-    <div class="form-group selector1">
-        <label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
-        <select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
-        {section loop=$addresses step=-1 name=address}
-            <option value="{$addresses[address].id_address|intval}" {if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice}selected="selected"{/if}>{$addresses[address].alias|escape:'html':'UTF-8'}</option>
-        {/section}
-        </select>
+  {if $addresses|@count >= 1}
+  <div class="form-group selector1">
+    <label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
+    <select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
+    {section loop=$addresses step=-1 name=address}
+      <option value="{$addresses[address].id_address|intval}" {if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice}selected="selected"{/if}>{$addresses[address].alias|escape:'html':'UTF-8'}</option>
+    {/section}
+    </select>
+  </div>
+  {else}
+    <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{'&multi-shipping=1'|urlencode}{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
+  {/if}
+  </p>
+  <div class="row">
+    <div class="col-sm-12 col-md-6">
+      <ul class="address alternate_item {if $cart->isVirtualCart()}full_width{/if} box" id="address_invoice">
+      </ul>
     </div>
-    {else}
-        <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{'&multi-shipping=1'|urlencode}{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
-    {/if}
-    </p>
-    <div class="row">
-        <div class="col-sm-12 col-md-6">
-            <ul class="address alternate_item {if $cart->isVirtualCart()}full_width{/if} box" id="address_invoice">
-            </ul>
-        </div>
-    </div>
-    <p class="address_add submit">
-        <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{'&multi-shipping=1'|urlencode}{if $back}&mod={$back|urlencode}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
-    </p>
-    {if !$opc}
-    <div id="ordermsg" class="form-group">
-        <label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
-        <textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
-    </div>
-    {/if}
+  </div>
+  <p class="address_add submit">
+    <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{'&multi-shipping=1'|urlencode}{if $back}&mod={$back|urlencode}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default"><span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span></a>
+  </p>
+  {if !$opc}
+  <div id="ordermsg" class="form-group">
+    <label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
+    <textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
+  </div>
+  {/if}
 </div>
 {if !$opc}
-            <p class="cart_navigation clearfix">
-                <input type="hidden" class="hidden" name="step" value="2" />
-                <input type="hidden" name="back" value="{$back}" />
-                {if $back}
-                    <a href="{$link->getPageLink('order', true, NULL, "back={$back}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Continue Shopping'}</a>
-                {else}
-                    <a href="{$link->getPageLink('order', true, NULL)|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Continue Shopping'}</a>
-                {/if}
-                <button type="submit" name="processAddress" class="button btn btn-default button-medium"><span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span></button>
-            </p>
-        </form>
+    <p class="cart_navigation clearfix">
+      <input type="hidden" class="hidden" name="step" value="2" />
+      <input type="hidden" name="back" value="{$back}" />
+      {if $back}
+        <a href="{$link->getPageLink('order', true, NULL, "back={$back}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Continue Shopping'}</a>
+      {else}
+        <a href="{$link->getPageLink('order', true, NULL)|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default"><i class="icon-chevron-left"></i>{l s='Continue Shopping'}</a>
+      {/if}
+      <button type="submit" name="processAddress" class="button btn btn-default button-medium"><span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span></button>
+    </p>
+  </form>
 {else}
-    </div>
+  </div>
 {/if}
 {strip}
-{if !$opc}
+  {if !$opc}
     {addJsDef orderProcess='order'}
     {addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
     {addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
     {addJsDefL name=CloseTxt}{l s='Submit' js=1}{/addJsDefL}
     {addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address' js=1}{/addJsDefL}
-{/if}
-{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
-{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
-{addJsDef addressUrl=$smarty.capture.addressUrl}
-{capture}{'&multi-shipping=1'|urlencode}{/capture}
-{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
-{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
-{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
-{addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
-{addJsDef opc=$opc|boolval}
-{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
-{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
-{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
-{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {/if}
+  {capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+  {capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+  {addJsDef addressUrl=$smarty.capture.addressUrl}
+  {capture}{'&multi-shipping=1'|urlencode}{/capture}
+  {addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+  {capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+  {addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+  {addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
+  {addJsDef opc=$opc|boolval}
+  {capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+  {addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+  {addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+  {addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
 {/strip}

--- a/themes/community-theme-16/order-address-product-line.tpl
+++ b/themes/community-theme-16/order-address-product-line.tpl
@@ -24,55 +24,55 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <tr id="product_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" class="{if $productLast}last_item{elseif $productFirst}first_item{/if} {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0}alternate_item{/if} cart_item {if $odd}odd{else}even{/if}">
-    <td class="cart_product">
-        <a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}" {if isset($smallSize)}width="{$smallSize.width}" height="{$smallSize.height}" {/if} /></a>
-    </td>
-    <td class="cart_description">
-        <p class="product-name"><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}">{$product.name|escape:'html':'UTF-8'}</a></p>
-        {if isset($product.attributes) && $product.attributes}<small><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}">{$product.attributes|escape:'html':'UTF-8'}</a></small>{/if}
-    </td>
-    <td class="cart_ref">{if $product.reference}{$product.reference|escape:'html':'UTF-8'}{else}--{/if}</td>
-    <td class="cart_avail">{if $product.stock_quantity > 0}<span class="label label-success">{l s='In Stock'}</span>{else}<span class="label label-warning">{l s='Out of Stock'}</span>{/if}</td>
-    <td class="cart_quantity {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0} text-center {/if}">
+  <td class="cart_product">
+    <a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}" {if isset($smallSize)}width="{$smallSize.width}" height="{$smallSize.height}" {/if} /></a>
+  </td>
+  <td class="cart_description">
+    <p class="product-name"><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}">{$product.name|escape:'html':'UTF-8'}</a></p>
+    {if isset($product.attributes) && $product.attributes}<small><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category)|escape:'html':'UTF-8'}">{$product.attributes|escape:'html':'UTF-8'}</a></small>{/if}
+  </td>
+  <td class="cart_ref">{if $product.reference}{$product.reference|escape:'html':'UTF-8'}{else}--{/if}</td>
+  <td class="cart_avail">{if $product.stock_quantity > 0}<span class="label label-success">{l s='In Stock'}</span>{else}<span class="label label-warning">{l s='Out of Stock'}</span>{/if}</td>
+  <td class="cart_quantity {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0} text-center {/if}">
     {if isset($cannotModify) AND $cannotModify == 1}
-        <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
+      <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
     {else}
-        {if !isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0}
-            <input type="hidden" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}_hidden" />
-            <input size="2" type="text" class="cart_quantity_input form-control grey" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}"  name="quantity_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" />
-            <div class="cart_quantity_button">
-            {if $product.minimal_quantity < ($product.cart_quantity-$quantityDisplayed) OR $product.minimal_quantity <= 1}
+      {if !isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0}
+        <input type="hidden" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}_hidden" />
+        <input size="2" type="text" class="cart_quantity_input form-control grey" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}"  name="quantity_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" />
+        <div class="cart_quantity_button">
+          {if $product.minimal_quantity < ($product.cart_quantity-$quantityDisplayed) OR $product.minimal_quantity <= 1}
             <a rel="nofollow" class="cart_quantity_down btn btn-default button-minus" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}"><span><i class="icon-minus"></i></span></a>
-            {else}
+          {else}
             <a class="cart_quantity_down btn btn-default button-minus disabled" href="#" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" title="{l s='You must purchase a minimum of %d of this product.' sprintf=$product.minimal_quantity}"><span><i class="icon-minus"></i></span></a>
-            {/if}
-            <a rel="nofollow" class="cart_quantity_up btn btn-default button-plus" id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
-            </div>
-        {/if}
+          {/if}
+          <a rel="nofollow" class="cart_quantity_up btn btn-default button-plus" id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_0_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
+        </div>
+      {/if}
     {/if}
-    </td>
-    <td>
-        <form method="post" action="{$link->getPageLink('cart', true, NULL, "token={$token_cart}")|escape:'html':'UTF-8'}">
-            <div class="selector2">
-                <input type="hidden" name="id_product" value="{$product.id_product}" />
-                <input type="hidden" name="id_product_attribute" value="{$product.id_product_attribute}" />
-                <select name="address_delivery" id="select_address_delivery_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}" class="cart_address_delivery form-control">
-                    {if $product.id_address_delivery == 0 && $delivery->id == 0}
-                    <option></option>
-                    {/if}
-                    <option value="-1">{l s='Create a new address'}</option>
-                    {foreach $address_list as $address}
-                        <option value="{$address.id_address}"
-                            {if ($product.id_address_delivery > 0 && $product.id_address_delivery == $address.id_address) || ($product.id_address_delivery == 0  && $address.id_address == $delivery->id)}
-                                selected="selected"
-                            {/if}
-                        >
-                            {$address.alias}
-                        </option>
-                    {/foreach}
-                    <option value="-2">{l s='Ship to multiple addresses'}</option>
-                </select>
-            </div>
-        </form>
-    </td>
+  </td>
+  <td>
+    <form method="post" action="{$link->getPageLink('cart', true, NULL, "token={$token_cart}")|escape:'html':'UTF-8'}">
+      <div class="selector2">
+        <input type="hidden" name="id_product" value="{$product.id_product}" />
+        <input type="hidden" name="id_product_attribute" value="{$product.id_product_attribute}" />
+        <select name="address_delivery" id="select_address_delivery_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}" class="cart_address_delivery form-control">
+          {if $product.id_address_delivery == 0 && $delivery->id == 0}
+            <option></option>
+          {/if}
+          <option value="-1">{l s='Create a new address'}</option>
+          {foreach $address_list as $address}
+            <option value="{$address.id_address}"
+              {if ($product.id_address_delivery > 0 && $product.id_address_delivery == $address.id_address) || ($product.id_address_delivery == 0  && $address.id_address == $delivery->id)}
+                selected="selected"
+              {/if}
+            >
+              {$address.alias}
+            </option>
+          {/foreach}
+          <option value="-2">{l s='Ship to multiple addresses'}</option>
+        </select>
+      </div>
+    </form>
+  </td>
 </tr>

--- a/themes/community-theme-16/order-address.tpl
+++ b/themes/community-theme-16/order-address.tpl
@@ -23,117 +23,117 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !$opc}
-    {assign var='current_step' value='address'}
-    {capture name=path}{l s='Addresses'}{/capture}
-    {assign var="back_order_page" value="order.php"}
-    <h1 class="page-heading">{l s='Addresses'}</h1>
-    {include file="$tpl_dir./order-steps.tpl"}
-    {include file="$tpl_dir./errors.tpl"}
-        <form action="{$link->getPageLink($back_order_page, true)|escape:'html':'UTF-8'}" method="post">
+  {assign var='current_step' value='address'}
+  {capture name=path}{l s='Addresses'}{/capture}
+  {assign var="back_order_page" value="order.php"}
+  <h1 class="page-heading">{l s='Addresses'}</h1>
+  {include file="$tpl_dir./order-steps.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
+  <form action="{$link->getPageLink($back_order_page, true)|escape:'html':'UTF-8'}" method="post">
 {else}
-    {assign var="back_order_page" value="order-opc.php"}
-    <h1 class="page-heading step-num"><span>1</span> {l s='Addresses'}</h1>
-    <div id="opc_account" class="opc-main-block">
-        <div id="opc_account-overlay" class="opc-overlay" style="display: none;"></div>
+  {assign var="back_order_page" value="order-opc.php"}
+  <h1 class="page-heading step-num"><span>1</span> {l s='Addresses'}</h1>
+  <div id="opc_account" class="opc-main-block">
+    <div id="opc_account-overlay" class="opc-overlay" style="display: none;"></div>
 {/if}
 <div class="addresses clearfix">
-    <div class="row">
-        <div class="col-xs-12 col-sm-6">
-            <div class="address_delivery select form-group selector1">
-                <label for="id_address_delivery">{if $cart->isVirtualCart()}{l s='Choose a billing address:'}{else}{l s='Choose a delivery address:'}{/if}</label>
-                <select name="id_address_delivery" id="id_address_delivery" class="address_select form-control">
-                    {foreach from=$addresses key=k item=address}
-                        <option value="{$address.id_address|intval}"{if $address.id_address == $cart->id_address_delivery} selected="selected"{/if}>
-                            {$address.alias|escape:'html':'UTF-8'}
-                        </option>
-                    {/foreach}
-                </select><span class="waitimage"></span>
-            </div>
-            <p class="checkbox addressesAreEquals"{if $cart->isVirtualCart()} style="display:none;"{/if}>
-                <input type="checkbox" name="same" id="addressesAreEquals" value="1"{if $cart->id_address_invoice == $cart->id_address_delivery || $addresses|@count == 1} checked="checked"{/if} />
-                <label for="addressesAreEquals">{l s='Use the delivery address as the billing address.'}</label>
-            </p>
-        </div>
-        <div class="col-xs-12 col-sm-6">
-            <div id="address_invoice_form" class="select form-group selector1"{if $cart->id_address_invoice == $cart->id_address_delivery} style="display: none;"{/if}>
-                {if $addresses|@count > 1}
-                    <label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
-                    <select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
-                    {section loop=$addresses step=-1 name=address}
-                        <option value="{$addresses[address].id_address|intval}"{if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice} selected="selected"{/if}>
-                            {$addresses[address].alias|escape:'html':'UTF-8'}
-                        </option>
-                    {/section}
-                    </select><span class="waitimage"></span>
-                {else}
-                    <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1&select_address=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
-                        <span>
-                            {l s='Add a new address'}
-                            <i class="icon-chevron-right right"></i>
-                        </span>
-                    </a>
-                {/if}
-            </div>
-        </div>
-    </div> <!-- end row -->
-    <div class="row">
-        <div class="col-xs-12 col-sm-6"{if $cart->isVirtualCart()} style="display:none;"{/if}>
-            <ul class="address item box" id="address_delivery">
-            </ul>
-        </div>
-        <div class="col-xs-12 col-sm-6">
-            <ul class="address alternate_item{if $cart->isVirtualCart()} full_width{/if} box" id="address_invoice">
-            </ul>
-        </div>
-    </div> <!-- end row -->
-    <p class="address_add submit">
-        <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
-            <span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span>
-        </a>
-    </p>
-    {if !$opc}
-        <div id="ordermsg" class="form-group">
-            <label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
-            <textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
-        </div>
-    {/if}
+  <div class="row">
+    <div class="col-xs-12 col-sm-6">
+      <div class="address_delivery select form-group selector1">
+        <label for="id_address_delivery">{if $cart->isVirtualCart()}{l s='Choose a billing address:'}{else}{l s='Choose a delivery address:'}{/if}</label>
+        <select name="id_address_delivery" id="id_address_delivery" class="address_select form-control">
+          {foreach from=$addresses key=k item=address}
+            <option value="{$address.id_address|intval}"{if $address.id_address == $cart->id_address_delivery} selected="selected"{/if}>
+              {$address.alias|escape:'html':'UTF-8'}
+            </option>
+          {/foreach}
+        </select><span class="waitimage"></span>
+      </div>
+      <p class="checkbox addressesAreEquals"{if $cart->isVirtualCart()} style="display:none;"{/if}>
+        <input type="checkbox" name="same" id="addressesAreEquals" value="1"{if $cart->id_address_invoice == $cart->id_address_delivery || $addresses|@count == 1} checked="checked"{/if} />
+        <label for="addressesAreEquals">{l s='Use the delivery address as the billing address.'}</label>
+      </p>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+      <div id="address_invoice_form" class="select form-group selector1"{if $cart->id_address_invoice == $cart->id_address_delivery} style="display: none;"{/if}>
+        {if $addresses|@count > 1}
+          <label for="id_address_invoice" class="strong">{l s='Choose a billing address:'}</label>
+          <select name="id_address_invoice" id="id_address_invoice" class="address_select form-control">
+          {section loop=$addresses step=-1 name=address}
+             <option value="{$addresses[address].id_address|intval}"{if $addresses[address].id_address == $cart->id_address_invoice && $cart->id_address_delivery != $cart->id_address_invoice} selected="selected"{/if}>
+               {$addresses[address].alias|escape:'html':'UTF-8'}
+             </option>
+          {/section}
+          </select><span class="waitimage"></span>
+        {else}
+           <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1&select_address=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
+             <span>
+               {l s='Add a new address'}
+               <i class="icon-chevron-right right"></i>
+             </span>
+           </a>
+        {/if}
+      </div>
+    </div>
+  </div> <!-- end row -->
+  <div class="row">
+    <div class="col-xs-12 col-sm-6"{if $cart->isVirtualCart()} style="display:none;"{/if}>
+      <ul class="address item box" id="address_delivery">
+      </ul>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+      <ul class="address alternate_item{if $cart->isVirtualCart()} full_width{/if} box" id="address_invoice">
+      </ul>
+    </div>
+  </div> <!-- end row -->
+  <p class="address_add submit">
+    <a href="{$link->getPageLink('address', true, NULL, "back={$back_order_page}?step=1{if $back}&mod={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Add'}" class="button button-small btn btn-default">
+      <span>{l s='Add a new address'}<i class="icon-chevron-right right"></i></span>
+    </a>
+  </p>
+  {if !$opc}
+    <div id="ordermsg" class="form-group">
+       <label>{l s='If you would like to add a comment about your order, please write it in the field below.'}</label>
+       <textarea class="form-control" cols="60" rows="6" name="message">{if isset($oldMessage)}{$oldMessage}{/if}</textarea>
+    </div>
+  {/if}
 </div> <!-- end addresses -->
 {if !$opc}
-            <p class="cart_navigation clearfix">
-                <input type="hidden" class="hidden" name="step" value="2" />
-                <input type="hidden" name="back" value="{$back}" />
-                <a href="{$link->getPageLink($back_order_page, true, NULL, "{if $back}back={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                    <i class="icon-chevron-left"></i>
-                    {l s='Continue Shopping'}
-                </a>
-                <button type="submit" name="processAddress" class="button btn btn-default button-medium">
-                    <span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
-                </button>
-            </p>
-        </form>
+    <p class="cart_navigation clearfix">
+      <input type="hidden" class="hidden" name="step" value="2" />
+      <input type="hidden" name="back" value="{$back}" />
+      <a href="{$link->getPageLink($back_order_page, true, NULL, "{if $back}back={$back}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+        <i class="icon-chevron-left"></i>
+        {l s='Continue Shopping'}
+      </a>
+      <button type="submit" name="processAddress" class="button btn btn-default button-medium">
+        <span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
+      </button>
+    </p>
+  </form>
 {else}
-    </div> <!--  end opc_account -->
+  </div> <!--  end opc_account -->
 {/if}
 {strip}
-{if !$opc}
+  {if !$opc}
     {addJsDef orderProcess='order'}
     {addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
     {addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
     {addJsDefL name=CloseTxt}{l s='Submit' js=1}{/addJsDefL}
-{/if}
-{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
-{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
-{addJsDef addressUrl=$smarty.capture.addressUrl}
-{capture}{'&multi-shipping=1'|urlencode}{/capture}
-{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
-{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
-{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
-{addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
-{addJsDef opc=$opc|boolval}
-{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
-{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
-{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
-{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {/if}
+  {capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+  {capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+  {addJsDef addressUrl=$smarty.capture.addressUrl}
+  {capture}{'&multi-shipping=1'|urlencode}{/capture}
+  {addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+  {capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+  {addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+  {addJsDef formatedAddressFieldsValuesList=$formatedAddressFieldsValuesList}
+  {addJsDef opc=$opc|boolval}
+  {capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+  {addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+  {addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+  {addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
 {/strip}

--- a/themes/community-theme-16/order-carrier-advanced.tpl
+++ b/themes/community-theme-16/order-carrier-advanced.tpl
@@ -26,395 +26,395 @@
 {capture name=path}{l s='Shipping:'}{/capture}
 {assign var='current_step' value='shipping'}
 <div id="carrier_area">
-    <h2>{l s='Shipping:'}</h2>
-    {include file="$tpl_dir./order-steps.tpl"}
-    {include file="$tpl_dir./errors.tpl"}
-    <form id="form" action="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" method="post" name="carrier_area">
-        {else}
-        <div id="carrier_area" class="opc-main-block">
-            <h2>{l s='Delivery methods'}</h2>
-            <div id="opc_delivery_methods" class="opc-main-block">
-                <div id="opc_delivery_methods-overlay" class="opc-overlay" style="display: none;"></div>
-                {/if}
-                <div class="order_carrier_content box">
-                    {if isset($virtual_cart) && $virtual_cart}
-                        <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
-                    {else}
-                        <div id="HOOK_BEFORECARRIER">
-                            {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
-                                {$HOOK_BEFORECARRIER}
-                            {/if}
-                        </div>
-                        {if isset($isVirtualCart) && $isVirtualCart}
-                            <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
-                        {else}
-                            <div class="delivery_options_address">
-                                {if isset($delivery_option_list)}
-                                    {foreach $delivery_option_list as $id_address => $option_list}
-                                        <p class="carrier_title">
-                                            {if isset($address_collection[$id_address])}
-                                                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
-                                            {else}
-                                                {l s='Choose a shipping option'}
-                                            {/if}
-                                        </p>
-                                        <div class="delivery_options">
-                                            {foreach $option_list as $key => $option}
-                                                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
-                                                    <div>
-                                                        <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
-                                                            <tr>
-                                                                <td class="delivery_option_radio">
-                                                                    <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
-                                                                </td>
-                                                                <td class="delivery_option_logo">
-                                                                    {foreach $option.carrier_list as $carrier}
-                                                                        {if $carrier.logo}
-                                                                            <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                                        {elseif !$option.unique_carrier}
-                                                                            {$carrier.instance->name|escape:'htmlall':'UTF-8'}
-                                                                            {if !$carrier@last} - {/if}
-                                                                        {/if}
-                                                                    {/foreach}
-                                                                </td>
-                                                                <td>
-                                                                    {if $option.unique_carrier}
-                                                                        {foreach $option.carrier_list as $carrier}
-                                                                            <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
-                                                                        {/foreach}
-                                                                        {if isset($carrier.instance->delay[$cookie->id_lang])}
-                                                                            <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                    {/if}
-                                                                    {if count($option_list) > 1}
-                                                                        <br />
-                                                                        {if $option.is_best_grade}
-                                                                            {if $option.is_best_price}
-                                                                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
-                                                                            {else}
-                                                                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
-                                                                            {/if}
-                                                                        {elseif $option.is_best_price}
-                                                                            <span class="best_grade best_grade_price">{l s='The best price'}</span>
-                                                                        {/if}
-                                                                    {/if}
-                                                                </td>
-                                                                <td class="delivery_option_price">
-                                                                    <div class="delivery_option_price">
-                                                                        {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
-                                                                            {if $use_taxes == 1}
-                                                                                {if $priceDisplay == 1}
-                                                                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
-                                                                                {else}
-                                                                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
-                                                                                {/if}
-                                                                            {else}
-                                                                                {convertPrice price=$option.total_price_without_tax}
-                                                                            {/if}
-                                                                        {else}
-                                                                            {l s='Free'}
-                                                                        {/if}
-                                                                    </div>
-                                                                </td>
-                                                            </tr>
-                                                        </table>
-                                                        {if !$option.unique_carrier}
-                                                            <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
-                                                                <tr>
-                                                                    {if !$option.unique_carrier}
-                                                                        <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
-                                                                            <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
-                                                                        </td>
-                                                                    {/if}
-                                                                    {assign var="first" value=current($option.carrier_list)}
-                                                                    <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                                        {if $first.logo}
-                                                                            <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                                        {elseif !$option.unique_carrier}
-                                                                            {$first.instance->name|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                    </td>
-                                                                    <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                                        <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
-                                                                        {if isset($first.instance->delay[$cookie->id_lang])}
-                                                                            <i class="icon-info-sign"></i>
-                                                                            {strip}
-                                                                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                                &nbsp;
-                                                                                {if count($first.product_list) <= 1}
-                                                                                    ({l s='For this product:'}
-                                                                                {else}
-                                                                                    ({l s='For these products:'}
-                                                                                {/if}
-                                                                            {/strip}
-                                                                            {foreach $first.product_list as $product}
-                                                                                {if $product@index == 4}
-                                                                                    <acronym title="
-                                                                {/if}
-                                                                {strip}
-                                                                    {if $product@index >= 4}
-                                                                        {$product.name|escape:'htmlall':'UTF-8'}
-                                                                        {if isset($product.attributes) && $product.attributes}
-                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                        {if !$product@last}
-                                                                            ,&nbsp;
-                                                                        {else}
-                                                                            ">&hellip;</acronym>)
-                                                                            {/if}
-                                                                            {else}
-                                                                                {$product.name|escape:'htmlall':'UTF-8'}
-                                                                                {if isset($product.attributes) && $product.attributes}
-                                                                                    {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                                {/if}
-                                                                                {if !$product@last}
-                                                                                    ,&nbsp;
-                                                                                {else}
-                                                                                    )
-                                                                                {/if}
-                                                                            {/if}
-                                                                                {strip}
-                                                                            {/foreach}
-                                                                        {/if}
-                                                                    </td>
-                                                                    <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
-                                                                        <div class="delivery_option_price">
-                                                                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
-                                                                                {if $use_taxes == 1}
-                                                                                    {if $priceDisplay == 1}
-                                                                                        {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
-                                                                                    {else}
-                                                                                        {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
-                                                                                    {/if}
-                                                                                {else}
-                                                                                    {convertPrice price=$option.total_price_without_tax}
-                                                                                {/if}
-                                                                            {else}
-                                                                                {l s='Free'}
-                                                                            {/if}
-                                                                        </div>
-                                                                    </td>
-                                                                </tr>
-                                                                {foreach $option.carrier_list as $carrier}
-                                                                    {if $carrier@iteration != 1}
-                                                                        <tr>
-                                                                            <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                                                {if $carrier.logo}
-                                                                                    <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                                                {elseif !$option.unique_carrier}
-                                                                                    {$carrier.instance->name|escape:'htmlall':'UTF-8'}
-                                                                                {/if}
-                                                                            </td>
-                                                                            <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
-                                                                                {if isset($carrier.instance->delay[$cookie->id_lang])}
-                                                                                    <i class="icon-info-sign"></i>
-                                                                                    {strip}
-                                                                                        {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                                        &nbsp;
-                                                                                        {if count($first.product_list) <= 1}
-                                                                                            ({l s='For this product:'}
-                                                                                        {else}
-                                                                                            ({l s='For these products:'}
-                                                                                        {/if}
-                                                                                    {/strip}
-                                                                                    {foreach $carrier.product_list as $product}
-                                                                                        {if $product@index == 4}
-                                                                                            <acronym title="
-                                                                    {/if}
-                                                                    {strip}
-                                                                        {if $product@index >= 4}
-                                                                            {$product.name|escape:'htmlall':'UTF-8'}
-                                                                            {if isset($product.attributes) && $product.attributes}
-                                                                                {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                            {/if}
-                                                                            {if !$product@last}
-                                                                                ,&nbsp;
-                                                                            {else}
-                                                                                ">&hellip;</acronym>)
-                                                                                    {/if}
-                                                                                    {else}
-                                                                                        {$product.name|escape:'htmlall':'UTF-8'}
-                                                                                        {if isset($product.attributes) && $product.attributes}
-                                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                                        {/if}
-                                                                                        {if !$product@last}
-                                                                                            ,&nbsp;
-                                                                                        {else}
-                                                                                            )
-                                                                                        {/if}
-                                                                                    {/if}
-                                                                                        {strip}
-                                                                                    {/foreach}
-                                                                                {/if}
-                                                                            </td>
-                                                                        </tr>
-                                                                    {/if}
-                                                                {/foreach}
-                                                            </table>
-                                                        {/if}
-                                                    </div>
-                                                </div> <!-- end delivery_option -->
-                                            {/foreach}
-                                        </div> <!-- end delivery_options -->
-                                        <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
-                                            {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
-                                        </div>
-                                        {foreachelse}
-                                        {assign var='errors' value=' '|explode:''}
-                                        <p class="alert alert-warning" id="noCarrierWarning">
-                                            {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
-                                                {if empty($address->alias)}
-                                                    {l s='No carriers available.'}
-                                                {else}
-                                                    {assign var='flag_error_message' value=false}
-                                                    {foreach $errors as $error}
-                                                        {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
-                                                            {$flag_error_message = true}
-                                                            {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
-                                                        {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
-                                                            {$flag_error_message = true}
-                                                            {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
-                                                        {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
-                                                            {$flag_error_message = true}
-                                                            {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
-                                                        {/if}
-                                                    {/foreach}
-                                                    {if !$flag_error_message}
-                                                        {l s='No carriers available for the address "%s".' sprintf=$address->alias}
-                                                    {/if}
-                                                {/if}
-                                                {if !$address@last}
-                                                    <br />
-                                                {/if}
-                                                {foreachelse}
-                                                {l s='No carriers available.'}
-                                            {/foreach}
-                                        </p>
-                                    {/foreach}
-                                {/if}
-                            </div> <!-- end delivery_options_address -->
-                            <div id="extra_carrier" style="display: none;"></div>
-                            {if $opc}
-                                <p class="carrier_title">{l s='Leave a message'}</p>
-                                <div>
-                                    <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
-                        <textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
-                            {if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
-                        {/strip}</textarea>
-                                </div>
-                            {/if}
-                            {if $recyclablePackAllowed}
-                                <div class="checkbox recyclable">
-                                    <p class="carrier_title">{l s='Recyclable Packaging'}</p>
-                                    <label for="recyclable">
-                                        <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
-                                        {l s='I would like to receive my order in recycled packaging.'}
-                                    </label>
-                                </div>
-                            {/if}
-                            {if $giftAllowed}
-                                {if $opc}
-                                    <hr style="" />
-                                {/if}
-                                <p class="carrier_title">{l s='Gift'}</p>
-                                <p class="checkbox gift">
-                                    <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
-                                    <label for="gift">
-                                        {l s='I would like my order to be gift wrapped.'}
-                                        {if $gift_wrapping_price > 0}
-                                            &nbsp;<i>({l s='Additional cost of'}
-                                            <span class="price" id="gift-price">
-                                    {if $priceDisplay == 1}
-                                        {convertPrice price=$total_wrapping_tax_exc_cost}
-                                    {else}
-                                        {convertPrice price=$total_wrapping_cost}
-                                    {/if}
-                                </span>
-                                            {if $use_taxes && $display_tax_label}
-                                                {if $priceDisplay == 1}
-                                                    {l s='(tax excl.)'}
-                                                {else}
-                                                    {l s='(tax incl.)'}
-                                                {/if}
-                                            {/if})
-                                        </i>
-                                        {/if}
-                                    </label>
-                                </p>
-                                <p id="gift_div">
-                                    <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
-                                    <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
-                                </p>
-                            {/if}
-                        {/if}
-                    {/if}
-                    {if $conditions && $cms_id && !$advanced_payment_api}
-                        {if $opc}
-                            <hr style="" />
-                        {/if}
-                        {if $override_tos_display }
-                            {$override_tos_display}
-                        {else}
-                            <div class="box">
-                                <p class="checkbox">
-                                    <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
-                                    <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
-                                    <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
-                                </p>
-                            </div>
-                        {/if}
-                    {/if}
-                </div> <!-- end delivery_options_address -->
-                {if !$opc}
-                <p class="cart_navigation clearfix">
-                    <input type="hidden" name="step" value="3" />
-                    <input type="hidden" name="back" value="{$back}" />
-                    {if !$is_guest}
-                        {if $back}
-                            <a href="{$link->getPageLink('order', true, NULL, "step=1&back={$back}{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                                <i class="icon-chevron-left"></i>
-                                {l s='Continue shopping'}
-                            </a>
-                        {else}
-                            <a href="{$link->getPageLink('order', true, NULL, "step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                                <i class="icon-chevron-left"></i>
-                                {l s='Continue shopping'}
-                            </a>
-                        {/if}
-                    {else}
-                        <a href="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                            <i class="icon-chevron-left"></i>
-                            {l s='Continue shopping'}
-                        </a>
-                    {/if}
-                    {if isset($virtual_cart) && $virtual_cart || (isset($delivery_option_list) && !empty($delivery_option_list))}
-                        <button type="submit" name="processCarrier" class="button btn btn-default standard-checkout button-medium">
-                            <span>
-                                {l s='Proceed to checkout'}
-                                <i class="icon-chevron-right right"></i>
-                            </span>
-                        </button>
-                    {/if}
-                </p>
-    </form>
+  <h2>{l s='Shipping:'}</h2>
+  {include file="$tpl_dir./order-steps.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
+  <form id="form" action="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" method="post" name="carrier_area">
+{else}
+  <div id="carrier_area" class="opc-main-block">
+    <h2>{l s='Delivery methods'}</h2>
+    <div id="opc_delivery_methods" class="opc-main-block">
+      <div id="opc_delivery_methods-overlay" class="opc-overlay" style="display: none;"></div>
+{/if}
+<div class="order_carrier_content box">
+  {if isset($virtual_cart) && $virtual_cart}
+    <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
+  {else}
+    <div id="HOOK_BEFORECARRIER">
+      {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
+        {$HOOK_BEFORECARRIER}
+      {/if}
+    </div>
+    {if isset($isVirtualCart) && $isVirtualCart}
+      <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
     {else}
-</div>
+      <div class="delivery_options_address">
+        {if isset($delivery_option_list)}
+          {foreach $delivery_option_list as $id_address => $option_list}
+            <p class="carrier_title">
+              {if isset($address_collection[$id_address])}
+                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
+              {else}
+                {l s='Choose a shipping option'}
+              {/if}
+            </p>
+            <div class="delivery_options">
+              {foreach $option_list as $key => $option}
+                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
+                  <div>
+                    <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
+                      <tr>
+                        <td class="delivery_option_radio">
+                          <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                        </td>
+                        <td class="delivery_option_logo">
+                          {foreach $option.carrier_list as $carrier}
+                            {if $carrier.logo}
+                              <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                            {elseif !$option.unique_carrier}
+                              {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                              {if !$carrier@last} - {/if}
+                            {/if}
+                          {/foreach}
+                        </td>
+                        <td>
+                          {if $option.unique_carrier}
+                            {foreach $option.carrier_list as $carrier}
+                              <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
+                            {/foreach}
+                            {if isset($carrier.instance->delay[$cookie->id_lang])}
+                              <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                            {/if}
+                          {/if}
+                          {if count($option_list) > 1}
+                            <br />
+                            {if $option.is_best_grade}
+                              {if $option.is_best_price}
+                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
+                              {else}
+                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
+                              {/if}
+                            {elseif $option.is_best_price}
+                              <span class="best_grade best_grade_price">{l s='The best price'}</span>
+                            {/if}
+                          {/if}
+                        </td>
+                        <td class="delivery_option_price">
+                          <div class="delivery_option_price">
+                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                              {if $use_taxes == 1}
+                                {if $priceDisplay == 1}
+                                  {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                {else}
+                                  {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                {/if}
+                              {else}
+                                {convertPrice price=$option.total_price_without_tax}
+                              {/if}
+                            {else}
+                              {l s='Free'}
+                            {/if}
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+                    {if !$option.unique_carrier}
+                      <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
+                        <tr>
+                          {if !$option.unique_carrier}
+                            <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
+                              <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                            </td>
+                          {/if}
+                          {assign var="first" value=current($option.carrier_list)}
+                          <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                            {if $first.logo}
+                              <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
+                            {elseif !$option.unique_carrier}
+                              {$first.instance->name|escape:'htmlall':'UTF-8'}
+                            {/if}
+                          </td>
+                          <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                            <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                            {if isset($first.instance->delay[$cookie->id_lang])}
+                              <i class="icon-info-sign"></i>
+                              {strip}
+                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                &nbsp;
+                                {if count($first.product_list) <= 1}
+                                  ({l s='For this product:'}
+                                {else}
+                                  ({l s='For these products:'}
+                                {/if}
+                              {/strip}
+                              {foreach $first.product_list as $product}
+                                {if $product@index == 4}
+                                  <acronym title="
+                                {/if}
+                                {strip}
+                                  {if $product@index >= 4}
+                                    {$product.name|escape:'htmlall':'UTF-8'}
+                                    {if isset($product.attributes) && $product.attributes}
+                                        {$product.attributes|escape:'htmlall':'UTF-8'}
+                                    {/if}
+                                    {if !$product@last}
+                                        ,&nbsp;
+                                    {else}
+                                        ">&hellip;</acronym>)
+                                    {/if}
+                                  {else}
+                                    {$product.name|escape:'htmlall':'UTF-8'}
+                                    {if isset($product.attributes) && $product.attributes}
+                                      {$product.attributes|escape:'htmlall':'UTF-8'}
+                                    {/if}
+                                    {if !$product@last}
+                                      ,&nbsp;
+                                    {else}
+                                      )
+                                    {/if}
+                                  {/if}
+                                {strip}
+                              {/foreach}
+                            {/if}
+                          </td>
+                          <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
+                            <div class="delivery_option_price">
+                              {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                {if $use_taxes == 1}
+                                  {if $priceDisplay == 1}
+                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                  {else}
+                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                  {/if}
+                                {else}
+                                  {convertPrice price=$option.total_price_without_tax}
+                                {/if}
+                              {else}
+                                {l s='Free'}
+                              {/if}
+                            </div>
+                          </td>
+                        </tr>
+                        {foreach $option.carrier_list as $carrier}
+                          {if $carrier@iteration != 1}
+                            <tr>
+                              <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                {if $carrier.logo}
+                                  <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                {elseif !$option.unique_carrier}
+                                  {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                                {/if}
+                              </td>
+                              <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                  <i class="icon-info-sign"></i>
+                                  {strip}
+                                    {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                    &nbsp;
+                                    {if count($first.product_list) <= 1}
+                                      ({l s='For this product:'}
+                                    {else}
+                                      ({l s='For these products:'}
+                                    {/if}
+                                  {/strip}
+                                  {foreach $carrier.product_list as $product}
+                                    {if $product@index == 4}
+                                      <acronym title="
+                                    {/if}
+                                    {strip}
+                                      {if $product@index >= 4}
+                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                        {if isset($product.attributes) && $product.attributes}
+                                            {$product.attributes|escape:'htmlall':'UTF-8'}
+                                        {/if}
+                                        {if !$product@last}
+                                            ,&nbsp;
+                                        {else}
+                                            ">&hellip;</acronym>)
+                                        {/if}
+                                      {else}
+                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                        {if isset($product.attributes) && $product.attributes}
+                                          {$product.attributes|escape:'htmlall':'UTF-8'}
+                                        {/if}
+                                        {if !$product@last}
+                                          ,&nbsp;
+                                        {else}
+                                          )
+                                        {/if}
+                                      {/if}
+                                    {strip}
+                                  {/foreach}
+                                {/if}
+                              </td>
+                            </tr>
+                          {/if}
+                        {/foreach}
+                      </table>
+                    {/if}
+                  </div>
+                </div> <!-- end delivery_option -->
+              {/foreach}
+            </div> <!-- end delivery_options -->
+            <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
+              {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
+            </div>
+            {foreachelse}
+            {assign var='errors' value=' '|explode:''}
+            <p class="alert alert-warning" id="noCarrierWarning">
+              {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
+                {if empty($address->alias)}
+                  {l s='No carriers available.'}
+                {else}
+                  {assign var='flag_error_message' value=false}
+                  {foreach $errors as $error}
+                    {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
+                    {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
+                    {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
+                    {/if}
+                  {/foreach}
+                  {if !$flag_error_message}
+                    {l s='No carriers available for the address "%s".' sprintf=$address->alias}
+                  {/if}
+                {/if}
+                {if !$address@last}
+                  <br />
+                {/if}
+                {foreachelse}
+                {l s='No carriers available.'}
+              {/foreach}
+            </p>
+          {/foreach}
+        {/if}
+      </div> <!-- end delivery_options_address -->
+      <div id="extra_carrier" style="display: none;"></div>
+      {if $opc}
+        <p class="carrier_title">{l s='Leave a message'}</p>
+        <div>
+          <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
+            <textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
+                {if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
+            {/strip}</textarea>
+        </div>
+      {/if}
+      {if $recyclablePackAllowed}
+        <div class="checkbox recyclable">
+          <p class="carrier_title">{l s='Recyclable Packaging'}</p>
+          <label for="recyclable">
+            <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
+            {l s='I would like to receive my order in recycled packaging.'}
+          </label>
+        </div>
+      {/if}
+      {if $giftAllowed}
+        {if $opc}
+          <hr style="" />
+        {/if}
+        <p class="carrier_title">{l s='Gift'}</p>
+        <p class="checkbox gift">
+          <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
+          <label for="gift">
+            {l s='I would like my order to be gift wrapped.'}
+            {if $gift_wrapping_price > 0}
+              &nbsp;<i>({l s='Additional cost of'}
+              <span class="price" id="gift-price">
+                {if $priceDisplay == 1}
+                  {convertPrice price=$total_wrapping_tax_exc_cost}
+                {else}
+                  {convertPrice price=$total_wrapping_cost}
+                {/if}
+              </span>
+              {if $use_taxes && $display_tax_label}
+                {if $priceDisplay == 1}
+                  {l s='(tax excl.)'}
+                {else}
+                  {l s='(tax incl.)'}
+                {/if}
+              {/if})
+            </i>
+            {/if}
+          </label>
+        </p>
+        <p id="gift_div">
+          <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
+          <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
+        </p>
+      {/if}
+    {/if}
+  {/if}
+  {if $conditions && $cms_id && !$advanced_payment_api}
+    {if $opc}
+      <hr style="" />
+    {/if}
+    {if $override_tos_display }
+      {$override_tos_display}
+    {else}
+      <div class="box">
+        <p class="checkbox">
+          <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+          <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+          <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+        </p>
+      </div>
+    {/if}
+  {/if}
+</div> <!-- end delivery_options_address -->
+{if !$opc}
+    <p class="cart_navigation clearfix">
+      <input type="hidden" name="step" value="3" />
+      <input type="hidden" name="back" value="{$back}" />
+      {if !$is_guest}
+        {if $back}
+          <a href="{$link->getPageLink('order', true, NULL, "step=1&back={$back}{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+            <i class="icon-chevron-left"></i>
+            {l s='Continue shopping'}
+          </a>
+        {else}
+          <a href="{$link->getPageLink('order', true, NULL, "step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+            <i class="icon-chevron-left"></i>
+            {l s='Continue shopping'}
+          </a>
+        {/if}
+      {else}
+        <a href="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+          <i class="icon-chevron-left"></i>
+          {l s='Continue shopping'}
+        </a>
+      {/if}
+      {if isset($virtual_cart) && $virtual_cart || (isset($delivery_option_list) && !empty($delivery_option_list))}
+        <button type="submit" name="processCarrier" class="button btn btn-default standard-checkout button-medium">
+          <span>
+            {l s='Proceed to checkout'}
+            <i class="icon-chevron-right right"></i>
+          </span>
+        </button>
+      {/if}
+    </p>
+  </form>
+{else}
+  </div>
 {/if}
 </div> <!-- end carrier_area -->
 {strip}
-    {if !$opc}
-        {addJsDef orderProcess='order'}
-        {if isset($virtual_cart) && !$virtual_cart && $giftAllowed && $cart->gift == 1}
-            {addJsDef cart_gift=true}
-        {else}
-            {addJsDef cart_gift=false}
-        {/if}
-        {addJsDef orderUrl=$link->getPageLink("order", true)|escape:'quotes':'UTF-8'}
-        {addJsDefL name=txtProduct}{l s='Product' js=1}{/addJsDefL}
-        {addJsDefL name=txtProducts}{l s='Products' js=1}{/addJsDefL}
+  {if !$opc}
+    {addJsDef orderProcess='order'}
+    {if isset($virtual_cart) && !$virtual_cart && $giftAllowed && $cart->gift == 1}
+      {addJsDef cart_gift=true}
+    {else}
+      {addJsDef cart_gift=false}
     {/if}
-    {if $conditions}
-        {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
-    {/if}
+    {addJsDef orderUrl=$link->getPageLink("order", true)|escape:'quotes':'UTF-8'}
+    {addJsDefL name=txtProduct}{l s='Product' js=1}{/addJsDefL}
+    {addJsDefL name=txtProducts}{l s='Products' js=1}{/addJsDefL}
+  {/if}
+  {if $conditions}
+    {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/order-carrier-opc-advanced.tpl
+++ b/themes/community-theme-16/order-carrier-opc-advanced.tpl
@@ -23,338 +23,338 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="order_carrier_content box">
-    {if isset($virtual_cart) && $virtual_cart}
-        <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
+  {if isset($virtual_cart) && $virtual_cart}
+    <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
+  {else}
+    <div id="HOOK_BEFORECARRIER">
+      {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
+        {$HOOK_BEFORECARRIER}
+      {/if}
+    </div>
+    {if isset($isVirtualCart) && $isVirtualCart}
+      <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
     {else}
-        <div id="HOOK_BEFORECARRIER">
-            {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
-                {$HOOK_BEFORECARRIER}
-            {/if}
-        </div>
-        {if isset($isVirtualCart) && $isVirtualCart}
-            <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
-        {else}
-            <div class="delivery_options_address">
-                {if isset($delivery_option_list)}
-                    {foreach $delivery_option_list as $id_address => $option_list}
-                        <p class="carrier_title">
-                            {if isset($address_collection[$id_address])}
-                                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
-                            {else}
-                                {l s='Choose a shipping option'}
+      <div class="delivery_options_address">
+        {if isset($delivery_option_list)}
+          {foreach $delivery_option_list as $id_address => $option_list}
+            <p class="carrier_title">
+              {if isset($address_collection[$id_address])}
+                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
+              {else}
+                {l s='Choose a shipping option'}
+              {/if}
+            </p>
+            <div class="delivery_options">
+              {foreach $option_list as $key => $option}
+                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
+                  <div>
+                    <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
+                      <tr>
+                        <td class="delivery_option_radio">
+                          <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                        </td>
+                        <td class="delivery_option_logo">
+                          {foreach $option.carrier_list as $carrier}
+                            {if $carrier.logo}
+                              <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                            {elseif !$option.unique_carrier}
+                              {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                              {if !$carrier@last} - {/if}
                             {/if}
-                        </p>
-                        <div class="delivery_options">
-                            {foreach $option_list as $key => $option}
-                                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
-                                    <div>
-                                        <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
-                                            <tr>
-                                                <td class="delivery_option_radio">
-                                                    <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
-                                                </td>
-                                                <td class="delivery_option_logo">
-                                                    {foreach $option.carrier_list as $carrier}
-                                                        {if $carrier.logo}
-                                                            <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                        {elseif !$option.unique_carrier}
-                                                            {$carrier.instance->name|escape:'htmlall':'UTF-8'}
-                                                            {if !$carrier@last} - {/if}
-                                                        {/if}
-                                                    {/foreach}
-                                                </td>
-                                                <td>
-                                                    {if $option.unique_carrier}
-                                                        {foreach $option.carrier_list as $carrier}
-                                                            <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
-                                                        {/foreach}
-                                                        {if isset($carrier.instance->delay[$cookie->id_lang])}
-                                                            <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                        {/if}
-                                                    {/if}
-                                                    {if count($option_list) > 1}
-                                                        <br />
-                                                        {if $option.is_best_grade}
-                                                            {if $option.is_best_price}
-                                                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
-                                                            {else}
-                                                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
-                                                            {/if}
-                                                        {elseif $option.is_best_price}
-                                                            <span class="best_grade best_grade_price">{l s='The best price'}</span>
-                                                        {/if}
-                                                    {/if}
-                                                </td>
-                                                <td class="delivery_option_price">
-                                                    <div class="delivery_option_price">
-                                                        {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
-                                                            {if $use_taxes == 1}
-                                                                {if $priceDisplay == 1}
-                                                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
-                                                                {else}
-                                                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
-                                                                {/if}
-                                                            {else}
-                                                                {convertPrice price=$option.total_price_without_tax}
-                                                            {/if}
-                                                        {else}
-                                                            {l s='Free'}
-                                                        {/if}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                        {if !$option.unique_carrier}
-                                            <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
-                                                <tr>
-                                                    {if !$option.unique_carrier}
-                                                        <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
-                                                            <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
-                                                        </td>
-                                                    {/if}
-                                                    {assign var="first" value=current($option.carrier_list)}
-                                                    <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                        {if $first.logo}
-                                                            <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                        {elseif !$option.unique_carrier}
-                                                            {$first.instance->name|escape:'htmlall':'UTF-8'}
-                                                        {/if}
-                                                    </td>
-                                                    <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                        <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
-                                                        {if isset($first.instance->delay[$cookie->id_lang])}
-                                                            <i class="icon-info-sign"></i>
-                                                            {strip}
-                                                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                &nbsp;
-                                                                {if count($first.product_list) <= 1}
-                                                                    ({l s='For this product:'}
-                                                                {else}
-                                                                    ({l s='For these products:'}
-                                                                {/if}
-                                                            {/strip}
-                                                            {foreach $first.product_list as $product}
-                                                                {if $product@index == 4}
-                                                                    <acronym title="
-                                                                {/if}
-                                                                {strip}
-                                                                    {if $product@index >= 4}
-                                                                        {$product.name|escape:'htmlall':'UTF-8'}
-                                                                        {if isset($product.attributes) && $product.attributes}
-                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                        {if !$product@last}
-                                                                            ,&nbsp;
-                                                                        {else}
-                                                                            ">&hellip;</acronym>)
-                                                                        {/if}
-                                                                    {else}
-                                                                        {$product.name|escape:'htmlall':'UTF-8'}
-                                                                        {if isset($product.attributes) && $product.attributes}
-                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                        {if !$product@last}
-                                                                            ,&nbsp;
-                                                                        {else}
-                                                                            )
-                                                                        {/if}
-                                                                    {/if}
-                                                                {/strip}
-                                                            {/foreach}
-                                                        {/if}
-                                                    </td>
-                                                    <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
-                                                        <div class="delivery_option_price">
-                                                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
-                                                                {if $use_taxes == 1}
-                                                                    {if $priceDisplay == 1}
-                                                                        {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
-                                                                    {else}
-                                                                        {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
-                                                                    {/if}
-                                                                {else}
-                                                                    {convertPrice price=$option.total_price_without_tax}
-                                                                {/if}
-                                                            {else}
-                                                                {l s='Free'}
-                                                            {/if}
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                                {foreach $option.carrier_list as $carrier}
-                                                    {if $carrier@iteration != 1}
-                                                        <tr>
-                                                            <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                                {if $carrier.logo}
-                                                                    <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                                {elseif !$option.unique_carrier}
-                                                                    {$carrier.instance->name|escape:'htmlall':'UTF-8'}
-                                                                {/if}
-                                                            </td>
-                                                            <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
-                                                                {if isset($carrier.instance->delay[$cookie->id_lang])}
-                                                                    <i class="icon-info-sign"></i>
-                                                                    {strip}
-                                                                        {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                        &nbsp;
-                                                                        {if count($first.product_list) <= 1}
-                                                                            ({l s='For this product:'}
-                                                                        {else}
-                                                                            ({l s='For these products:'}
-                                                                        {/if}
-                                                                    {/strip}
-                                                                    {foreach $carrier.product_list as $product}
-                                                                        {if $product@index == 4}
-                                                                            <acronym title="
-                                                                        {/if}
-                                                                        {strip}
-                                                                            {if $product@index >= 4}
-                                                                                {$product.name|escape:'htmlall':'UTF-8'}
-                                                                                {if isset($product.attributes) && $product.attributes}
-                                                                                    {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                                {/if}
-                                                                                {if !$product@last}
-                                                                                    ,&nbsp;
-                                                                                {else}
-                                                                                    ">&hellip;</acronym>)
-                                                                                {/if}
-                                                                            {else}
-                                                                                {$product.name|escape:'htmlall':'UTF-8'}
-                                                                                {if isset($product.attributes) && $product.attributes}
-                                                                                    {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                                {/if}
-                                                                                {if !$product@last}
-                                                                                    ,&nbsp;
-                                                                                {else}
-                                                                                    )
-                                                                                {/if}
-                                                                            {/if}
-                                                                        {/strip}
-                                                                    {/foreach}
-                                                                {/if}
-                                                            </td>
-                                                        </tr>
-                                                    {/if}
-                                                {/foreach}
-                                            </table>
-                                        {/if}
-                                    </div>
-                                </div> <!-- end delivery_option -->
+                          {/foreach}
+                        </td>
+                        <td>
+                          {if $option.unique_carrier}
+                            {foreach $option.carrier_list as $carrier}
+                              <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
                             {/foreach}
-                        </div> <!-- end delivery_options -->
-                        <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
-                            {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
-                        </div>
-                        {foreachelse}
-                        {assign var='errors' value=' '|explode:''}
-                        <p class="alert alert-warning" id="noCarrierWarning">
-                            {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
-                                {if empty($address->alias)}
-                                    {l s='No carriers available.'}
+                            {if isset($carrier.instance->delay[$cookie->id_lang])}
+                              <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                            {/if}
+                          {/if}
+                          {if count($option_list) > 1}
+                            <br />
+                            {if $option.is_best_grade}
+                              {if $option.is_best_price}
+                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
+                              {else}
+                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
+                              {/if}
+                            {elseif $option.is_best_price}
+                              <span class="best_grade best_grade_price">{l s='The best price'}</span>
+                            {/if}
+                          {/if}
+                        </td>
+                        <td class="delivery_option_price">
+                          <div class="delivery_option_price">
+                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                              {if $use_taxes == 1}
+                                {if $priceDisplay == 1}
+                                  {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
                                 {else}
-                                    {assign var='flag_error_message' value=false}
-                                    {foreach $errors as $error}
-                                        {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
-                                            {$flag_error_message = true}
-                                            {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
-                                        {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
-                                            {$flag_error_message = true}
-                                            {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
-                                        {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
-                                            {$flag_error_message = true}
-                                            {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
-                                        {/if}
-                                    {/foreach}
-                                    {if !$flag_error_message}
-                                        {l s='No carriers available for the address "%s".' sprintf=$address->alias}
+                                  {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                {/if}
+                              {else}
+                                {convertPrice price=$option.total_price_without_tax}
+                              {/if}
+                            {else}
+                              {l s='Free'}
+                            {/if}
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+                    {if !$option.unique_carrier}
+                      <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
+                        <tr>
+                          {if !$option.unique_carrier}
+                            <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
+                              <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                            </td>
+                          {/if}
+                          {assign var="first" value=current($option.carrier_list)}
+                          <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                            {if $first.logo}
+                              <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
+                            {elseif !$option.unique_carrier}
+                              {$first.instance->name|escape:'htmlall':'UTF-8'}
+                            {/if}
+                          </td>
+                          <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                            <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                            {if isset($first.instance->delay[$cookie->id_lang])}
+                              <i class="icon-info-sign"></i>
+                              {strip}
+                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                &nbsp;
+                                {if count($first.product_list) <= 1}
+                                  ({l s='For this product:'}
+                                {else}
+                                  ({l s='For these products:'}
+                                {/if}
+                              {/strip}
+                              {foreach $first.product_list as $product}
+                                {if $product@index == 4}
+                                  <acronym title="
+                                {/if}
+                                {strip}
+                                  {if $product@index >= 4}
+                                    {$product.name|escape:'htmlall':'UTF-8'}
+                                    {if isset($product.attributes) && $product.attributes}
+                                        {$product.attributes|escape:'htmlall':'UTF-8'}
                                     {/if}
+                                    {if !$product@last}
+                                        ,&nbsp;
+                                    {else}
+                                        ">&hellip;</acronym>)
+                                    {/if}
+                                  {else}
+                                    {$product.name|escape:'htmlall':'UTF-8'}
+                                    {if isset($product.attributes) && $product.attributes}
+                                      {$product.attributes|escape:'htmlall':'UTF-8'}
+                                    {/if}
+                                    {if !$product@last}
+                                      ,&nbsp;
+                                    {else}
+                                      )
+                                    {/if}
+                                  {/if}
+                              {/strip}
+                              {/foreach}
+                            {/if}
+                          </td>
+                          <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
+                            <div class="delivery_option_price">
+                              {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                {if $use_taxes == 1}
+                                  {if $priceDisplay == 1}
+                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                  {else}
+                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                  {/if}
+                                {else}
+                                  {convertPrice price=$option.total_price_without_tax}
                                 {/if}
-                                {if !$address@last}
-                                    <br />
+                              {else}
+                                {l s='Free'}
+                              {/if}
+                            </div>
+                          </td>
+                        </tr>
+                        {foreach $option.carrier_list as $carrier}
+                          {if $carrier@iteration != 1}
+                            <tr>
+                              <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                {if $carrier.logo}
+                                  <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                {elseif !$option.unique_carrier}
+                                  {$carrier.instance->name|escape:'htmlall':'UTF-8'}
                                 {/if}
-                                {foreachelse}
-                                {l s='No carriers available.'}
-                            {/foreach}
-                        </p>
-                    {/foreach}
+                              </td>
+                              <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                  <i class="icon-info-sign"></i>
+                                  {strip}
+                                    {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                    &nbsp;
+                                    {if count($first.product_list) <= 1}
+                                      ({l s='For this product:'}
+                                    {else}
+                                      ({l s='For these products:'}
+                                    {/if}
+                                  {/strip}
+                                  {foreach $carrier.product_list as $product}
+                                    {if $product@index == 4}
+                                      <acronym title="
+                                    {/if}
+                                    {strip}
+                                      {if $product@index >= 4}
+                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                        {if isset($product.attributes) && $product.attributes}
+                                            {$product.attributes|escape:'htmlall':'UTF-8'}
+                                        {/if}
+                                        {if !$product@last}
+                                            ,&nbsp;
+                                        {else}
+                                            ">&hellip;</acronym>)
+                                        {/if}
+                                      {else}
+                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                        {if isset($product.attributes) && $product.attributes}
+                                          {$product.attributes|escape:'htmlall':'UTF-8'}
+                                        {/if}
+                                        {if !$product@last}
+                                          ,&nbsp;
+                                        {else}
+                                          )
+                                        {/if}
+                                      {/if}
+                                    {/strip}
+                                  {/foreach}
+                                {/if}
+                              </td>
+                            </tr>
+                          {/if}
+                        {/foreach}
+                      </table>
+                    {/if}
+                  </div>
+                </div> <!-- end delivery_option -->
+              {/foreach}
+            </div> <!-- end delivery_options -->
+            <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
+              {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
+            </div>
+            {foreachelse}
+            {assign var='errors' value=' '|explode:''}
+            <p class="alert alert-warning" id="noCarrierWarning">
+              {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
+                {if empty($address->alias)}
+                  {l s='No carriers available.'}
+                {else}
+                  {assign var='flag_error_message' value=false}
+                  {foreach $errors as $error}
+                    {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
+                    {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
+                    {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
+                    {/if}
+                  {/foreach}
+                  {if !$flag_error_message}
+                    {l s='No carriers available for the address "%s".' sprintf=$address->alias}
+                  {/if}
                 {/if}
-            </div> <!-- end delivery_options_address -->
-            <div id="extra_carrier" style="display: none;"></div>
-            {if $opc}
-                <p class="carrier_title">{l s='Leave a message'}</p>
-                <div>
-                    <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
+                {if !$address@last}
+                  <br />
+                {/if}
+                {foreachelse}
+                {l s='No carriers available.'}
+              {/foreach}
+            </p>
+          {/foreach}
+        {/if}
+      </div> <!-- end delivery_options_address -->
+      <div id="extra_carrier" style="display: none;"></div>
+      {if $opc}
+        <p class="carrier_title">{l s='Leave a message'}</p>
+        <div>
+          <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
         <textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
             {if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
         {/strip}</textarea>
-                </div>
-            {/if}
-            {if $recyclablePackAllowed}
-                <p class="carrier_title">{l s='Recyclable Packaging'}</p>
-                <div class="checkbox recyclable">
-                    <label for="recyclable">
-                        <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
-                        {l s='I would like to receive my order in recycled packaging.'}
-                    </label>
-                </div>
-            {/if}
-            {if $giftAllowed}
-                {if $opc}
-                    <hr style="" />
-                {/if}
-                <p class="carrier_title">{l s='Gift'}</p>
-                <p class="checkbox gift">
-                    <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
-                    <label for="gift">
-                        {l s='I would like my order to be gift wrapped.'}
-                        {if $gift_wrapping_price > 0}
-                            &nbsp;<i>({l s='Additional cost of'}
-                            <span class="price" id="gift-price">
+        </div>
+      {/if}
+      {if $recyclablePackAllowed}
+        <p class="carrier_title">{l s='Recyclable Packaging'}</p>
+        <div class="checkbox recyclable">
+          <label for="recyclable">
+            <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
+            {l s='I would like to receive my order in recycled packaging.'}
+          </label>
+        </div>
+      {/if}
+      {if $giftAllowed}
+        {if $opc}
+          <hr style="" />
+        {/if}
+        <p class="carrier_title">{l s='Gift'}</p>
+        <p class="checkbox gift">
+          <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
+          <label for="gift">
+            {l s='I would like my order to be gift wrapped.'}
+            {if $gift_wrapping_price > 0}
+              &nbsp;<i>({l s='Additional cost of'}
+              <span class="price" id="gift-price">
                     {if $priceDisplay == 1}
-                        {convertPrice price=$total_wrapping_tax_exc_cost}
+                      {convertPrice price=$total_wrapping_tax_exc_cost}
                     {else}
-                        {convertPrice price=$total_wrapping_cost}
+                      {convertPrice price=$total_wrapping_cost}
                     {/if}
                 </span>
-                            {if $use_taxes && $display_tax_label}
-                                {if $priceDisplay == 1}
-                                    {l s='(tax excl.)'}
-                                {else}
-                                    {l s='(tax incl.)'}
-                                {/if}
-                            {/if})
-                        </i>
-                        {/if}
-                    </label>
-                </p>
-                <p id="gift_div">
-                    <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
-                    <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
-                </p>
+              {if $use_taxes && $display_tax_label}
+                {if $priceDisplay == 1}
+                  {l s='(tax excl.)'}
+                {else}
+                  {l s='(tax incl.)'}
+                {/if}
+              {/if})
+            </i>
             {/if}
-        {/if}
+          </label>
+        </p>
+        <p id="gift_div">
+          <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
+          <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
+        </p>
+      {/if}
     {/if}
-    {if $conditions && $cms_id && !$advanced_payment_api}
-        {if $opc}
-            <hr style="" />
-        {/if}
-        {if $override_tos_display }
-            {$override_tos_display}
-        {else}
-            <div class="box">
-                <p class="checkbox">
-                    <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
-                    <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
-                    <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
-                </p>
-            </div>
-        {/if}
+  {/if}
+  {if $conditions && $cms_id && !$advanced_payment_api}
+    {if $opc}
+      <hr style="" />
     {/if}
+    {if $override_tos_display }
+      {$override_tos_display}
+    {else}
+      <div class="box">
+        <p class="checkbox">
+          <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+          <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+          <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+        </p>
+      </div>
+    {/if}
+  {/if}
 </div> <!-- end delivery_options_address -->
 </div> <!-- end carrier_area -->
 {strip}
-    {if $conditions}
-        {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
-    {/if}
+  {if $conditions}
+    {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/order-carrier.tpl
+++ b/themes/community-theme-16/order-carrier.tpl
@@ -23,399 +23,399 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !$opc}
-    {capture name=path}{l s='Shipping:'}{/capture}
-    {assign var='current_step' value='shipping'}
-    <div id="carrier_area">
-        <h1 class="page-heading">{l s='Shipping:'}</h1>
-        {include file="$tpl_dir./order-steps.tpl"}
-        {include file="$tpl_dir./errors.tpl"}
-        <form id="form" action="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" method="post" name="carrier_area">
+  {capture name=path}{l s='Shipping:'}{/capture}
+  {assign var='current_step' value='shipping'}
+  <div id="carrier_area">
+    <h1 class="page-heading">{l s='Shipping:'}</h1>
+    {include file="$tpl_dir./order-steps.tpl"}
+    {include file="$tpl_dir./errors.tpl"}
+    <form id="form" action="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" method="post" name="carrier_area">
 {else}
-    <div id="carrier_area" class="opc-main-block">
-        <h1 class="page-heading step-num"><span>2</span> {l s='Delivery methods'}</h1>
-            <div id="opc_delivery_methods" class="opc-main-block">
-                <div id="opc_delivery_methods-overlay" class="opc-overlay" style="display: none;"></div>
+  <div id="carrier_area" class="opc-main-block">
+    <h1 class="page-heading step-num"><span>2</span> {l s='Delivery methods'}</h1>
+      <div id="opc_delivery_methods" class="opc-main-block">
+        <div id="opc_delivery_methods-overlay" class="opc-overlay" style="display: none;"></div>
 {/if}
 <div class="order_carrier_content box">
-    {if isset($virtual_cart) && $virtual_cart}
-        <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
-        <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
+  {if isset($virtual_cart) && $virtual_cart}
+    <input id="input_virtual_carrier" class="hidden" type="hidden" name="id_carrier" value="0" />
+    <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
+  {else}
+    <div id="HOOK_BEFORECARRIER">
+      {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
+        {$HOOK_BEFORECARRIER}
+      {/if}
+    </div>
+    {if isset($isVirtualCart) && $isVirtualCart}
+      <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
     {else}
-        <div id="HOOK_BEFORECARRIER">
-            {if isset($carriers) && isset($HOOK_BEFORECARRIER)}
-                {$HOOK_BEFORECARRIER}
-            {/if}
-        </div>
-        {if isset($isVirtualCart) && $isVirtualCart}
-            <p class="alert alert-warning">{l s='No carrier is needed for this order.'}</p>
-        {else}
-            <div class="delivery_options_address">
-                {if isset($delivery_option_list)}
-                    {foreach $delivery_option_list as $id_address => $option_list}
-                        <p class="carrier_title">
-                            {if isset($address_collection[$id_address])}
-                                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
-                            {else}
-                                {l s='Choose a shipping option'}
+      <div class="delivery_options_address">
+        {if isset($delivery_option_list)}
+          {foreach $delivery_option_list as $id_address => $option_list}
+            <p class="carrier_title">
+              {if isset($address_collection[$id_address])}
+                {l s='Choose a shipping option for this address:'} {$address_collection[$id_address]->alias}
+              {else}
+                {l s='Choose a shipping option'}
+              {/if}
+            </p>
+            <div class="delivery_options">
+              {foreach $option_list as $key => $option}
+                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
+                  <div>
+                    <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
+                      <tr>
+                        <td class="delivery_option_radio">
+                          <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                        </td>
+                        <td class="delivery_option_logo">
+                          {foreach $option.carrier_list as $carrier}
+                            {if $carrier.logo}
+                              <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                            {elseif !$option.unique_carrier}
+                              {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                              {if !$carrier@last} - {/if}
                             {/if}
-                        </p>
-                        <div class="delivery_options">
-                            {foreach $option_list as $key => $option}
-                                <div class="delivery_option {if ($option@index % 2)}alternate_{/if}item">
-                                    <div>
-                                        <table class="resume table table-bordered{if !$option.unique_carrier} hide{/if}">
-                                            <tr>
-                                                <td class="delivery_option_radio">
-                                                    <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
-                                                </td>
-                                                <td class="delivery_option_logo">
-                                                    {foreach $option.carrier_list as $carrier}
-                                                        {if $carrier.logo}
-                                                            <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                        {elseif !$option.unique_carrier}
-                                                            {$carrier.instance->name|escape:'htmlall':'UTF-8'}
-                                                            {if !$carrier@last} - {/if}
-                                                        {/if}
-                                                    {/foreach}
-                                                </td>
-                                                <td>
-                                                    {if $option.unique_carrier}
-                                                        {foreach $option.carrier_list as $carrier}
-                                                            <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
-                                                        {/foreach}
-                                                        {if isset($carrier.instance->delay[$cookie->id_lang])}
-                                                            <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                        {/if}
-                                                    {/if}
-                                                    {if count($option_list) > 1}
-                                                    <br />
-                                                        {if $option.is_best_grade}
-                                                            {if $option.is_best_price}
-                                                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
-                                                            {else}
-                                                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
-                                                            {/if}
-                                                        {elseif $option.is_best_price}
-                                                            <span class="best_grade best_grade_price">{l s='The best price'}</span>
-                                                        {/if}
-                                                    {/if}
-                                                </td>
-                                                <td class="delivery_option_price">
-                                                    <div class="delivery_option_price">
-                                                        {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
-                                                            {if $use_taxes == 1}
-                                                                {if $priceDisplay == 1}
-                                                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
-                                                                {else}
-                                                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
-                                                                {/if}
-                                                            {else}
-                                                                {convertPrice price=$option.total_price_without_tax}
-                                                            {/if}
-                                                        {else}
-                                                            {l s='Free'}
-                                                        {/if}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                        {if !$option.unique_carrier}
-                                            <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
-                                                <tr>
-                                                    {if !$option.unique_carrier}
-                                                        <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
-                                                            <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
-                                                        </td>
-                                                    {/if}
-                                                    {assign var="first" value=current($option.carrier_list)}
-                                                    <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                        {if $first.logo}
-                                                            <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                        {elseif !$option.unique_carrier}
-                                                            {$first.instance->name|escape:'htmlall':'UTF-8'}
-                                                        {/if}
-                                                    </td>
-                                                    <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                        <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
-                                                        {if isset($first.instance->delay[$cookie->id_lang])}
-                                                            <i class="icon-info-sign"></i>
-                                                            {strip}
-                                                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                &nbsp;
-                                                                {if count($first.product_list) <= 1}
-                                                                    ({l s='For this product:'}
-                                                                {else}
-                                                                    ({l s='For these products:'}
-                                                                {/if}
-                                                            {/strip}
-                                                            {foreach $first.product_list as $product}
-                                                                {if $product@index == 4}
-                                                                    <acronym title="
-                                                                {/if}
-                                                                {strip}
-                                                                    {if $product@index >= 4}
-                                                                        {$product.name|escape:'htmlall':'UTF-8'}
-                                                                        {if isset($product.attributes) && $product.attributes}
-                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                        {if !$product@last}
-                                                                            ,&nbsp;
-                                                                        {else}
-                                                                            ">&hellip;</acronym>)
-                                                                        {/if}
-                                                                    {else}
-                                                                        {$product.name|escape:'htmlall':'UTF-8'}
-                                                                        {if isset($product.attributes) && $product.attributes}
-                                                                            {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                        {/if}
-                                                                        {if !$product@last}
-                                                                            ,&nbsp;
-                                                                        {else}
-                                                                            )
-                                                                        {/if}
-                                                                    {/if}
-                                                                {/strip}
-                                                            {/foreach}
-                                                        {/if}
-                                                    </td>
-                                                    <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
-                                                        <div class="delivery_option_price">
-                                                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
-                                                                {if $use_taxes == 1}
-                                                                    {if $priceDisplay == 1}
-                                                                        {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
-                                                                    {else}
-                                                                        {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
-                                                                    {/if}
-                                                                {else}
-                                                                    {convertPrice price=$option.total_price_without_tax}
-                                                                {/if}
-                                                            {else}
-                                                                {l s='Free'}
-                                                            {/if}
-                                                        </div>
-                                                    </td>
-                                                </tr>
-                                                {foreach $option.carrier_list as $carrier}
-                                                    {if $carrier@iteration != 1}
-                                                    <tr>
-                                                        <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                            {if $carrier.logo}
-                                                                <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
-                                                            {elseif !$option.unique_carrier}
-                                                                {$carrier.instance->name|escape:'htmlall':'UTF-8'}
-                                                            {/if}
-                                                        </td>
-                                                        <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
-                                                            <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
-                                                            {if isset($carrier.instance->delay[$cookie->id_lang])}
-                                                                <i class="icon-info-sign"></i>
-                                                                {strip}
-                                                                    {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
-                                                                    &nbsp;
-                                                                    {if count($first.product_list) <= 1}
-                                                                        ({l s='For this product:'}
-                                                                    {else}
-                                                                        ({l s='For these products:'}
-                                                                    {/if}
-                                                                {/strip}
-                                                                {foreach $carrier.product_list as $product}
-                                                                    {if $product@index == 4}
-                                                                        <acronym title="
-                                                                    {/if}
-                                                                    {strip}
-                                                                        {if $product@index >= 4}
-                                                                            {$product.name|escape:'htmlall':'UTF-8'}
-                                                                            {if isset($product.attributes) && $product.attributes}
-                                                                                {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                            {/if}
-                                                                            {if !$product@last}
-                                                                                ,&nbsp;
-                                                                            {else}
-                                                                                ">&hellip;</acronym>)
-                                                                            {/if}
-                                                                        {else}
-                                                                            {$product.name|escape:'htmlall':'UTF-8'}
-                                                                            {if isset($product.attributes) && $product.attributes}
-                                                                                {$product.attributes|escape:'htmlall':'UTF-8'}
-                                                                            {/if}
-                                                                            {if !$product@last}
-                                                                                ,&nbsp;
-                                                                            {else}
-                                                                                )
-                                                                            {/if}
-                                                                        {/if}
-                                                                    {/strip}
-                                                                {/foreach}
-                                                            {/if}
-                                                        </td>
-                                                    </tr>
-                                                    {/if}
-                                                {/foreach}
-                                            </table>
-                                        {/if}
-                                    </div>
-                                </div> <!-- end delivery_option -->
+                          {/foreach}
+                        </td>
+                        <td>
+                          {if $option.unique_carrier}
+                            {foreach $option.carrier_list as $carrier}
+                              <strong>{$carrier.instance->name|escape:'htmlall':'UTF-8'}</strong>
                             {/foreach}
-                        </div> <!-- end delivery_options -->
-                        <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
-                            {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
-                        </div>
-                        {foreachelse}
-                            {assign var='errors' value=' '|explode:''}
-                            <p class="alert alert-warning" id="noCarrierWarning">
-                                {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
-                                    {if empty($address->alias)}
-                                        {l s='No carriers available.'}
-                                    {else}
-                                        {assign var='flag_error_message' value=false}
-                                        {foreach $errors as $error}
-                                            {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
-                                                {$flag_error_message = true}
-                                                {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
-                                            {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
-                                                {$flag_error_message = true}
-                                                {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
-                                            {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
-                                                {$flag_error_message = true}
-                                                {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
-                                            {/if}
-                                        {/foreach}
-                                        {if !$flag_error_message}
-                                            {l s='No carriers available for the address "%s".' sprintf=$address->alias}
-                                        {/if}
-                                    {/if}
-                                    {if !$address@last}
-                                        <br />
-                                    {/if}
-                                {foreachelse}
-                                    {l s='No carriers available.'}
-                                {/foreach}
-                            </p>
-                        {/foreach}
-                    {/if}
-                </div> <!-- end delivery_options_address -->
-                <div id="extra_carrier" style="display: none;"></div>
-                {if $opc}
-                    <p class="carrier_title">{l s='Leave a message'}</p>
-                    <div>
-                        <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
-                        <textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
-                            {if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
-                        {/strip}</textarea>
-                    </div>
-                {/if}
-                {if $recyclablePackAllowed}
-                    <p class="carrier_title">{l s='Recyclable Packaging'}</p>
-                    <div class="checkbox recyclable">
-                        <label for="recyclable">
-                            <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
-                            {l s='I would like to receive my order in recycled packaging.'}
-                        </label>
-                    </div>
-                {/if}
-                {if $giftAllowed}
-                    {if $opc}
-                        <hr style="" />
-                    {/if}
-                    <p class="carrier_title">{l s='Gift'}</p>
-                    <div class="checkbox gift">
-                        <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
-                        <label for="gift">
-                            {l s='I would like my order to be gift wrapped.'}
-                            {if $gift_wrapping_price > 0}
-                                &nbsp;<i>({l s='Additional cost of'}
-                                <span class="price" id="gift-price">
-                                    {if $priceDisplay == 1}
-                                        {convertPrice price=$total_wrapping_tax_exc_cost}
-                                    {else}
-                                        {convertPrice price=$total_wrapping_cost}
-                                    {/if}
-                                </span>
-                                {if $use_taxes && $display_tax_label}
-                                    {if $priceDisplay == 1}
-                                        {l s='(tax excl.)'}
-                                    {else}
-                                        {l s='(tax incl.)'}
-                                    {/if}
-                                {/if})
-                                </i>
+                            {if isset($carrier.instance->delay[$cookie->id_lang])}
+                              <br />{l s='Delivery time:'}&nbsp;{$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
                             {/if}
-                        </label>
-                    </div>
-                    <p id="gift_div">
-                        <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
-                        <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
-                    </p>
-                {/if}
-                {/if}
-            {/if}
-            {if $conditions && $cms_id && (! isset($advanced_payment_api) || !$advanced_payment_api)}
-                {if $opc}
-                    <hr style="" />
-                {/if}
-                {if isset($override_tos_display) && $override_tos_display}
-                    {$override_tos_display}
+                          {/if}
+                          {if count($option_list) > 1}
+                            <br />
+                            {if $option.is_best_grade}
+                              {if $option.is_best_price}
+                                <span class="best_grade best_grade_price best_grade_speed">{l s='The best price and speed'}</span>
+                              {else}
+                                <span class="best_grade best_grade_speed">{l s='The fastest'}</span>
+                              {/if}
+                            {elseif $option.is_best_price}
+                              <span class="best_grade best_grade_price">{l s='The best price'}</span>
+                            {/if}
+                          {/if}
+                        </td>
+                        <td class="delivery_option_price">
+                          <div class="delivery_option_price">
+                            {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                              {if $use_taxes == 1}
+                                {if $priceDisplay == 1}
+                                  {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                {else}
+                                  {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                {/if}
+                              {else}
+                                {convertPrice price=$option.total_price_without_tax}
+                              {/if}
+                            {else}
+                              {l s='Free'}
+                            {/if}
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+                    {if !$option.unique_carrier}
+                      <table class="delivery_option_carrier{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} selected{/if} resume table table-bordered{if $option.unique_carrier} hide{/if}">
+                        <tr>
+                          {if !$option.unique_carrier}
+                            <td rowspan="{$option.carrier_list|@count}" class="delivery_option_radio first_item">
+                              <input id="delivery_option_{$id_address|intval}_{$option@index}" class="delivery_option_radio" type="radio" name="delivery_option[{$id_address|intval}]" data-key="{$key}" data-id_address="{$id_address|intval}" value="{$key}"{if isset($delivery_option[$id_address]) && $delivery_option[$id_address] == $key} checked="checked"{/if} />
+                            </td>
+                          {/if}
+                          {assign var="first" value=current($option.carrier_list)}
+                          <td class="delivery_option_logo{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                            {if $first.logo}
+                              <img class="order_carrier_logo" src="{$first.logo|escape:'htmlall':'UTF-8'}" alt="{$first.instance->name|escape:'htmlall':'UTF-8'}"/>
+                            {elseif !$option.unique_carrier}
+                              {$first.instance->name|escape:'htmlall':'UTF-8'}
+                            {/if}
+                          </td>
+                          <td class="{if $option.unique_carrier}first_item{/if}{if $first.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                            <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                            {if isset($first.instance->delay[$cookie->id_lang])}
+                              <i class="icon-info-sign"></i>
+                              {strip}
+                                {$first.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                &nbsp;
+                                {if count($first.product_list) <= 1}
+                                  ({l s='For this product:'}
+                                {else}
+                                  ({l s='For these products:'}
+                                {/if}
+                              {/strip}
+                              {foreach $first.product_list as $product}
+                                {if $product@index == 4}
+                                  <acronym title="
+                                {/if}
+                                {strip}
+                                  {if $product@index >= 4}
+                                    {$product.name|escape:'htmlall':'UTF-8'}
+                                    {if isset($product.attributes) && $product.attributes}
+                                        {$product.attributes|escape:'htmlall':'UTF-8'}
+                                    {/if}
+                                    {if !$product@last}
+                                        ,&nbsp;
+                                    {else}
+                                      ">&hellip;</acronym>)
+                                    {/if}
+                                  {else}
+                                    {$product.name|escape:'htmlall':'UTF-8'}
+                                    {if isset($product.attributes) && $product.attributes}
+                                      {$product.attributes|escape:'htmlall':'UTF-8'}
+                                    {/if}
+                                    {if !$product@last}
+                                      ,&nbsp;
+                                    {else}
+                                      )
+                                    {/if}
+                                  {/if}
+                                {/strip}
+                              {/foreach}
+                            {/if}
+                          </td>
+                          <td rowspan="{$option.carrier_list|@count}" class="delivery_option_price">
+                            <div class="delivery_option_price">
+                              {if $option.total_price_with_tax && !$option.is_free && (!isset($free_shipping) || (isset($free_shipping) && !$free_shipping))}
+                                {if $use_taxes == 1}
+                                  {if $priceDisplay == 1}
+                                    {convertPrice price=$option.total_price_without_tax}{if $display_tax_label} {l s='(tax excl.)'}{/if}
+                                  {else}
+                                    {convertPrice price=$option.total_price_with_tax}{if $display_tax_label} {l s='(tax incl.)'}{/if}
+                                  {/if}
+                                {else}
+                                  {convertPrice price=$option.total_price_without_tax}
+                                {/if}
+                              {else}
+                                {l s='Free'}
+                              {/if}
+                            </div>
+                          </td>
+                        </tr>
+                        {foreach $option.carrier_list as $carrier}
+                          {if $carrier@iteration != 1}
+                            <tr>
+                              <td class="delivery_option_logo{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                {if $carrier.logo}
+                                  <img class="order_carrier_logo" src="{$carrier.logo|escape:'htmlall':'UTF-8'}" alt="{$carrier.instance->name|escape:'htmlall':'UTF-8'}"/>
+                                {elseif !$option.unique_carrier}
+                                  {$carrier.instance->name|escape:'htmlall':'UTF-8'}
+                                {/if}
+                              </td>
+                              <td class="{if $option.unique_carrier} first_item{/if}{if $carrier.product_list[0].carrier_list[0] eq 0} hide{/if}">
+                                <input type="hidden" value="{$first.instance->id|intval}" name="id_carrier" />
+                                {if isset($carrier.instance->delay[$cookie->id_lang])}
+                                  <i class="icon-info-sign"></i>
+                                  {strip}
+                                    {$carrier.instance->delay[$cookie->id_lang]|escape:'htmlall':'UTF-8'}
+                                    &nbsp;
+                                    {if count($first.product_list) <= 1}
+                                      ({l s='For this product:'}
+                                    {else}
+                                      ({l s='For these products:'}
+                                    {/if}
+                                  {/strip}
+                                  {foreach $carrier.product_list as $product}
+                                    {if $product@index == 4}
+                                      <acronym title="
+                                    {/if}
+                                    {strip}
+                                      {if $product@index >= 4}
+                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                        {if isset($product.attributes) && $product.attributes}
+                                            {$product.attributes|escape:'htmlall':'UTF-8'}
+                                        {/if}
+                                        {if !$product@last}
+                                            ,&nbsp;
+                                        {else}
+                                            ">&hellip;</acronym>)
+                                        {/if}
+                                      {else}
+                                        {$product.name|escape:'htmlall':'UTF-8'}
+                                        {if isset($product.attributes) && $product.attributes}
+                                          {$product.attributes|escape:'htmlall':'UTF-8'}
+                                        {/if}
+                                        {if !$product@last}
+                                          ,&nbsp;
+                                        {else}
+                                          )
+                                        {/if}
+                                      {/if}
+                                    {/strip}
+                                  {/foreach}
+                                {/if}
+                              </td>
+                            </tr>
+                          {/if}
+                        {/foreach}
+                      </table>
+                    {/if}
+                  </div>
+                </div> <!-- end delivery_option -->
+              {/foreach}
+            </div> <!-- end delivery_options -->
+            <div class="hook_extracarrier" id="HOOK_EXTRACARRIER_{$id_address}">
+              {if isset($HOOK_EXTRACARRIER_ADDR) &&  isset($HOOK_EXTRACARRIER_ADDR.$id_address)}{$HOOK_EXTRACARRIER_ADDR.$id_address}{/if}
+            </div>
+            {foreachelse}
+            {assign var='errors' value=' '|explode:''}
+            <p class="alert alert-warning" id="noCarrierWarning">
+              {foreach $cart->getDeliveryAddressesWithoutCarriers(true, $errors) as $address}
+                {if empty($address->alias)}
+                  {l s='No carriers available.'}
                 {else}
-                    <div class="box">
-                        <p class="checkbox">
-                            <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
-                            <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
-                            <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
-                        </p>
-                    </div>
+                  {assign var='flag_error_message' value=false}
+                  {foreach $errors as $error}
+                    {if $error == Carrier::SHIPPING_WEIGHT_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s): it is too heavy. Please amend your cart to lower its weight.'}
+                    {elseif $error == Carrier::SHIPPING_PRICE_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s). Please amend your cart.'}
+                    {elseif $error == Carrier::SHIPPING_SIZE_EXCEPTION}
+                      {$flag_error_message = true}
+                      {l s='The product selection cannot be delivered by the available carrier(s): its size does not fit. Please amend your cart to reduce its size.'}
+                    {/if}
+                  {/foreach}
+                  {if !$flag_error_message}
+                    {l s='No carriers available for the address "%s".' sprintf=$address->alias}
+                  {/if}
                 {/if}
+                {if !$address@last}
+                  <br />
+                {/if}
+                {foreachelse}
+                {l s='No carriers available.'}
+              {/foreach}
+            </p>
+          {/foreach}
+        {/if}
+      </div> <!-- end delivery_options_address -->
+      <div id="extra_carrier" style="display: none;"></div>
+      {if $opc}
+        <p class="carrier_title">{l s='Leave a message'}</p>
+        <div>
+          <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
+            <textarea class="form-control" cols="120" rows="2" name="message" id="message">{strip}
+                {if isset($oldMessage)}{$oldMessage|escape:'html':'UTF-8'}{/if}
+            {/strip}</textarea>
+        </div>
+      {/if}
+      {if $recyclablePackAllowed}
+        <p class="carrier_title">{l s='Recyclable Packaging'}</p>
+        <div class="checkbox recyclable">
+          <label for="recyclable">
+            <input type="checkbox" name="recyclable" id="recyclable" value="1"{if $recyclable == 1} checked="checked"{/if} />
+            {l s='I would like to receive my order in recycled packaging.'}
+          </label>
+        </div>
+      {/if}
+      {if $giftAllowed}
+        {if $opc}
+          <hr style="" />
+        {/if}
+        <p class="carrier_title">{l s='Gift'}</p>
+        <div class="checkbox gift">
+          <input type="checkbox" name="gift" id="gift" value="1"{if $cart->gift == 1} checked="checked"{/if} />
+          <label for="gift">
+            {l s='I would like my order to be gift wrapped.'}
+            {if $gift_wrapping_price > 0}
+              &nbsp;<i>({l s='Additional cost of'}
+              <span class="price" id="gift-price">
+                {if $priceDisplay == 1}
+                  {convertPrice price=$total_wrapping_tax_exc_cost}
+                {else}
+                  {convertPrice price=$total_wrapping_cost}
+                {/if}
+              </span>
+              {if $use_taxes && $display_tax_label}
+                {if $priceDisplay == 1}
+                  {l s='(tax excl.)'}
+                {else}
+                  {l s='(tax incl.)'}
+                {/if}
+              {/if})
+            </i>
             {/if}
-        </div> <!-- end delivery_options_address -->
-        {if !$opc}
-                <p class="cart_navigation clearfix">
-                    <input type="hidden" name="step" value="3" />
-                    <input type="hidden" name="back" value="{$back}" />
-                    {if !$is_guest}
-                        {if $back}
-                            <a href="{$link->getPageLink('order', true, NULL, "step=1&back={$back}{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                                <i class="icon-chevron-left"></i>
-                                {l s='Continue shopping'}
-                            </a>
-                        {else}
-                            <a href="{$link->getPageLink('order', true, NULL, "step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                                <i class="icon-chevron-left"></i>
-                                {l s='Continue shopping'}
-                            </a>
-                        {/if}
-                    {else}
-                        <a href="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-                            <i class="icon-chevron-left"></i>
-                            {l s='Continue shopping'}
-                        </a>
-                    {/if}
-                    {if isset($virtual_cart) && $virtual_cart || (isset($delivery_option_list) && !empty($delivery_option_list))}
-                        <button type="submit" name="processCarrier" class="button btn btn-default standard-checkout button-medium">
-                            <span>
-                                {l s='Proceed to checkout'}
-                                <i class="icon-chevron-right right"></i>
-                            </span>
-                        </button>
-                    {/if}
-                </p>
-            </form>
-    {else}
-        </div> <!-- end opc_delivery_methods -->
+          </label>
+        </div>
+        <p id="gift_div">
+          <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:'}</label>
+          <textarea rows="2" cols="120" id="gift_message" class="form-control" name="gift_message">{$cart->gift_message|escape:'html':'UTF-8'}</textarea>
+        </p>
+      {/if}
     {/if}
+  {/if}
+  {if $conditions && $cms_id && (! isset($advanced_payment_api) || !$advanced_payment_api)}
+    {if $opc}
+      <hr style="" />
+    {/if}
+    {if isset($override_tos_display) && $override_tos_display}
+      {$override_tos_display}
+    {else}
+      <div class="box">
+        <p class="checkbox">
+          <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+          <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+          <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+        </p>
+      </div>
+    {/if}
+  {/if}
+</div> <!-- end delivery_options_address -->
+{if !$opc}
+  <p class="cart_navigation clearfix">
+    <input type="hidden" name="step" value="3" />
+    <input type="hidden" name="back" value="{$back}" />
+    {if !$is_guest}
+      {if $back}
+        <a href="{$link->getPageLink('order', true, NULL, "step=1&back={$back}{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+          <i class="icon-chevron-left"></i>
+          {l s='Continue shopping'}
+        </a>
+      {else}
+        <a href="{$link->getPageLink('order', true, NULL, "step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+          <i class="icon-chevron-left"></i>
+          {l s='Continue shopping'}
+        </a>
+      {/if}
+    {else}
+      <a href="{$link->getPageLink('order', true, NULL, "{if $multi_shipping}multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+        <i class="icon-chevron-left"></i>
+        {l s='Continue shopping'}
+      </a>
+    {/if}
+    {if isset($virtual_cart) && $virtual_cart || (isset($delivery_option_list) && !empty($delivery_option_list))}
+      <button type="submit" name="processCarrier" class="button btn btn-default standard-checkout button-medium">
+        <span>
+          {l s='Proceed to checkout'}
+          <i class="icon-chevron-right right"></i>
+        </span>
+      </button>
+    {/if}
+  </p>
+</form>
+{else}
+  </div> <!-- end opc_delivery_methods -->
+{/if}
 </div> <!-- end carrier_area -->
 {strip}
-{if !$opc}
+  {if !$opc}
     {addJsDef orderProcess='order'}
     {if isset($virtual_cart) && !$virtual_cart && $giftAllowed && $cart->gift == 1}
-        {addJsDef cart_gift=true}
+      {addJsDef cart_gift=true}
     {else}
-        {addJsDef cart_gift=false}
+      {addJsDef cart_gift=false}
     {/if}
     {addJsDef orderUrl=$link->getPageLink("order", true)|escape:'quotes':'UTF-8'}
     {addJsDefL name=txtProduct}{l s='Product' js=1}{/addJsDefL}
     {addJsDefL name=txtProducts}{l s='Products' js=1}{/addJsDefL}
-{/if}
-{if $conditions}
+  {/if}
+  {if $conditions}
     {addJsDefL name=msg_order_carrier}{l s='You must agree to the terms of service before continuing.' js=1}{/addJsDefL}
-{/if}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/order-confirmation.tpl
+++ b/themes/community-theme-16/order-confirmation.tpl
@@ -35,12 +35,12 @@
 {$HOOK_ORDER_CONFIRMATION}
 {$HOOK_PAYMENT_RETURN}
 {if $is_guest}
-    <p>{l s='Your order ID is:'} <span class="bold">{$id_order_formatted}</span> . {l s='Your order ID has been sent via email.'}</p>
-    <p class="cart_navigation exclusive">
+  <p>{l s='Your order ID is:'} <span class="bold">{$id_order_formatted}</span> . {l s='Your order ID has been sent via email.'}</p>
+  <p class="cart_navigation exclusive">
     <a class="button-exclusive btn btn-default" href="{$link->getPageLink('guest-tracking', true, NULL, "id_order={$reference_order|urlencode}&email={$email|urlencode}")|escape:'html':'UTF-8'}" title="{l s='Follow my order'}"><i class="icon-chevron-left"></i>{l s='Follow my order'}</a>
-    </p>
+  </p>
 {else}
-<p class="cart_navigation exclusive">
+  <p class="cart_navigation exclusive">
     <a class="button-exclusive btn btn-default" href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" title="{l s='Go to your order history page'}"><i class="icon-chevron-left"></i>{l s='View your order history'}</a>
-</p>
+  </p>
 {/if}

--- a/themes/community-theme-16/order-detail.tpl
+++ b/themes/community-theme-16/order-detail.tpl
@@ -23,447 +23,447 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($order)}
-<div class="box box-small clearfix">
+  <div class="box box-small clearfix">
     {if isset($reorderingAllowed) && $reorderingAllowed}
-    <form id="submitReorder" action="{if isset($opc) && $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" class="submit">
+      <form id="submitReorder" action="{if isset($opc) && $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" class="submit">
         <input type="hidden" value="{$order->id}" name="id_order"/>
         <input type="hidden" value="" name="submitReorder"/>
 
         <a href="#" onclick="$(this).closest('form').submit(); return false;" class="button btn btn-default button-medium pull-right"><span>{l s='Reorder'}<i class="icon-chevron-right right"></i></span></a>
-    </form>
+      </form>
     {/if}
     <p class="dark">
-        <strong>{l s='Order Reference %s - placed on' sprintf=$order->getUniqReference()} {dateFormat date=$order->date_add full=0}</strong>
+      <strong>{l s='Order Reference %s - placed on' sprintf=$order->getUniqReference()} {dateFormat date=$order->date_add full=0}</strong>
     </p>
-</div>
-<div class="info-order box">
+  </div>
+  <div class="info-order box">
     {if $carrier->id}<p><strong class="dark">{l s='Carrier'}</strong> {if $carrier->name == "0"}{$shop_name|escape:'html':'UTF-8'}{else}{$carrier->name|escape:'html':'UTF-8'}{/if}</p>{/if}
     <p><strong class="dark">{l s='Payment method'}</strong> <span class="color-myaccount">{$order->payment|escape:'html':'UTF-8'}</span></p>
     {if $invoice AND $invoiceAllowed}
-    <p>
+      <p>
         <i class="icon-file-text"></i>
         <a target="_blank" href="{$link->getPageLink('pdf-invoice', true)}?id_order={$order->id|intval}{if $is_guest}&amp;secure_key={$order->secure_key|escape:'html':'UTF-8'}{/if}">{l s='Download your invoice as a PDF file.'}</a>
-    </p>
+      </p>
     {/if}
     {if $order->recyclable}
-    <p><i class="icon-repeat"></i>&nbsp;{l s='You have given permission to receive your order in recycled packaging.'}</p>
+      <p><i class="icon-repeat"></i>&nbsp;{l s='You have given permission to receive your order in recycled packaging.'}</p>
     {/if}
     {if $order->gift}
-        <p><i class="icon-gift"></i>&nbsp;{l s='You have requested gift wrapping for this order.'}</p>
-        <p><strong class="dark">{l s='Message'}</strong> {$order->gift_message|nl2br}</p>
+      <p><i class="icon-gift"></i>&nbsp;{l s='You have requested gift wrapping for this order.'}</p>
+      <p><strong class="dark">{l s='Message'}</strong> {$order->gift_message|nl2br}</p>
     {/if}
-</div>
+  </div>
 
-{if count($order_history)}
-<h1 class="page-heading">{l s='Follow your order\'s status step-by-step'}</h1>
-<div class="table_block">
-    <table class="detail_step_by_step table table-bordered">
+  {if count($order_history)}
+    <h1 class="page-heading">{l s='Follow your order\'s status step-by-step'}</h1>
+    <div class="table_block">
+      <table class="detail_step_by_step table table-bordered">
         <thead>
-            <tr>
-                <th class="first_item">{l s='Date'}</th>
-                <th class="last_item">{l s='Status'}</th>
-            </tr>
+        <tr>
+          <th class="first_item">{l s='Date'}</th>
+          <th class="last_item">{l s='Status'}</th>
+        </tr>
         </thead>
         <tbody>
         {foreach from=$order_history item=state name="orderStates"}
-            <tr class="{if $smarty.foreach.orderStates.first}first_item{elseif $smarty.foreach.orderStates.last}last_item{/if} {if $smarty.foreach.orderStates.index % 2}alternate_item{else}item{/if}">
-                <td class="step-by-step-date">{dateFormat date=$state.date_add full=0}</td>
-                <td><span{if isset($state.color) && $state.color} style="background-color:{$state.color|escape:'html':'UTF-8'}; border-color:{$state.color|escape:'html':'UTF-8'};"{/if} class="label{if isset($state.color) && Tools::getBrightness($state.color) > 128} dark{/if}">{$state.ostate_name|escape:'html':'UTF-8'}</span></td>
-            </tr>
+          <tr class="{if $smarty.foreach.orderStates.first}first_item{elseif $smarty.foreach.orderStates.last}last_item{/if} {if $smarty.foreach.orderStates.index % 2}alternate_item{else}item{/if}">
+            <td class="step-by-step-date">{dateFormat date=$state.date_add full=0}</td>
+            <td><span{if isset($state.color) && $state.color} style="background-color:{$state.color|escape:'html':'UTF-8'}; border-color:{$state.color|escape:'html':'UTF-8'};"{/if} class="label{if isset($state.color) && Tools::getBrightness($state.color) > 128} dark{/if}">{$state.ostate_name|escape:'html':'UTF-8'}</span></td>
+          </tr>
         {/foreach}
         </tbody>
-    </table>
-</div>
-{/if}
+      </table>
+    </div>
+  {/if}
 
-{if isset($followup)}
-<p class="bold">{l s='Click the following link to track the delivery of your order'}</p>
-<a href="{$followup|escape:'html':'UTF-8'}">{$followup|escape:'html':'UTF-8'}</a>
-{/if}
+  {if isset($followup)}
+    <p class="bold">{l s='Click the following link to track the delivery of your order'}</p>
+    <a href="{$followup|escape:'html':'UTF-8'}">{$followup|escape:'html':'UTF-8'}</a>
+  {/if}
 
-<div class="adresses_bloc">
+  <div class="adresses_bloc">
     <div class="row">
-        <div class="col-xs-12 col-sm-6"{if $order->isVirtual()} style="display:none;"{/if}>
-            <ul class="address alternate_item box">
-                <li><h3 class="page-subheading">{l s='Delivery address'} ({$address_delivery->alias})</h3></li>
-                {foreach from=$dlv_adr_fields name=dlv_loop item=field_item}
-                    {if $field_item eq "company" && isset($address_delivery->company)}<li class="address_company">{$address_delivery->company|escape:'html':'UTF-8'}</li>
-                    {elseif $field_item eq "address2" && $address_delivery->address2}<li class="address_address2">{$address_delivery->address2|escape:'html':'UTF-8'}</li>
-                    {elseif $field_item eq "phone_mobile" && $address_delivery->phone_mobile}<li class="address_phone_mobile">{$address_delivery->phone_mobile|escape:'html':'UTF-8'}</li>
-                    {else}
-                            {assign var=address_words value=" "|explode:$field_item}
-                            <li>{foreach from=$address_words item=word_item name="word_loop"}{if !$smarty.foreach.word_loop.first} {/if}<span class="address_{$word_item|replace:',':''}">{$deliveryAddressFormatedValues[$word_item|replace:',':'']|escape:'html':'UTF-8'}</span>{/foreach}</li>
-                    {/if}
-                {/foreach}
-            </ul>
-        </div>
-        <div class="col-xs-12 col-sm-6">
-            <ul class="address item {if $order->isVirtual()}full_width{/if} box">
-                <li><h3 class="page-subheading">{l s='Invoice address'} ({$address_invoice->alias})</h3></li>
-                {foreach from=$inv_adr_fields name=inv_loop item=field_item}
-                    {if $field_item eq "company" && isset($address_invoice->company)}<li class="address_company">{$address_invoice->company|escape:'html':'UTF-8'}</li>
-                    {elseif $field_item eq "address2" && $address_invoice->address2}<li class="address_address2">{$address_invoice->address2|escape:'html':'UTF-8'}</li>
-                    {elseif $field_item eq "phone_mobile" && $address_invoice->phone_mobile}<li class="address_phone_mobile">{$address_invoice->phone_mobile|escape:'html':'UTF-8'}</li>
-                    {else}
-                            {assign var=address_words value=" "|explode:$field_item}
-                            <li>{foreach from=$address_words item=word_item name="word_loop"}{if !$smarty.foreach.word_loop.first} {/if}<span class="address_{$word_item|replace:',':''}">{$invoiceAddressFormatedValues[$word_item|replace:',':'']|escape:'html':'UTF-8'}</span>{/foreach}</li>
-                    {/if}
-                {/foreach}
-            </ul>
-        </div>
+      <div class="col-xs-12 col-sm-6"{if $order->isVirtual()} style="display:none;"{/if}>
+        <ul class="address alternate_item box">
+          <li><h3 class="page-subheading">{l s='Delivery address'} ({$address_delivery->alias})</h3></li>
+          {foreach from=$dlv_adr_fields name=dlv_loop item=field_item}
+            {if $field_item eq "company" && isset($address_delivery->company)}<li class="address_company">{$address_delivery->company|escape:'html':'UTF-8'}</li>
+            {elseif $field_item eq "address2" && $address_delivery->address2}<li class="address_address2">{$address_delivery->address2|escape:'html':'UTF-8'}</li>
+            {elseif $field_item eq "phone_mobile" && $address_delivery->phone_mobile}<li class="address_phone_mobile">{$address_delivery->phone_mobile|escape:'html':'UTF-8'}</li>
+            {else}
+              {assign var=address_words value=" "|explode:$field_item}
+              <li>{foreach from=$address_words item=word_item name="word_loop"}{if !$smarty.foreach.word_loop.first} {/if}<span class="address_{$word_item|replace:',':''}">{$deliveryAddressFormatedValues[$word_item|replace:',':'']|escape:'html':'UTF-8'}</span>{/foreach}</li>
+            {/if}
+          {/foreach}
+        </ul>
+      </div>
+      <div class="col-xs-12 col-sm-6">
+        <ul class="address item {if $order->isVirtual()}full_width{/if} box">
+          <li><h3 class="page-subheading">{l s='Invoice address'} ({$address_invoice->alias})</h3></li>
+          {foreach from=$inv_adr_fields name=inv_loop item=field_item}
+            {if $field_item eq "company" && isset($address_invoice->company)}<li class="address_company">{$address_invoice->company|escape:'html':'UTF-8'}</li>
+            {elseif $field_item eq "address2" && $address_invoice->address2}<li class="address_address2">{$address_invoice->address2|escape:'html':'UTF-8'}</li>
+            {elseif $field_item eq "phone_mobile" && $address_invoice->phone_mobile}<li class="address_phone_mobile">{$address_invoice->phone_mobile|escape:'html':'UTF-8'}</li>
+            {else}
+              {assign var=address_words value=" "|explode:$field_item}
+              <li>{foreach from=$address_words item=word_item name="word_loop"}{if !$smarty.foreach.word_loop.first} {/if}<span class="address_{$word_item|replace:',':''}">{$invoiceAddressFormatedValues[$word_item|replace:',':'']|escape:'html':'UTF-8'}</span>{/foreach}</li>
+            {/if}
+          {/foreach}
+        </ul>
+      </div>
     </div>
-</div>
-{$HOOK_ORDERDETAILDISPLAYED}
-{if !$is_guest}<form action="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" method="post">{/if}
-<div id="order-detail-content" class="table_block table-responsive">
+  </div>
+  {$HOOK_ORDERDETAILDISPLAYED}
+  {if !$is_guest}<form action="{$link->getPageLink('order-follow', true)|escape:'html':'UTF-8'}" method="post">{/if}
+  <div id="order-detail-content" class="table_block table-responsive">
     <table class="table table-bordered">
-        <thead>
-            <tr>
-                {if $return_allowed}<th class="first_item"><input type="checkbox" /></th>{/if}
-                <th class="{if $return_allowed}item{else}first_item{/if}">{l s='Reference'}</th>
-                <th class="item">{l s='Product'}</th>
-                <th class="item">{l s='Quantity'}</th>
-                {if $order->hasProductReturned()}
-                    <th class="item">{l s='Returned'}</th>
-                {/if}
-                <th class="item">{l s='Unit price'}</th>
-                <th class="last_item">{l s='Total price'}</th>
-            </tr>
-        </thead>
-        <tfoot>
-            {if $priceDisplay && $use_tax}
-                <tr class="item">
-                    <td colspan="{if $return_allowed}2{else}1{/if}">
-                        <strong>{l s='Items (tax excl.)'}</strong>
-                    </td>
-                    <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
-                        <span class="price">{displayWtPriceWithCurrency price=$order->getTotalProductsWithoutTaxes() currency=$currency}</span>
-                    </td>
-                </tr>
-            {/if}
+      <thead>
+      <tr>
+        {if $return_allowed}<th class="first_item"><input type="checkbox" /></th>{/if}
+        <th class="{if $return_allowed}item{else}first_item{/if}">{l s='Reference'}</th>
+        <th class="item">{l s='Product'}</th>
+        <th class="item">{l s='Quantity'}</th>
+        {if $order->hasProductReturned()}
+          <th class="item">{l s='Returned'}</th>
+        {/if}
+        <th class="item">{l s='Unit price'}</th>
+        <th class="last_item">{l s='Total price'}</th>
+      </tr>
+      </thead>
+      <tfoot>
+      {if $priceDisplay && $use_tax}
+        <tr class="item">
+          <td colspan="{if $return_allowed}2{else}1{/if}">
+            <strong>{l s='Items (tax excl.)'}</strong>
+          </td>
+          <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
+            <span class="price">{displayWtPriceWithCurrency price=$order->getTotalProductsWithoutTaxes() currency=$currency}</span>
+          </td>
+        </tr>
+      {/if}
+      <tr class="item">
+        <td colspan="{if $return_allowed}2{else}1{/if}">
+          <strong>{l s='Items'} {if $use_tax}{l s='(tax incl.)'}{/if} </strong>
+        </td>
+        <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
+          <span class="price">{displayWtPriceWithCurrency price=$order->getTotalProductsWithTaxes() currency=$currency}</span>
+        </td>
+      </tr>
+      {if $order->total_discounts > 0}
+        <tr class="item">
+          <td colspan="{if $return_allowed}2{else}1{/if}">
+            <strong>{l s='Total vouchers'}</strong>
+          </td>
+          <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
+            <span class="price-discount">{displayWtPriceWithCurrency price=$order->total_discounts currency=$currency convert=1}</span>
+          </td>
+        </tr>
+      {/if}
+      {if $order->total_wrapping > 0}
+        <tr class="item">
+          <td colspan="{if $return_allowed}2{else}1{/if}">
+            <strong>{l s='Total gift wrapping cost'}</strong>
+          </td>
+          <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
+            <span class="price-wrapping">{displayWtPriceWithCurrency price=$order->total_wrapping currency=$currency}</span>
+          </td>
+        </tr>
+      {/if}
+      <tr class="item">
+        <td colspan="{if $return_allowed}2{else}1{/if}">
+          <strong>{l s='Shipping & handling'} {if $use_tax}{l s='(tax incl.)'}{/if} </strong>
+        </td>
+        <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
+          <span class="price-shipping">{displayWtPriceWithCurrency price=$order->total_shipping currency=$currency}</span>
+        </td>
+      </tr>
+      <tr class="totalprice item">
+        <td colspan="{if $return_allowed}2{else}1{/if}">
+          <strong>{l s='Total'}</strong>
+        </td>
+        <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
+          <span class="price">{displayWtPriceWithCurrency price=$order->total_paid currency=$currency}</span>
+        </td>
+      </tr>
+      </tfoot>
+      <tbody>
+      {foreach from=$products item=product name=products}
+        {if !isset($product.deleted)}
+          {assign var='productId' value=$product.product_id}
+          {assign var='productAttributeId' value=$product.product_attribute_id}
+          {if isset($product.customizedDatas)}
+            {assign var='productQuantity' value=$product.product_quantity-$product.customizationQuantityTotal}
+          {else}
+            {assign var='productQuantity' value=$product.product_quantity}
+          {/if}
+          <!-- Customized products -->
+          {if isset($product.customizedDatas)}
             <tr class="item">
-                <td colspan="{if $return_allowed}2{else}1{/if}">
-                    <strong>{l s='Items'} {if $use_tax}{l s='(tax incl.)'}{/if} </strong>
-                </td>
-                <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
-                    <span class="price">{displayWtPriceWithCurrency price=$order->getTotalProductsWithTaxes() currency=$currency}</span>
-                </td>
-            </tr>
-            {if $order->total_discounts > 0}
-            <tr class="item">
-                <td colspan="{if $return_allowed}2{else}1{/if}">
-                    <strong>{l s='Total vouchers'}</strong>
-                </td>
-                <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
-                    <span class="price-discount">{displayWtPriceWithCurrency price=$order->total_discounts currency=$currency convert=1}</span>
-                </td>
-            </tr>
-            {/if}
-            {if $order->total_wrapping > 0}
-            <tr class="item">
-                <td colspan="{if $return_allowed}2{else}1{/if}">
-                    <strong>{l s='Total gift wrapping cost'}</strong>
-                </td>
-                <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
-                    <span class="price-wrapping">{displayWtPriceWithCurrency price=$order->total_wrapping currency=$currency}</span>
-                </td>
-            </tr>
-            {/if}
-            <tr class="item">
-                <td colspan="{if $return_allowed}2{else}1{/if}">
-                    <strong>{l s='Shipping & handling'} {if $use_tax}{l s='(tax incl.)'}{/if} </strong>
-                </td>
-                <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
-                    <span class="price-shipping">{displayWtPriceWithCurrency price=$order->total_shipping currency=$currency}</span>
-                </td>
-            </tr>
-            <tr class="totalprice item">
-                <td colspan="{if $return_allowed}2{else}1{/if}">
-                    <strong>{l s='Total'}</strong>
-                </td>
-                <td colspan="{if $order->hasProductReturned()}5{else}4{/if}">
-                    <span class="price">{displayWtPriceWithCurrency price=$order->total_paid currency=$currency}</span>
-                </td>
-            </tr>
-        </tfoot>
-        <tbody>
-        {foreach from=$products item=product name=products}
-            {if !isset($product.deleted)}
-                {assign var='productId' value=$product.product_id}
-                {assign var='productAttributeId' value=$product.product_attribute_id}
-                {if isset($product.customizedDatas)}
-                    {assign var='productQuantity' value=$product.product_quantity-$product.customizationQuantityTotal}
-                {else}
-                    {assign var='productQuantity' value=$product.product_quantity}
-                {/if}
-                <!-- Customized products -->
-                {if isset($product.customizedDatas)}
-                    <tr class="item">
-                        {if $return_allowed}<td class="order_cb"></td>{/if}
-                        <td><label for="cb_{$product.id_order_detail|intval}">{if $product.product_reference}{$product.product_reference|escape:'html':'UTF-8'}{else}--{/if}</label></td>
-                        <td class="bold">
-                            <label for="cb_{$product.id_order_detail|intval}">{$product.product_name|escape:'html':'UTF-8'}</label>
-                        </td>
-                        <td>
-                        <input class="order_qte_input form-control grey"  name="order_qte_input[{$smarty.foreach.products.index}]" type="text" size="2" value="{$product.customizationQuantityTotal|intval}" />
-                            <div class="clearfix return_quantity_buttons">
-                                <a href="#" class="return_quantity_down btn btn-default button-minus"><span><i class="icon-minus"></i></span></a>
-                                <a href="#" class="return_quantity_up btn btn-default button-plus"><span><i class="icon-plus"></i></span></a>
-                            </div>
-                            <label for="cb_{$product.id_order_detail|intval}"><span class="order_qte_span editable">{$product.customizationQuantityTotal|intval}</span></label></td>
-                        {if $order->hasProductReturned()}
-                            <td>
-                                {$product['qty_returned']}
-                            </td>
-                        {/if}
-                        <td>
-                            <label class="price" for="cb_{$product.id_order_detail|intval}">
-                                {if $group_use_tax}
-                                    {convertPriceWithCurrency price=$product.unit_price_tax_incl currency=$currency}
-                                {else}
-                                    {convertPriceWithCurrency price=$product.unit_price_tax_excl currency=$currency}
-                                {/if}
-                            </label>
-                        </td>
-                        <td>
-                            <label class="price" for="cb_{$product.id_order_detail|intval}">
-                                {if isset($customizedDatas.$productId.$productAttributeId)}
-                                    {if $group_use_tax}
-                                        {convertPriceWithCurrency price=$product.total_customization_wt currency=$currency}
-                                    {else}
-                                        {convertPriceWithCurrency price=$product.total_customization currency=$currency}
-                                    {/if}
-                                {else}
-                                    {if $group_use_tax}
-                                        {convertPriceWithCurrency price=$product.total_price_tax_incl currency=$currency}
-                                    {else}
-                                        {convertPriceWithCurrency price=$product.total_price_tax_excl currency=$currency}
-                                    {/if}
-                                {/if}
-                            </label>
-                        </td>
-                    </tr>
-                    {foreach $product.customizedDatas  as $customizationPerAddress}
-                        {foreach $customizationPerAddress as $customizationId => $customization}
-                        <tr class="alternate_item">
-                            {if $return_allowed}<td class="order_cb"><input type="checkbox" id="cb_{$product.id_order_detail|intval}" name="customization_ids[{$product.id_order_detail|intval}][]" value="{$customizationId|intval}" /></td>{/if}
-                            <td colspan="2">
-                            {foreach from=$customization.datas key='type' item='datas'}
-                                {if $type == $CUSTOMIZE_FILE}
-                                <ul class="customizationUploaded">
-                                    {foreach from=$datas item='data'}
-                                        <li><img src="{$pic_dir}{$data.value}_small" alt="" class="customizationUploaded" /></li>
-                                    {/foreach}
-                                </ul>
-                                {elseif $type == $CUSTOMIZE_TEXTFIELD}
-                                <ul class="typedText">{counter start=0 print=false}
-                                    {foreach from=$datas item='data'}
-                                        {assign var='customizationFieldName' value="Text #"|cat:$data.id_customization_field}
-                                        <li>{$data.name|default:$customizationFieldName} : {$data.value}</li>
-                                    {/foreach}
-                                </ul>
-                                {/if}
-                            {/foreach}
-                            </td>
-                            <td>
-                                <input class="order_qte_input form-control grey" name="customization_qty_input[{$customizationId|intval}]" type="text" size="2" value="{$customization.quantity|intval}" />
-                                <div class="clearfix return_quantity_buttons">
-                                    <a href="#" class="return_quantity_down btn btn-default button-minus"><span><i class="icon-minus"></i></span></a>
-                                    <a href="#" class="return_quantity_up btn btn-default button-plus"><span><i class="icon-plus"></i></span></a>
-                                </div>
-                                <label for="cb_{$product.id_order_detail|intval}"><span class="order_qte_span editable">{$customization.quantity|intval}</span></label>
-                            </td>
-                            <td colspan="2"></td>
-                        </tr>
-                        {/foreach}
-                    {/foreach}
-                {/if}
-                <!-- Classic products -->
-                {if $product.product_quantity > $product.customizationQuantityTotal}
-                    <tr class="item">
-                        {if $return_allowed}<td class="order_cb"><input type="checkbox" id="cb_{$product.id_order_detail|intval}" name="ids_order_detail[{$product.id_order_detail|intval}]" value="{$product.id_order_detail|intval}" /></td>{/if}
-                        <td><label for="cb_{$product.id_order_detail|intval}">{if $product.product_reference}{$product.product_reference|escape:'html':'UTF-8'}{else}--{/if}</label></td>
-                        <td class="bold">
-                            <label for="cb_{$product.id_order_detail|intval}">
-                                {if $product.download_hash && $logable && $product.display_filename != '' && $product.product_quantity_refunded == 0 && $product.product_quantity_return == 0}
-                                    {if isset($is_guest) && $is_guest}
-                                    <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}&amp;id_order={$order->id}&secure_key={$order->secure_key}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}">
-                                    {else}
-                                        <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}">
-                                    {/if}
-                                        <img src="{$img_dir}icon/download_product.gif" class="icon" alt="{l s='Download product'}" />
-                                    </a>
-                                    {if isset($is_guest) && $is_guest}
-                                        <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}&id_order={$order->id}&secure_key={$order->secure_key}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}"> {$product.product_name|escape:'html':'UTF-8'} </a>
-                                    {else}
-                                    <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}"> {$product.product_name|escape:'html':'UTF-8'} </a>
-                                    {/if}
-                                {else}
-                                    {$product.product_name|escape:'html':'UTF-8'}
-                                {/if}
-                            </label>
-                        </td>
-                        <td class="return_quantity">
-                            <input class="order_qte_input form-control grey" name="order_qte_input[{$product.id_order_detail|intval}]" type="text" size="2" value="{$productQuantity|intval}" />
-                            <div class="clearfix return_quantity_buttons">
-                                <a href="#" class="return_quantity_down btn btn-default button-minus"><span><i class="icon-minus"></i></span></a>
-                                <a href="#" class="return_quantity_up btn btn-default button-plus"><span><i class="icon-plus"></i></span></a>
-                            </div>
-                            <label for="cb_{$product.id_order_detail|intval}"><span class="order_qte_span editable">{$productQuantity|intval}</span></label></td>
-                        {if $order->hasProductReturned()}
-                            <td>
-                                {$product['qty_returned']}
-                            </td>
-                        {/if}
-                        <td class="price">
-                            <label for="cb_{$product.id_order_detail|intval}">
-                            {if $group_use_tax}
-                                {convertPriceWithCurrency price=$product.unit_price_tax_incl currency=$currency}
-                            {else}
-                                {convertPriceWithCurrency price=$product.unit_price_tax_excl currency=$currency}
-                            {/if}
-                            </label>
-                        </td>
-                        <td class="price">
-                            <label for="cb_{$product.id_order_detail|intval}">
-                            {if $group_use_tax}
-                                {convertPriceWithCurrency price=$product.total_price_tax_incl currency=$currency}
-                            {else}
-                                {convertPriceWithCurrency price=$product.total_price_tax_excl currency=$currency}
-                            {/if}
-                            </label>
-                        </td>
-                    </tr>
-                {/if}
-            {/if}
-        {/foreach}
-        {foreach from=$discounts item=discount}
-            <tr class="item">
-                <td>{$discount.name|escape:'html':'UTF-8'}</td>
-                <td>{l s='Voucher'} {$discount.name|escape:'html':'UTF-8'}</td>
-                <td><span class="order_qte_span editable">1</span></td>
-                <td>&nbsp;</td>
-                <td>{if $discount.value != 0.00}-{/if}{convertPriceWithCurrency price=$discount.value currency=$currency}</td>
-                {if $return_allowed}
-                <td>&nbsp;</td>
-                {/if}
-            </tr>
-        {/foreach}
-        </tbody>
-    </table>
-</div>
-{if $return_allowed}
-    <div id="returnOrderMessage">
-        <h3 class="page-heading bottom-indent">{l s='Merchandise return'}</h3>
-        <p>{l s='If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.'}</p>
-        <p class="form-group">
-            <textarea class="form-control" cols="67" rows="3" name="returnText"></textarea>
-        </p>
-        <p class="form-group">
-            <button type="submit" name="submitReturnMerchandise" class="btn btn-default button button-small"><span>{l s='Make an RMA slip'}<i class="icon-chevron-right right"></i></span></button>
-            <input type="hidden" class="hidden" value="{$order->id|intval}" name="id_order" />
-        </p>
-    </div>
-{/if}
-{if !$is_guest}</form>{/if}
-{assign var='carriers' value=$order->getShipping()}
-{if $carriers|count > 0 && isset($carriers.0.carrier_name) && $carriers.0.carrier_name}
-    <table class="table table-bordered footab">
-        <thead>
-            <tr>
-                <th class="first_item">{l s='Date'}</th>
-                <th class="item" data-sort-ignore="true">{l s='Carrier'}</th>
-                <th data-hide="phone" class="item">{l s='Weight'}</th>
-                <th data-hide="phone" class="item">{l s='Shipping cost'}</th>
-                <th data-hide="phone" class="last_item" data-sort-ignore="true">{l s='Tracking number'}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {foreach from=$carriers item=line}
-            <tr class="item">
-                <td data-value="{$line.date_add|regex_replace:"/[\-\:\ ]/":""}">{dateFormat date=$line.date_add full=0}</td>
-                <td>{$line.carrier_name}</td>
-                <td data-value="{if $line.weight > 0}{$line.weight|string_format:"%.3f"}{else}0{/if}">{if $line.weight > 0}{$line.weight|string_format:"%.3f"} {Configuration::get('PS_WEIGHT_UNIT')}{else}-{/if}</td>
-                <td data-value="{if $order->getTaxCalculationMethod() == $smarty.const.PS_TAX_INC}{$line.shipping_cost_tax_incl}{else}{$line.shipping_cost_tax_excl}{/if}">{if $order->getTaxCalculationMethod() == $smarty.const.PS_TAX_INC}{displayPrice price=$line.shipping_cost_tax_incl currency=$currency->id}{else}{displayPrice price=$line.shipping_cost_tax_excl currency=$currency->id}{/if}</td>
+              {if $return_allowed}<td class="order_cb"></td>{/if}
+              <td><label for="cb_{$product.id_order_detail|intval}">{if $product.product_reference}{$product.product_reference|escape:'html':'UTF-8'}{else}--{/if}</label></td>
+              <td class="bold">
+                <label for="cb_{$product.id_order_detail|intval}">{$product.product_name|escape:'html':'UTF-8'}</label>
+              </td>
+              <td>
+                <input class="order_qte_input form-control grey"  name="order_qte_input[{$smarty.foreach.products.index}]" type="text" size="2" value="{$product.customizationQuantityTotal|intval}" />
+                <div class="clearfix return_quantity_buttons">
+                  <a href="#" class="return_quantity_down btn btn-default button-minus"><span><i class="icon-minus"></i></span></a>
+                  <a href="#" class="return_quantity_up btn btn-default button-plus"><span><i class="icon-plus"></i></span></a>
+                </div>
+                <label for="cb_{$product.id_order_detail|intval}"><span class="order_qte_span editable">{$product.customizationQuantityTotal|intval}</span></label></td>
+              {if $order->hasProductReturned()}
                 <td>
-                    <span class="shipping_number_show">{if $line.tracking_number}{if $line.url && $line.tracking_number}<a href="{$line.url|replace:'@':$line.tracking_number}">{$line.tracking_number}</a>{else}{$line.tracking_number}{/if}{else}-{/if}</span>
+                  {$product['qty_returned']}
                 </td>
+              {/if}
+              <td>
+                <label class="price" for="cb_{$product.id_order_detail|intval}">
+                  {if $group_use_tax}
+                    {convertPriceWithCurrency price=$product.unit_price_tax_incl currency=$currency}
+                  {else}
+                    {convertPriceWithCurrency price=$product.unit_price_tax_excl currency=$currency}
+                  {/if}
+                </label>
+              </td>
+              <td>
+                <label class="price" for="cb_{$product.id_order_detail|intval}">
+                  {if isset($customizedDatas.$productId.$productAttributeId)}
+                    {if $group_use_tax}
+                      {convertPriceWithCurrency price=$product.total_customization_wt currency=$currency}
+                    {else}
+                      {convertPriceWithCurrency price=$product.total_customization currency=$currency}
+                    {/if}
+                  {else}
+                    {if $group_use_tax}
+                      {convertPriceWithCurrency price=$product.total_price_tax_incl currency=$currency}
+                    {else}
+                      {convertPriceWithCurrency price=$product.total_price_tax_excl currency=$currency}
+                    {/if}
+                  {/if}
+                </label>
+              </td>
             </tr>
+            {foreach $product.customizedDatas  as $customizationPerAddress}
+              {foreach $customizationPerAddress as $customizationId => $customization}
+                <tr class="alternate_item">
+                  {if $return_allowed}<td class="order_cb"><input type="checkbox" id="cb_{$product.id_order_detail|intval}" name="customization_ids[{$product.id_order_detail|intval}][]" value="{$customizationId|intval}" /></td>{/if}
+                  <td colspan="2">
+                    {foreach from=$customization.datas key='type' item='datas'}
+                      {if $type == $CUSTOMIZE_FILE}
+                        <ul class="customizationUploaded">
+                          {foreach from=$datas item='data'}
+                            <li><img src="{$pic_dir}{$data.value}_small" alt="" class="customizationUploaded" /></li>
+                          {/foreach}
+                        </ul>
+                      {elseif $type == $CUSTOMIZE_TEXTFIELD}
+                        <ul class="typedText">{counter start=0 print=false}
+                          {foreach from=$datas item='data'}
+                            {assign var='customizationFieldName' value="Text #"|cat:$data.id_customization_field}
+                            <li>{$data.name|default:$customizationFieldName} : {$data.value}</li>
+                          {/foreach}
+                        </ul>
+                      {/if}
+                    {/foreach}
+                  </td>
+                  <td>
+                    <input class="order_qte_input form-control grey" name="customization_qty_input[{$customizationId|intval}]" type="text" size="2" value="{$customization.quantity|intval}" />
+                    <div class="clearfix return_quantity_buttons">
+                      <a href="#" class="return_quantity_down btn btn-default button-minus"><span><i class="icon-minus"></i></span></a>
+                      <a href="#" class="return_quantity_up btn btn-default button-plus"><span><i class="icon-plus"></i></span></a>
+                    </div>
+                    <label for="cb_{$product.id_order_detail|intval}"><span class="order_qte_span editable">{$customization.quantity|intval}</span></label>
+                  </td>
+                  <td colspan="2"></td>
+                </tr>
+              {/foreach}
             {/foreach}
-        </tbody>
+          {/if}
+          <!-- Classic products -->
+          {if $product.product_quantity > $product.customizationQuantityTotal}
+            <tr class="item">
+              {if $return_allowed}<td class="order_cb"><input type="checkbox" id="cb_{$product.id_order_detail|intval}" name="ids_order_detail[{$product.id_order_detail|intval}]" value="{$product.id_order_detail|intval}" /></td>{/if}
+              <td><label for="cb_{$product.id_order_detail|intval}">{if $product.product_reference}{$product.product_reference|escape:'html':'UTF-8'}{else}--{/if}</label></td>
+              <td class="bold">
+                <label for="cb_{$product.id_order_detail|intval}">
+                  {if $product.download_hash && $logable && $product.display_filename != '' && $product.product_quantity_refunded == 0 && $product.product_quantity_return == 0}
+                  {if isset($is_guest) && $is_guest}
+                  <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}&amp;id_order={$order->id}&secure_key={$order->secure_key}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}">
+                    {else}
+                    <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}">
+                      {/if}
+                      <img src="{$img_dir}icon/download_product.gif" class="icon" alt="{l s='Download product'}" />
+                    </a>
+                    {if isset($is_guest) && $is_guest}
+                      <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}&id_order={$order->id}&secure_key={$order->secure_key}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}"> {$product.product_name|escape:'html':'UTF-8'} </a>
+                    {else}
+                      <a href="{$link->getPageLink('get-file', true, NULL, "key={$product.filename|escape:'html':'UTF-8'}-{$product.download_hash|escape:'html':'UTF-8'}")|escape:'html':'UTF-8'}" title="{l s='Download this product'}"> {$product.product_name|escape:'html':'UTF-8'} </a>
+                    {/if}
+                    {else}
+                    {$product.product_name|escape:'html':'UTF-8'}
+                    {/if}
+                </label>
+              </td>
+              <td class="return_quantity">
+                <input class="order_qte_input form-control grey" name="order_qte_input[{$product.id_order_detail|intval}]" type="text" size="2" value="{$productQuantity|intval}" />
+                <div class="clearfix return_quantity_buttons">
+                  <a href="#" class="return_quantity_down btn btn-default button-minus"><span><i class="icon-minus"></i></span></a>
+                  <a href="#" class="return_quantity_up btn btn-default button-plus"><span><i class="icon-plus"></i></span></a>
+                </div>
+                <label for="cb_{$product.id_order_detail|intval}"><span class="order_qte_span editable">{$productQuantity|intval}</span></label></td>
+              {if $order->hasProductReturned()}
+                <td>
+                  {$product['qty_returned']}
+                </td>
+              {/if}
+              <td class="price">
+                <label for="cb_{$product.id_order_detail|intval}">
+                  {if $group_use_tax}
+                    {convertPriceWithCurrency price=$product.unit_price_tax_incl currency=$currency}
+                  {else}
+                    {convertPriceWithCurrency price=$product.unit_price_tax_excl currency=$currency}
+                  {/if}
+                </label>
+              </td>
+              <td class="price">
+                <label for="cb_{$product.id_order_detail|intval}">
+                  {if $group_use_tax}
+                    {convertPriceWithCurrency price=$product.total_price_tax_incl currency=$currency}
+                  {else}
+                    {convertPriceWithCurrency price=$product.total_price_tax_excl currency=$currency}
+                  {/if}
+                </label>
+              </td>
+            </tr>
+          {/if}
+        {/if}
+      {/foreach}
+      {foreach from=$discounts item=discount}
+        <tr class="item">
+          <td>{$discount.name|escape:'html':'UTF-8'}</td>
+          <td>{l s='Voucher'} {$discount.name|escape:'html':'UTF-8'}</td>
+          <td><span class="order_qte_span editable">1</span></td>
+          <td>&nbsp;</td>
+          <td>{if $discount.value != 0.00}-{/if}{convertPriceWithCurrency price=$discount.value currency=$currency}</td>
+          {if $return_allowed}
+            <td>&nbsp;</td>
+          {/if}
+        </tr>
+      {/foreach}
+      </tbody>
     </table>
-{/if}
-{if !$is_guest}
-    {if count($messages)}
-    <h3 class="page-heading">{l s='Messages'}</h3>
-     <div class="table_block">
-        <table class="detail_step_by_step table table-bordered">
-            <thead>
-                <tr>
-                    <th class="first_item" style="width:150px;">{l s='From'}</th>
-                    <th class="last_item">{l s='Message'}</th>
-                </tr>
-            </thead>
-            <tbody>
-            {foreach from=$messages item=message name="messageList"}
-                <tr class="{if $smarty.foreach.messageList.first}first_item{elseif $smarty.foreach.messageList.last}last_item{/if} {if $smarty.foreach.messageList.index % 2}alternate_item{else}item{/if}">
-                    <td>
-                        <strong class="dark">
-                            {if isset($message.elastname) && $message.elastname}
-                                {$message.efirstname|escape:'html':'UTF-8'} {$message.elastname|escape:'html':'UTF-8'}
-                            {elseif $message.clastname}
-                                {$message.cfirstname|escape:'html':'UTF-8'} {$message.clastname|escape:'html':'UTF-8'}
-                            {else}
-                                {$shop_name|escape:'html':'UTF-8'}
-                            {/if}
-                        </strong>
-                        <br />
-                        {dateFormat date=$message.date_add full=1}
-                    </td>
-                    <td>{$message.message|escape:'html':'UTF-8'|nl2br}</td>
-                </tr>
-            {/foreach}
-            </tbody>
-        </table>
+  </div>
+  {if $return_allowed}
+    <div id="returnOrderMessage">
+      <h3 class="page-heading bottom-indent">{l s='Merchandise return'}</h3>
+      <p>{l s='If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.'}</p>
+      <p class="form-group">
+        <textarea class="form-control" cols="67" rows="3" name="returnText"></textarea>
+      </p>
+      <p class="form-group">
+        <button type="submit" name="submitReturnMerchandise" class="btn btn-default button button-small"><span>{l s='Make an RMA slip'}<i class="icon-chevron-right right"></i></span></button>
+        <input type="hidden" class="hidden" value="{$order->id|intval}" name="id_order" />
+      </p>
     </div>
+  {/if}
+  {if !$is_guest}</form>{/if}
+  {assign var='carriers' value=$order->getShipping()}
+  {if $carriers|count > 0 && isset($carriers.0.carrier_name) && $carriers.0.carrier_name}
+    <table class="table table-bordered footab">
+      <thead>
+      <tr>
+        <th class="first_item">{l s='Date'}</th>
+        <th class="item" data-sort-ignore="true">{l s='Carrier'}</th>
+        <th data-hide="phone" class="item">{l s='Weight'}</th>
+        <th data-hide="phone" class="item">{l s='Shipping cost'}</th>
+        <th data-hide="phone" class="last_item" data-sort-ignore="true">{l s='Tracking number'}</th>
+      </tr>
+      </thead>
+      <tbody>
+      {foreach from=$carriers item=line}
+        <tr class="item">
+          <td data-value="{$line.date_add|regex_replace:"/[\-\:\ ]/":""}">{dateFormat date=$line.date_add full=0}</td>
+          <td>{$line.carrier_name}</td>
+          <td data-value="{if $line.weight > 0}{$line.weight|string_format:"%.3f"}{else}0{/if}">{if $line.weight > 0}{$line.weight|string_format:"%.3f"} {Configuration::get('PS_WEIGHT_UNIT')}{else}-{/if}</td>
+          <td data-value="{if $order->getTaxCalculationMethod() == $smarty.const.PS_TAX_INC}{$line.shipping_cost_tax_incl}{else}{$line.shipping_cost_tax_excl}{/if}">{if $order->getTaxCalculationMethod() == $smarty.const.PS_TAX_INC}{displayPrice price=$line.shipping_cost_tax_incl currency=$currency->id}{else}{displayPrice price=$line.shipping_cost_tax_excl currency=$currency->id}{/if}</td>
+          <td>
+            <span class="shipping_number_show">{if $line.tracking_number}{if $line.url && $line.tracking_number}<a href="{$line.url|replace:'@':$line.tracking_number}">{$line.tracking_number}</a>{else}{$line.tracking_number}{/if}{else}-{/if}</span>
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    </table>
+  {/if}
+  {if !$is_guest}
+    {if count($messages)}
+      <h3 class="page-heading">{l s='Messages'}</h3>
+      <div class="table_block">
+        <table class="detail_step_by_step table table-bordered">
+          <thead>
+          <tr>
+            <th class="first_item" style="width:150px;">{l s='From'}</th>
+            <th class="last_item">{l s='Message'}</th>
+          </tr>
+          </thead>
+          <tbody>
+          {foreach from=$messages item=message name="messageList"}
+            <tr class="{if $smarty.foreach.messageList.first}first_item{elseif $smarty.foreach.messageList.last}last_item{/if} {if $smarty.foreach.messageList.index % 2}alternate_item{else}item{/if}">
+              <td>
+                <strong class="dark">
+                  {if isset($message.elastname) && $message.elastname}
+                    {$message.efirstname|escape:'html':'UTF-8'} {$message.elastname|escape:'html':'UTF-8'}
+                  {elseif $message.clastname}
+                    {$message.cfirstname|escape:'html':'UTF-8'} {$message.clastname|escape:'html':'UTF-8'}
+                  {else}
+                    {$shop_name|escape:'html':'UTF-8'}
+                  {/if}
+                </strong>
+                <br />
+                {dateFormat date=$message.date_add full=1}
+              </td>
+              <td>{$message.message|escape:'html':'UTF-8'|nl2br}</td>
+            </tr>
+          {/foreach}
+          </tbody>
+        </table>
+      </div>
     {/if}
     {if isset($errors) && $errors}
-        <div class="alert alert-danger">
-            <p>{if $errors|@count > 1}{l s='There are %d errors' sprintf=$errors|@count}{else}{l s='There is %d error' sprintf=$errors|@count}{/if}</p>
-            <ol>
-            {foreach from=$errors key=k item=error}
-                <li>{$error}</li>
-            {/foreach}
-            </ol>
-        </div>
+      <div class="alert alert-danger">
+        <p>{if $errors|@count > 1}{l s='There are %d errors' sprintf=$errors|@count}{else}{l s='There is %d error' sprintf=$errors|@count}{/if}</p>
+        <ol>
+          {foreach from=$errors key=k item=error}
+            <li>{$error}</li>
+          {/foreach}
+        </ol>
+      </div>
     {/if}
     {if isset($message_confirmation) && $message_confirmation}
-    <p class="alert alert-success">
+      <p class="alert alert-success">
         {l s='Message successfully sent'}
-    </p>
+      </p>
     {/if}
     <form action="{$link->getPageLink('order-detail', true)|escape:'html':'UTF-8'}" method="post" class="std" id="sendOrderMessage">
-        <h3 class="page-heading bottom-indent">{l s='Add a message'}</h3>
-        <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
-        <p class="form-group">
+      <h3 class="page-heading bottom-indent">{l s='Add a message'}</h3>
+      <p>{l s='If you would like to add a comment about your order, please write it in the field below.'}</p>
+      <p class="form-group">
         <label for="id_product">{l s='Product'}</label>
-            <select name="id_product" class="form-control">
-                <option value="0">{l s='-- Choose --'}</option>
-                {foreach from=$products item=product name=products}
-                    <option value="{$product.product_id}">{$product.product_name}</option>
-                {/foreach}
-            </select>
-        </p>
-        <p class="form-group">
-            <textarea class="form-control" cols="67" rows="3" name="msgText"></textarea>
-        </p>
-        <div class="submit">
-            <input type="hidden" name="id_order" value="{$order->id|intval}" />
-            <input type="submit" class="unvisible" name="submitMessage" value="{l s='Send'}"/>
-            <button type="submit" name="submitMessage" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
-        </div>
+        <select name="id_product" class="form-control">
+          <option value="0">{l s='-- Choose --'}</option>
+          {foreach from=$products item=product name=products}
+            <option value="{$product.product_id}">{$product.product_name}</option>
+          {/foreach}
+        </select>
+      </p>
+      <p class="form-group">
+        <textarea class="form-control" cols="67" rows="3" name="msgText"></textarea>
+      </p>
+      <div class="submit">
+        <input type="hidden" name="id_order" value="{$order->id|intval}" />
+        <input type="submit" class="unvisible" name="submitMessage" value="{l s='Send'}"/>
+        <button type="submit" name="submitMessage" class="button btn btn-default button-medium"><span>{l s='Send'}<i class="icon-chevron-right right"></i></span></button>
+      </div>
     </form>
-{else}
-<p class="alert alert-info"><i class="icon-info-sign"></i>{l s='You cannot return merchandise with a guest account'}</p>
-{/if}
+  {else}
+    <p class="alert alert-info"><i class="icon-info-sign"></i>{l s='You cannot return merchandise with a guest account'}</p>
+  {/if}
 {/if}

--- a/themes/community-theme-16/order-follow.tpl
+++ b/themes/community-theme-16/order-follow.tpl
@@ -24,140 +24,140 @@
 *}
 
 {capture name=path}
-    <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-        {l s='My account'}
-    </a>
-    <span class="navigation-pipe">
+  <a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+    {l s='My account'}
+  </a>
+  <span class="navigation-pipe">
         {$navigationPipe}
     </span>
-    <span class="navigation_page">
+  <span class="navigation_page">
         {l s='Return Merchandise Authorization (RMA)'}
     </span>
 {/capture}
 
 <h1 class="page-heading bottom-indent">
-    {l s='Return Merchandise Authorization (RMA)'}
+  {l s='Return Merchandise Authorization (RMA)'}
 </h1>
 {if isset($errorQuantity) && $errorQuantity}
-    <p class="error">
-        {l s='You do not have enough products to request an additional merchandise return.'}
-    </p>
+  <p class="error">
+    {l s='You do not have enough products to request an additional merchandise return.'}
+  </p>
 {/if}
 {if isset($errorMsg) && $errorMsg}
-    <p class="alert alert-danger">
-        {l s='Please provide an explanation for your RMA.'}
+  <p class="alert alert-danger">
+    {l s='Please provide an explanation for your RMA.'}
+  </p>
+  <form method="POST"  id="returnOrderMessage">
+    <p class="textarea form-group">
+      <label>{l s='Please provide an explanation for your RMA:'}</label>
+      <textarea name="returnText" class="form-control"></textarea>
     </p>
-    <form method="POST"  id="returnOrderMessage">
-        <p class="textarea form-group">
-            <label>{l s='Please provide an explanation for your RMA:'}</label>
-            <textarea name="returnText" class="form-control"></textarea>
-        </p>
-        {foreach $ids_order_detail as $id_order_detail}
-            <input type="hidden" name="ids_order_detail[{$id_order_detail|intval}]" value="{$id_order_detail|intval}"/>
-        {/foreach}
-        {foreach $order_qte_input as $key => $value}
-            <input type="hidden" name="order_qte_input[{$key|intval}]" value="{$value|intval}"/>
-        {/foreach}
-        <input type="hidden" name="id_order" value="{$id_order|intval}"/>
-        <input class="unvisible" type="submit" name="submitReturnMerchandise" value="{l s='Make an RMA slip'}"/>
-        <p>
-            <button type="submit" name="submitReturnMerchandise" class="btn btn-default button button-small">
-                <span>
-                    {l s='Make an RMA slip'}<i class="icon-chevron-right right"></i>
-                </span>
-            </button>
-        </p>
-    </form>
+    {foreach $ids_order_detail as $id_order_detail}
+      <input type="hidden" name="ids_order_detail[{$id_order_detail|intval}]" value="{$id_order_detail|intval}"/>
+    {/foreach}
+    {foreach $order_qte_input as $key => $value}
+      <input type="hidden" name="order_qte_input[{$key|intval}]" value="{$value|intval}"/>
+    {/foreach}
+    <input type="hidden" name="id_order" value="{$id_order|intval}"/>
+    <input class="unvisible" type="submit" name="submitReturnMerchandise" value="{l s='Make an RMA slip'}"/>
+    <p>
+      <button type="submit" name="submitReturnMerchandise" class="btn btn-default button button-small">
+       <span>
+         {l s='Make an RMA slip'}<i class="icon-chevron-right right"></i>
+       </span>
+      </button>
+    </p>
+  </form>
 
 {/if}
 {if isset($errorDetail1) && $errorDetail1}
-    <p class="alert alert-danger">
-        {l s='Please check at least one product you would like to return.'}
-    </p>
+  <p class="alert alert-danger">
+    {l s='Please check at least one product you would like to return.'}
+  </p>
 {/if}
 {if isset($errorDetail2) && $errorDetail2}
-    <p class="alert alert-danger">
-        {l s='For each product you wish to add, please specify the desired quantity.'}
-    </p>
+  <p class="alert alert-danger">
+    {l s='For each product you wish to add, please specify the desired quantity.'}
+  </p>
 {/if}
 {if isset($errorNotReturnable) && $errorNotReturnable}
-    <p class="alert alert-danger">
-        {l s='This order cannot be returned.'}
-    </p>
+  <p class="alert alert-danger">
+    {l s='This order cannot be returned.'}
+  </p>
 {/if}
 
 <p class="info-title">
-    {l s='Here is a list of pending merchandise returns'}.
+  {l s='Here is a list of pending merchandise returns'}.
 </p>
 <div class="block-center" id="block-history">
-    {if $ordersReturn && count($ordersReturn)}
+  {if $ordersReturn && count($ordersReturn)}
     <table id="order-list" class="table table-bordered footab">
-        <thead>
-            <tr>
-                <th data-sort-ignore="true" class="first_item">{l s='Return'}</th>
-                <th data-sort-ignore="true" class="item">{l s='Order'}</th>
-                <th data-hide="phone" class="item">{l s='Package status'}</th>
-                <th data-hide="phone,tablet" class="item">{l s='Date issued'}</th>
-                <th data-sort-ignore="true" data-hide="phone,tablet" class="last_item">{l s='Return slip'}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {foreach from=$ordersReturn item=return name=myLoop}
-                <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
-                    <td class="bold">
-                        <a
-                        class="color-myaccount"
-                        href="javascript:showOrder(0, {$return.id_order_return|intval}, '{$link->getPageLink('order-return', true)|escape:'html':'UTF-8'}');">
-                            {l s='#'}{$return.id_order_return|string_format:"%06d"}
-                        </a>
-                    </td>
-                    <td class="history_method">
-                        <a
-                        class="color-myaccount"
-                        href="javascript:showOrder(1, {$return.id_order|intval}, '{$link->getPageLink('order-detail', true)|escape:'html':'UTF-8'}');">
-                            {$return.reference}
-                        </a>
-                    </td>
-                    <td class="history_method" data-value="{$return.state}">
-                        <span class="label label-info">
-                            {$return.state_name|escape:'html':'UTF-8'}
-                        </span>
-                    </td>
-                    <td class="bold" data-value="{$return.date_add|regex_replace:"/[\-\:\ ]/":""}">
-                        {dateFormat date=$return.date_add full=0}
-                    </td>
-                    <td class="history_invoice">
-                        {if $return.state == 2}
-                            <a class="link-button" href="{$link->getPageLink('pdf-order-return', true, NULL, "id_order_return={$return.id_order_return|intval}")|escape:'html':'UTF-8'}" title="{l s='Order return'} {l s='#'}{$return.id_order_return|string_format:"%06d"}">
-                                <i class="icon-file-text"></i> {l s='Print out'}
-                            </a>
-                        {else}
-                            --
-                        {/if}
-                    </td>
-                </tr>
-            {/foreach}
-        </tbody>
+      <thead>
+      <tr>
+        <th data-sort-ignore="true" class="first_item">{l s='Return'}</th>
+        <th data-sort-ignore="true" class="item">{l s='Order'}</th>
+        <th data-hide="phone" class="item">{l s='Package status'}</th>
+        <th data-hide="phone,tablet" class="item">{l s='Date issued'}</th>
+        <th data-sort-ignore="true" data-hide="phone,tablet" class="last_item">{l s='Return slip'}</th>
+      </tr>
+      </thead>
+      <tbody>
+      {foreach from=$ordersReturn item=return name=myLoop}
+        <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
+          <td class="bold">
+            <a
+              class="color-myaccount"
+              href="javascript:showOrder(0, {$return.id_order_return|intval}, '{$link->getPageLink('order-return', true)|escape:'html':'UTF-8'}');">
+              {l s='#'}{$return.id_order_return|string_format:"%06d"}
+            </a>
+          </td>
+          <td class="history_method">
+            <a
+              class="color-myaccount"
+              href="javascript:showOrder(1, {$return.id_order|intval}, '{$link->getPageLink('order-detail', true)|escape:'html':'UTF-8'}');">
+              {$return.reference}
+            </a>
+          </td>
+          <td class="history_method" data-value="{$return.state}">
+            <span class="label label-info">
+              {$return.state_name|escape:'html':'UTF-8'}
+            </span>
+          </td>
+          <td class="bold" data-value="{$return.date_add|regex_replace:"/[\-\:\ ]/":""}">
+            {dateFormat date=$return.date_add full=0}
+          </td>
+          <td class="history_invoice">
+            {if $return.state == 2}
+              <a class="link-button" href="{$link->getPageLink('pdf-order-return', true, NULL, "id_order_return={$return.id_order_return|intval}")|escape:'html':'UTF-8'}" title="{l s='Order return'} {l s='#'}{$return.id_order_return|string_format:"%06d"}">
+                <i class="icon-file-text"></i> {l s='Print out'}
+              </a>
+            {else}
+              --
+            {/if}
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
     </table>
     <div id="block-order-detail" class="unvisible">&nbsp;</div>
-    {else}
-        <p class="alert alert-warning">{l s='You have no merchandise return authorizations.'}</p>
-    {/if}
+  {else}
+    <p class="alert alert-warning">{l s='You have no merchandise return authorizations.'}</p>
+  {/if}
 </div>
 
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Back to your account'}
-            </span>
-        </a>
-    </li>
-    <li>
-        <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Home'}
-            </span>
-        </a>
-    </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Back to your account'}
+      </span>
+    </a>
+  </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Home'}
+      </span>
+    </a>
+  </li>
 </ul>

--- a/themes/community-theme-16/order-opc-advanced.tpl
+++ b/themes/community-theme-16/order-opc-advanced.tpl
@@ -24,75 +24,75 @@
 *}
 
 {if $opc}
-    {assign var="back_order_page" value="order-opc.php"}
+  {assign var="back_order_page" value="order-opc.php"}
 {else}
-    {assign var="back_order_page" value="order.php"}
+  {assign var="back_order_page" value="order.php"}
 {/if}
 
 {if $PS_CATALOG_MODE}
-    {capture name=path}{l s='Your shopping cart'}{/capture}
-    <h2 id="cart_title">{l s='Your shopping cart'}</h2>
-    <p class="alert alert-warning">{l s='Your new order was not accepted.'}</p>
+  {capture name=path}{l s='Your shopping cart'}{/capture}
+  <h2 id="cart_title">{l s='Your shopping cart'}</h2>
+  <p class="alert alert-warning">{l s='Your new order was not accepted.'}</p>
 {else}
-    {if $productNumber}
-        <!-- Payment -->
-        {include file="$tpl_dir./order-payment-advanced.tpl"}
-        <!-- END Payment -->
-    {else}
-        {capture name=path}{l s='Your shopping cart'}{/capture}
-        <h2 class="page-heading">{l s='Your shopping cart'}</h2>
-        {include file="$tpl_dir./errors.tpl"}
-        <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
-    {/if}
-    {strip}
-        {addJsDef imgDir=$img_dir}
-        {addJsDef authenticationUrl=$link->getPageLink("authentication", true)|escape:'quotes':'UTF-8'}
-        {addJsDef orderOpcUrl=$link->getPageLink("order-opc", true)|escape:'quotes':'UTF-8'}
-        {addJsDef historyUrl=$link->getPageLink("history", true)|escape:'quotes':'UTF-8'}
-        {addJsDef guestTrackingUrl=$link->getPageLink("guest-tracking", true)|escape:'quotes':'UTF-8'}
-        {addJsDef addressUrl=$link->getPageLink("address", true, NULL, "back={$back_order_page}")|escape:'quotes':'UTF-8'}
-        {addJsDef orderProcess='order-opc'}
-        {addJsDef guestCheckoutEnabled=$PS_GUEST_CHECKOUT_ENABLED|intval}
-        {addJsDef displayPrice=$priceDisplay}
-        {addJsDef taxEnabled=$use_taxes}
-        {addJsDef conditionEnabled=$conditions|intval}
-        {addJsDef vat_management=$vat_management|intval}
-        {addJsDef errorCarrier=$errorCarrier|@addcslashes:'\''}
-        {addJsDef errorTOS=$errorTOS|@addcslashes:'\''}
-        {addJsDef checkedCarrier=$checked|intval}
-        {addJsDef addresses=array()}
-        {addJsDef isVirtualCart=$isVirtualCart|intval}
-        {addJsDef isPaymentStep=$isPaymentStep|intval}
-        {addJsDefL name=txtWithTax}{l s='(tax incl.)' js=1}{/addJsDefL}
-        {addJsDefL name=txtWithoutTax}{l s='(tax excl.)' js=1}{/addJsDefL}
-        {addJsDefL name=txtHasBeenSelected}{l s='has been selected' js=1}{/addJsDefL}
-        {addJsDefL name=txtNoCarrierIsSelected}{l s='No carrier has been selected' js=1}{/addJsDefL}
-        {addJsDefL name=txtNoCarrierIsNeeded}{l s='No carrier is needed for this order' js=1}{/addJsDefL}
-        {addJsDefL name=txtConditionsIsNotNeeded}{l s='You do not need to accept the Terms of Service for this order.' js=1}{/addJsDefL}
-        {addJsDefL name=txtTOSIsAccepted}{l s='The service terms have been accepted' js=1}{/addJsDefL}
-        {addJsDefL name=txtTOSIsNotAccepted}{l s='The service terms have not been accepted' js=1}{/addJsDefL}
-        {addJsDefL name=txtThereis}{l s='There is' js=1}{/addJsDefL}
-        {addJsDefL name=txtErrors}{l s='Error(s)' js=1}{/addJsDefL}
-        {addJsDefL name=txtDeliveryAddress}{l s='Delivery address' js=1}{/addJsDefL}
-        {addJsDefL name=txtInvoiceAddress}{l s='Invoice address' js=1}{/addJsDefL}
-        {addJsDefL name=txtModifyMyAddress}{l s='Modify my address' js=1}{/addJsDefL}
-        {addJsDefL name=txtInstantCheckout}{l s='Instant checkout' js=1}{/addJsDefL}
-        {addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address.' js=1}{/addJsDefL}
-        {addJsDefL name=txtFree}{l s='Free' js=1}{/addJsDefL}
+  {if $productNumber}
+    <!-- Payment -->
+    {include file="$tpl_dir./order-payment-advanced.tpl"}
+    <!-- END Payment -->
+  {else}
+    {capture name=path}{l s='Your shopping cart'}{/capture}
+    <h2 class="page-heading">{l s='Your shopping cart'}</h2>
+    {include file="$tpl_dir./errors.tpl"}
+    <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+  {/if}
+  {strip}
+    {addJsDef imgDir=$img_dir}
+    {addJsDef authenticationUrl=$link->getPageLink("authentication", true)|escape:'quotes':'UTF-8'}
+    {addJsDef orderOpcUrl=$link->getPageLink("order-opc", true)|escape:'quotes':'UTF-8'}
+    {addJsDef historyUrl=$link->getPageLink("history", true)|escape:'quotes':'UTF-8'}
+    {addJsDef guestTrackingUrl=$link->getPageLink("guest-tracking", true)|escape:'quotes':'UTF-8'}
+    {addJsDef addressUrl=$link->getPageLink("address", true, NULL, "back={$back_order_page}")|escape:'quotes':'UTF-8'}
+    {addJsDef orderProcess='order-opc'}
+    {addJsDef guestCheckoutEnabled=$PS_GUEST_CHECKOUT_ENABLED|intval}
+    {addJsDef displayPrice=$priceDisplay}
+    {addJsDef taxEnabled=$use_taxes}
+    {addJsDef conditionEnabled=$conditions|intval}
+    {addJsDef vat_management=$vat_management|intval}
+    {addJsDef errorCarrier=$errorCarrier|@addcslashes:'\''}
+    {addJsDef errorTOS=$errorTOS|@addcslashes:'\''}
+    {addJsDef checkedCarrier=$checked|intval}
+    {addJsDef addresses=array()}
+    {addJsDef isVirtualCart=$isVirtualCart|intval}
+    {addJsDef isPaymentStep=$isPaymentStep|intval}
+    {addJsDefL name=txtWithTax}{l s='(tax incl.)' js=1}{/addJsDefL}
+    {addJsDefL name=txtWithoutTax}{l s='(tax excl.)' js=1}{/addJsDefL}
+    {addJsDefL name=txtHasBeenSelected}{l s='has been selected' js=1}{/addJsDefL}
+    {addJsDefL name=txtNoCarrierIsSelected}{l s='No carrier has been selected' js=1}{/addJsDefL}
+    {addJsDefL name=txtNoCarrierIsNeeded}{l s='No carrier is needed for this order' js=1}{/addJsDefL}
+    {addJsDefL name=txtConditionsIsNotNeeded}{l s='You do not need to accept the Terms of Service for this order.' js=1}{/addJsDefL}
+    {addJsDefL name=txtTOSIsAccepted}{l s='The service terms have been accepted' js=1}{/addJsDefL}
+    {addJsDefL name=txtTOSIsNotAccepted}{l s='The service terms have not been accepted' js=1}{/addJsDefL}
+    {addJsDefL name=txtThereis}{l s='There is' js=1}{/addJsDefL}
+    {addJsDefL name=txtErrors}{l s='Error(s)' js=1}{/addJsDefL}
+    {addJsDefL name=txtDeliveryAddress}{l s='Delivery address' js=1}{/addJsDefL}
+    {addJsDefL name=txtInvoiceAddress}{l s='Invoice address' js=1}{/addJsDefL}
+    {addJsDefL name=txtModifyMyAddress}{l s='Modify my address' js=1}{/addJsDefL}
+    {addJsDefL name=txtInstantCheckout}{l s='Instant checkout' js=1}{/addJsDefL}
+    {addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address.' js=1}{/addJsDefL}
+    {addJsDefL name=txtFree}{l s='Free' js=1}{/addJsDefL}
 
-        {capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
-        {capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
-        {addJsDef addressUrl=$smarty.capture.addressUrl}
-        {capture}{'&multi-shipping=1'|urlencode}{/capture}
-        {addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
-        {capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
-        {addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
-        {addJsDef opc=$opc|boolval}
-        {capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
-        {addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-        {capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
-        {addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-        {capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
-        {addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-    {/strip}
+    {capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+    {capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+    {addJsDef addressUrl=$smarty.capture.addressUrl}
+    {capture}{'&multi-shipping=1'|urlencode}{/capture}
+    {addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+    {capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+    {addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+    {addJsDef opc=$opc|boolval}
+    {capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+    {addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+    {capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+    {addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+    {capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+    {addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/order-opc-new-account-advanced.tpl
+++ b/themes/community-theme-16/order-opc-new-account-advanced.tpl
@@ -1,426 +1,426 @@
 <div id="opc_new_account" class="opc-main-block">
-    <div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
-    <h2>{l s='Account'}</h2>
-    <form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
-        <fieldset>
-            <h3 class="page-subheading">{l s='Already registered?'}</h3>
-            <p><a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" id="openLoginFormBlock">&raquo; {l s='Click here'}</a></p>
-            <div id="login_form_content" style="display:none;">
-                <!-- Error return block -->
-                <div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
-                <!-- END Error return block -->
-                <p class="form-group">
-                    <label for="login_email">{l s='Email address'}</label>
-                    <input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
-                </p>
-                <p class="form-group">
-                    <label for="login_passwd">{l s='Password'}</label>
-                    <input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
-                </p>
-                <a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password">{l s='Forgot your password?'}</a>
-                <p class="submit">
-                    {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
-                    <button type="submit" id="SubmitLogin" name="SubmitLogin" data-adv-api="1" class="button btn btn-default button-medium"><span><i class="icon-lock left"></i>{l s='Sign in'}</span></button>
-                </p>
+  <div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
+  <h2>{l s='Account'}</h2>
+  <form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
+    <fieldset>
+      <h3 class="page-subheading">{l s='Already registered?'}</h3>
+      <p><a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" id="openLoginFormBlock">&raquo; {l s='Click here'}</a></p>
+      <div id="login_form_content" style="display:none;">
+        <!-- Error return block -->
+        <div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
+        <!-- END Error return block -->
+        <p class="form-group">
+          <label for="login_email">{l s='Email address'}</label>
+          <input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
+        </p>
+        <p class="form-group">
+          <label for="login_passwd">{l s='Password'}</label>
+          <input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
+        </p>
+        <a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password">{l s='Forgot your password?'}</a>
+        <p class="submit">
+          {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+          <button type="submit" id="SubmitLogin" name="SubmitLogin" data-adv-api="1" class="button btn btn-default button-medium"><span><i class="icon-lock left"></i>{l s='Sign in'}</span></button>
+        </p>
+      </div>
+    </fieldset>
+  </form>
+  <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
+    <fieldset>
+      <div class="box">
+        <h3 id="new_account_title" class="page-subheading">{l s='New Customer'}</h3>
+        <div id="opc_account_choice" class="row">
+          <div class="col-xs-12 col-md-6">
+            <p class="title_block">{l s='Instant Checkout'}</p>
+            <p class="opc-button">
+              <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_guestCheckout"><span>{l s='Guest checkout'}</span></button>
+            </p>
+          </div>
+          <div class="col-xs-12 col-md-6">
+            <p class="title_block">{l s='Create your account today and enjoy:'}</p>
+            <ul class="bullet">
+              <li>- {l s='Personalized and secure access'}</li>
+              <li>- {l s='A fast and easy check out process'}</li>
+              <li>- {l s='Separate billing and shipping addresses'}</li>
+            </ul>
+            <p class="opc-button">
+              <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_createAccount"><span><i class="icon-user left"></i>{l s='Create an account'}</span></button>
+            </p>
+          </div>
+        </div>
+        <div id="opc_account_form" class="unvisible">
+          {$HOOK_CREATE_ACCOUNT_TOP}
+          <!-- Error return block -->
+          <div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
+          <!-- END Error return block -->
+          <!-- Account -->
+          <input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
+          <input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
+          <input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+          <input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+          <div class="required text form-group">
+            <label for="email">{l s='Email'} <sup>*</sup></label>
+            <input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
+          </div>
+          <div class="required password is_customer_param form-group">
+            <label for="passwd">{l s='Password'} <sup>*</sup></label>
+            <input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
+            <span class="form_info">{l s='(five characters min.)'}</span>
+          </div>
+          <div class="required clearfix gender-line">
+            <label>{l s='Social title'}</label>
+            {foreach from=$genders key=k item=gender}
+              <div class="radio-inline">
+                <label for="id_gender{$gender->id_gender}" class="top">
+                  <input type="radio" name="id_gender" id="id_gender{$gender->id_gender}" value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} checked="checked"{/if} />
+                  {$gender->name}</label></div>
+            {/foreach}
+          </div>
+          <div class="required form-group">
+            <label for="firstname">{l s='First name'} <sup>*</sup></label>
+            <input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
+          </div>
+          <div class="required form-group">
+            <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+            <input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
+          </div>
+          <div class="select form-group date-select">
+            <label>{l s='Date of Birth'}</label>
+            <div class="row">
+              <div class="col-xs-4">
+                <select id="days" name="days" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$days item=day}
+                    <option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                  {/foreach}
+                </select>
+                {*
+                {l s='January'}
+                {l s='February'}
+                {l s='March'}
+                {l s='April'}
+                {l s='May'}
+                {l s='June'}
+                {l s='July'}
+                {l s='August'}
+                {l s='September'}
+                {l s='October'}
+                {l s='November'}
+                {l s='December'}
+                *}
+              </div>
+              <div class="col-xs-4">
+                <select id="months" name="months" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$months key=k item=month}
+                    <option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+                  {/foreach}
+                </select>
+              </div>
+              <div class="col-xs-4">
+                <select id="years" name="years" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$years item=year}
+                    <option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                  {/foreach}
+                </select>
+              </div>
             </div>
-        </fieldset>
-    </form>
-    <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
-        <fieldset>
-            <div class="box">
-                <h3 id="new_account_title" class="page-subheading">{l s='New Customer'}</h3>
-                <div id="opc_account_choice" class="row">
-                    <div class="col-xs-12 col-md-6">
-                        <p class="title_block">{l s='Instant Checkout'}</p>
-                        <p class="opc-button">
-                            <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_guestCheckout"><span>{l s='Guest checkout'}</span></button>
-                        </p>
-                    </div>
-                    <div class="col-xs-12 col-md-6">
-                        <p class="title_block">{l s='Create your account today and enjoy:'}</p>
-                        <ul class="bullet">
-                            <li>- {l s='Personalized and secure access'}</li>
-                            <li>- {l s='A fast and easy check out process'}</li>
-                            <li>- {l s='Separate billing and shipping addresses'}</li>
-                        </ul>
-                        <p class="opc-button">
-                            <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_createAccount"><span><i class="icon-user left"></i>{l s='Create an account'}</span></button>
-                        </p>
-                    </div>
+          </div>
+          {if isset($newsletter) && $newsletter}
+            <div class="checkbox">
+              <label for="newsletter">
+                <input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
+                {l s='Sign up for our newsletter!'}</label>
+              {if array_key_exists('newsletter', $field_required)}
+                <sup> *</sup>
+              {/if}
+            </div>
+          {/if}
+          {if isset($optin) && $optin}
+            <div class="checkbox">
+              <label for="optin">
+                <input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
+                {l s='Receive special offers from our partners!'}</label>
+              {if array_key_exists('optin', $field_required)}
+                <sup> *</sup>
+              {/if}
+            </div>
+          {/if}
+          <h3 class="page-subheading top-indent">{l s='Delivery address'}</h3>
+          {$stateExist = false}
+          {$postCodeExist = false}
+          {$dniExist = false}
+          {foreach from=$dlv_all_fields item=field_name}
+            {if $field_name eq "company"}
+              <div class="text form-group">
+                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
+              </div>
+            {elseif $field_name eq "vat_number"}
+              <div id="vat_number_block" style="display:none;">
+                <div class="form-group">
+                  <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="text form-control" name="vat_number" id="vat_number" value="{if isset($guestInformations) && isset($guestInformations.vat_number) && $guestInformations.vat_number}{$guestInformations.vat_number}{/if}" />
                 </div>
-                <div id="opc_account_form" class="unvisible">
-                    {$HOOK_CREATE_ACCOUNT_TOP}
-                    <!-- Error return block -->
-                    <div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
-                    <!-- END Error return block -->
-                    <!-- Account -->
-                    <input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
-                    <input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
-                    <input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
-                    <input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
-                    <div class="required text form-group">
-                        <label for="email">{l s='Email'} <sup>*</sup></label>
-                        <input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
-                    </div>
-                    <div class="required password is_customer_param form-group">
-                        <label for="passwd">{l s='Password'} <sup>*</sup></label>
-                        <input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
-                        <span class="form_info">{l s='(five characters min.)'}</span>
-                    </div>
-                    <div class="required clearfix gender-line">
-                        <label>{l s='Social title'}</label>
-                        {foreach from=$genders key=k item=gender}
-                            <div class="radio-inline">
-                                <label for="id_gender{$gender->id_gender}" class="top">
-                                    <input type="radio" name="id_gender" id="id_gender{$gender->id_gender}" value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} checked="checked"{/if} />
-                                    {$gender->name}</label></div>
-                        {/foreach}
-                    </div>
-                    <div class="required form-group">
-                        <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
-                    </div>
-                    <div class="required form-group">
-                        <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                        <input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
-                    </div>
-                    <div class="select form-group date-select">
-                        <label>{l s='Date of Birth'}</label>
-                        <div class="row">
-                            <div class="col-xs-4">
-                                <select id="days" name="days" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$days item=day}
-                                        <option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                                {*
-                                {l s='January'}
-                                {l s='February'}
-                                {l s='March'}
-                                {l s='April'}
-                                {l s='May'}
-                                {l s='June'}
-                                {l s='July'}
-                                {l s='August'}
-                                {l s='September'}
-                                {l s='October'}
-                                {l s='November'}
-                                {l s='December'}
-                                *}
-                            </div>
-                            <div class="col-xs-4">
-                                <select id="months" name="months" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$months key=k item=month}
-                                        <option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                            <div class="col-xs-4">
-                                <select id="years" name="years" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$years item=year}
-                                        <option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    {if isset($newsletter) && $newsletter}
-                        <div class="checkbox">
-                            <label for="newsletter">
-                                <input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
-                                {l s='Sign up for our newsletter!'}</label>
-                            {if array_key_exists('newsletter', $field_required)}
-                                <sup> *</sup>
-                            {/if}
-                        </div>
-                    {/if}
-                    {if isset($optin) && $optin}
-                        <div class="checkbox">
-                            <label for="optin">
-                                <input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
-                                {l s='Receive special offers from our partners!'}</label>
-                            {if array_key_exists('optin', $field_required)}
-                                <sup> *</sup>
-                            {/if}
-                        </div>
-                    {/if}
-                    <h3 class="page-subheading top-indent">{l s='Delivery address'}</h3>
-                    {$stateExist = false}
-                    {$postCodeExist = false}
-                    {$dniExist = false}
-                    {foreach from=$dlv_all_fields item=field_name}
-                        {if $field_name eq "company"}
-                            <div class="text form-group">
-                                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
-                            </div>
-                        {elseif $field_name eq "vat_number"}
-                            <div id="vat_number_block" style="display:none;">
-                                <div class="form-group">
-                                    <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                    <input type="text" class="text form-control" name="vat_number" id="vat_number" value="{if isset($guestInformations) && isset($guestInformations.vat_number) && $guestInformations.vat_number}{$guestInformations.vat_number}{/if}" />
-                                </div>
-                            </div>
-                        {elseif $field_name eq "dni"}
-                            {assign var='dniExist' value=true}
-                            <div class="required dni form-group">
-                                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
-                                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                            </div>
-                        {elseif $field_name eq "firstname"}
-                            <div class="required text form-group">
-                                <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
-                            </div>
-                        {elseif $field_name eq "lastname"}
-                            <div class="required text form-group">
-                                <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
-                            </div>
-                        {elseif $field_name eq "address1"}
-                            <div class="required text form-group">
-                                <label for="address1">{l s='Address'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
-                            </div>
-                        {elseif $field_name eq "address2"}
-                            <div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group">
-                                <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
-                            </div>
-                        {elseif $field_name eq "postcode"}
-                            {$postCodeExist = true}
-                            <div class="required postcode text form-group">
-                                <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
-                            </div>
-                        {elseif $field_name eq "city"}
-                            <div class="required text form-group">
-                                <label for="city">{l s='City'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
-                            </div>
-                        {elseif $field_name eq "country" || $field_name eq "Country:name"}
-                            <div class="required select form-group">
-                                <label for="id_country">{l s='Country'} <sup>*</sup></label>
-                                <select name="id_country" id="id_country" class="form-control">
-                                    {foreach from=$countries item=v}
-                                        <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                        {elseif $field_name eq "state" || $field_name eq 'State:name'}
-                            {$stateExist = true}
-                            <div class="required id_state form-group" style="display:none;">
-                                <label for="id_state">{l s='State'} <sup>*</sup></label>
-                                <select name="id_state" id="id_state" class="form-control">
-                                    <option value="">-</option>
-                                </select>
-                            </div>
-                        {/if}
+              </div>
+            {elseif $field_name eq "dni"}
+              {assign var='dniExist' value=true}
+              <div class="required dni form-group">
+                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+              </div>
+            {elseif $field_name eq "firstname"}
+              <div class="required text form-group">
+                <label for="firstname">{l s='First name'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
+              </div>
+            {elseif $field_name eq "lastname"}
+              <div class="required text form-group">
+                <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
+              </div>
+            {elseif $field_name eq "address1"}
+              <div class="required text form-group">
+                <label for="address1">{l s='Address'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
+              </div>
+            {elseif $field_name eq "address2"}
+              <div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group">
+                <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
+              </div>
+            {elseif $field_name eq "postcode"}
+              {$postCodeExist = true}
+              <div class="required postcode text form-group">
+                <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+              </div>
+            {elseif $field_name eq "city"}
+              <div class="required text form-group">
+                <label for="city">{l s='City'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
+              </div>
+            {elseif $field_name eq "country" || $field_name eq "Country:name"}
+              <div class="required select form-group">
+                <label for="id_country">{l s='Country'} <sup>*</sup></label>
+                <select name="id_country" id="id_country" class="form-control">
+                  {foreach from=$countries item=v}
+                    <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+                  {/foreach}
+                </select>
+              </div>
+            {elseif $field_name eq "state" || $field_name eq 'State:name'}
+              {$stateExist = true}
+              <div class="required id_state form-group" style="display:none;">
+                <label for="id_state">{l s='State'} <sup>*</sup></label>
+                <select name="id_state" id="id_state" class="form-control">
+                  <option value="">-</option>
+                </select>
+              </div>
+            {/if}
+          {/foreach}
+          {if !$postCodeExist}
+            <div class="required postcode form-group unvisible">
+              <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+              <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+            </div>
+          {/if}
+          {if !$stateExist}
+            <div class="required id_state form-group unvisible">
+              <label for="id_state">{l s='State'} <sup>*</sup></label>
+              <select name="id_state" id="id_state" class="form-control">
+                <option value="">-</option>
+              </select>
+            </div>
+          {/if}
+          {if !$dniExist}
+            <div class="required dni form-group">
+              <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+              <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+              <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+            </div>
+          {/if}
+          <div class="form-group is_customer_param">
+            <label for="other">{l s='Additional information'}</label>
+            <textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
+          </div>
+          {if isset($one_phone_at_least) && $one_phone_at_least}
+            <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+          {/if}
+          <div class="form-group is_customer_param">
+            <label for="phone">{l s='Home phone'}</label>
+            <input type="text" class="text form-control validate" name="phone" id="phone"  data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
+          </div>
+          <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+            <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+            <input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
+          </div>
+          <input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
+
+          <div class="checkbox">
+            <label for="invoice_address">
+              <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($guestInformations) && isset($guestInformations.invoice_address) && $guestInformations.invoice_address)} checked="checked"{/if} autocomplete="off"/>
+              {l s='Please use another address for invoice'}</label>
+          </div>
+
+          <div id="opc_invoice_address" class="is_customer_param">
+            {assign var=stateExist value=false}
+            {assign var=postCodeExist value=false}
+            {assign var='dniExist' value=false}
+            <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
+            {foreach from=$inv_all_fields item=field_name}
+              {if $field_name eq "company"}
+                <div class="form-group">
+                  <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="text form-control validate" id="company_invoice" name="company_invoice"  data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.company_invoice) && $guestInformations.company_invoice}{$guestInformations.company_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "vat_number"}
+                <div id="vat_number_block_invoice" class="is_customer_param" style="display:none;">
+                  <div class="form-group">
+                    <label for="vat_number_invoice">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                    <input type="text" class="form-control" id="vat_number_invoice" name="vat_number_invoice" value="{if isset($guestInformations) && isset($guestInformations.vat_number_invoice) && $guestInformations.vat_number_invoice}{$guestInformations.vat_number_invoice}{/if}" />
+                  </div>
+                </div>
+              {elseif $field_name eq "dni"}
+                {assign var='dniExist' value=true}
+                <div class="required form-group dni_invoice">
+                  <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
+                  <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+                  <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                </div>
+              {elseif $field_name eq "firstname"}
+                <div class="required form-group">
+                  <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" id="firstname_invoice" name="firstname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname_invoice) && $guestInformations.firstname_invoice}{$guestInformations.firstname_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "lastname"}
+                <div class="required form-group">
+                  <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" id="lastname_invoice" name="lastname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname_invoice) && $guestInformations.lastname_invoice}{$guestInformations.lastname_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "address1"}
+                <div class="required form-group">
+                  <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "address2"}
+                <div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
+                  <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "postcode"}
+                {$postCodeExist = true}
+                <div class="required postcode_invoice form-group">
+                  <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+                </div>
+              {elseif $field_name eq "city"}
+                <div class="required form-group">
+                  <label for="city_invoice">{l s='City'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" name="city_invoice" id="city_invoice" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city_invoice) && $guestInformations.city_invoice}{$guestInformations.city_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "country" || $field_name eq "Country:name"}
+                <div class="required form-group">
+                  <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
+                  <select name="id_country_invoice" id="id_country_invoice" class="form-control">
+                    <option value="">-</option>
+                    {foreach from=$countries item=v}
+                      <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
                     {/foreach}
-                    {if !$postCodeExist}
-                        <div class="required postcode form-group unvisible">
-                            <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
-                            <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
-                        </div>
-                    {/if}
-                    {if !$stateExist}
-                        <div class="required id_state form-group unvisible">
-                            <label for="id_state">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state" id="id_state" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </div>
-                    {/if}
-                    {if !$dniExist}
-                        <div class="required dni form-group">
-                            <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                            <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
-                            <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                        </div>
-                    {/if}
-                    <div class="form-group is_customer_param">
-                        <label for="other">{l s='Additional information'}</label>
-                        <textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
-                    </div>
-                    {if isset($one_phone_at_least) && $one_phone_at_least}
-                        <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
-                    {/if}
-                    <div class="form-group is_customer_param">
-                        <label for="phone">{l s='Home phone'}</label>
-                        <input type="text" class="text form-control validate" name="phone" id="phone"  data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
-                    </div>
-                    <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                        <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
-                        <input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
-                    </div>
-                    <input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
-
-                    <div class="checkbox">
-                        <label for="invoice_address">
-                            <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($guestInformations) && isset($guestInformations.invoice_address) && $guestInformations.invoice_address)} checked="checked"{/if} autocomplete="off"/>
-                            {l s='Please use another address for invoice'}</label>
-                    </div>
-
-                    <div id="opc_invoice_address" class="is_customer_param">
-                        {assign var=stateExist value=false}
-                        {assign var=postCodeExist value=false}
-                        {assign var='dniExist' value=false}
-                        <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
-                        {foreach from=$inv_all_fields item=field_name}
-                            {if $field_name eq "company"}
-                                <div class="form-group">
-                                    <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                    <input type="text" class="text form-control validate" id="company_invoice" name="company_invoice"  data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.company_invoice) && $guestInformations.company_invoice}{$guestInformations.company_invoice}{/if}" />
-                                </div>
-                            {elseif $field_name eq "vat_number"}
-                                <div id="vat_number_block_invoice" class="is_customer_param" style="display:none;">
-                                    <div class="form-group">
-                                        <label for="vat_number_invoice">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                        <input type="text" class="form-control" id="vat_number_invoice" name="vat_number_invoice" value="{if isset($guestInformations) && isset($guestInformations.vat_number_invoice) && $guestInformations.vat_number_invoice}{$guestInformations.vat_number_invoice}{/if}" />
-                                    </div>
-                                </div>
-                            {elseif $field_name eq "dni"}
-                                {assign var='dniExist' value=true}
-                                <div class="required form-group dni_invoice">
-                                    <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
-                                    <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
-                                    <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                                </div>
-                            {elseif $field_name eq "firstname"}
-                                <div class="required form-group">
-                                    <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
-                                    <input type="text" class="form-control validate" id="firstname_invoice" name="firstname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname_invoice) && $guestInformations.firstname_invoice}{$guestInformations.firstname_invoice}{/if}" />
-                                </div>
-                            {elseif $field_name eq "lastname"}
-                                <div class="required form-group">
-                                    <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
-                                    <input type="text" class="form-control validate" id="lastname_invoice" name="lastname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname_invoice) && $guestInformations.lastname_invoice}{$guestInformations.lastname_invoice}{/if}" />
-                                </div>
-                            {elseif $field_name eq "address1"}
-                                <div class="required form-group">
-                                    <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
-                                    <input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
-                                </div>
-                            {elseif $field_name eq "address2"}
-                                <div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
-                                    <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                    <input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
-                                </div>
-                            {elseif $field_name eq "postcode"}
-                                {$postCodeExist = true}
-                                <div class="required postcode_invoice form-group">
-                                    <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                                    <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
-                                </div>
-                            {elseif $field_name eq "city"}
-                                <div class="required form-group">
-                                    <label for="city_invoice">{l s='City'} <sup>*</sup></label>
-                                    <input type="text" class="form-control validate" name="city_invoice" id="city_invoice" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city_invoice) && $guestInformations.city_invoice}{$guestInformations.city_invoice}{/if}" />
-                                </div>
-                            {elseif $field_name eq "country" || $field_name eq "Country:name"}
-                                <div class="required form-group">
-                                    <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
-                                    <select name="id_country_invoice" id="id_country_invoice" class="form-control">
-                                        <option value="">-</option>
-                                        {foreach from=$countries item=v}
-                                            <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
-                                        {/foreach}
-                                    </select>
-                                </div>
-                            {elseif $field_name eq "state" || $field_name eq 'State:name'}
-                                {$stateExist = true}
-                                <div class="required id_state_invoice form-group" style="display:none;">
-                                    <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
-                                    <select name="id_state_invoice" id="id_state_invoice" class="form-control">
-                                        <option value="">-</option>
-                                    </select>
-                                </div>
-                            {/if}
-                        {/foreach}
-                        {if !$postCodeExist}
-                            <div class="required postcode_invoice form-group unvisible">
-                                <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                                <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
-                            </div>
-                        {/if}
-                        {if !$stateExist}
-                            <div class="required id_state_invoice form-group unvisible">
-                                <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
-                                <select name="id_state_invoice" id="id_state_invoice" class="form-control">
-                                    <option value="">-</option>
-                                </select>
-                            </div>
-                        {/if}
-                        {if !$dniExist}
-                            <div class="required form-group dni_invoice">
-                                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                                <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
-                                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                            </div>
-                        {/if}
-                        <div class="form-group is_customer_param">
-                            <label for="other_invoice">{l s='Additional information'}</label>
-                            <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
-                        </div>
-                        {if isset($one_phone_at_least) && $one_phone_at_least}
-                            <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
-                        {/if}
-                        <div class="form-group is_customer_param">
-                            <label for="phone_invoice">{l s='Home phone'}</label>
-                            <input type="text" class="form-control validate" name="phone_invoice" id="phone_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_invoice) && $guestInformations.phone_invoice}{$guestInformations.phone_invoice}{/if}" />
-                        </div>
-                        <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                            <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control validate" name="phone_mobile_invoice" id="phone_mobile_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile_invoice) && $guestInformations.phone_mobile_invoice}{$guestInformations.phone_mobile_invoice}{/if}" />
-                        </div>
-                        <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
-                    </div>
-                    {$HOOK_CREATE_ACCOUNT_FORM}
-                    <div class="submit opc-add-save clearfix">
-                        <p class="required opc-required pull-right">
-                            <sup>*</sup>{l s='Required field'}
-                        </p>
-                        <button type="submit" name="submitAccount" id="submitAccount" data-adv-api="1" class="btn btn-default button button-medium"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
-
-                    </div>
-                    <div style="display: none;" id="opc_account_saved" class="alert alert-success">
-                        {l s='Account information saved successfully'}
-                    </div>
-                    <!-- END Account -->
+                  </select>
                 </div>
+              {elseif $field_name eq "state" || $field_name eq 'State:name'}
+                {$stateExist = true}
+                <div class="required id_state_invoice form-group" style="display:none;">
+                  <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                  <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                    <option value="">-</option>
+                  </select>
+                </div>
+              {/if}
+            {/foreach}
+            {if !$postCodeExist}
+              <div class="required postcode_invoice form-group unvisible">
+                <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+              </div>
+            {/if}
+            {if !$stateExist}
+              <div class="required id_state_invoice form-group unvisible">
+                <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                  <option value="">-</option>
+                </select>
+              </div>
+            {/if}
+            {if !$dniExist}
+              <div class="required form-group dni_invoice">
+                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+              </div>
+            {/if}
+            <div class="form-group is_customer_param">
+              <label for="other_invoice">{l s='Additional information'}</label>
+              <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
             </div>
-        </fieldset>
-    </form>
+            {if isset($one_phone_at_least) && $one_phone_at_least}
+              <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+            {/if}
+            <div class="form-group is_customer_param">
+              <label for="phone_invoice">{l s='Home phone'}</label>
+              <input type="text" class="form-control validate" name="phone_invoice" id="phone_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_invoice) && $guestInformations.phone_invoice}{$guestInformations.phone_invoice}{/if}" />
+            </div>
+            <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+              <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+              <input type="text" class="form-control validate" name="phone_mobile_invoice" id="phone_mobile_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile_invoice) && $guestInformations.phone_mobile_invoice}{$guestInformations.phone_mobile_invoice}{/if}" />
+            </div>
+            <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
+          </div>
+          {$HOOK_CREATE_ACCOUNT_FORM}
+          <div class="submit opc-add-save clearfix">
+            <p class="required opc-required pull-right">
+              <sup>*</sup>{l s='Required field'}
+            </p>
+            <button type="submit" name="submitAccount" id="submitAccount" data-adv-api="1" class="btn btn-default button button-medium"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
+
+          </div>
+          <div style="display: none;" id="opc_account_saved" class="alert alert-success">
+            {l s='Account information saved successfully'}
+          </div>
+          <!-- END Account -->
+        </div>
+      </div>
+    </fieldset>
+  </form>
 </div>
 {strip}
-    {if isset($guestInformations) && isset($guestInformations.id_state) && $guestInformations.id_state}
-        {addJsDef idSelectedState=$guestInformations.id_state|intval}
-    {else}
-        {addJsDef idSelectedState=false}
-    {/if}
-    {if isset($guestInformations) && isset($guestInformations.id_state_invoice) && $guestInformations.id_state_invoice}
-        {addJsDef idSelectedStateInvoice=$guestInformations.id_state_invoice|intval}
-    {else}
-        {addJsDef idSelectedStateInvoice=false}
-    {/if}
-    {if isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country}
-        {addJsDef idSelectedCountry=$guestInformations.id_country|intval}
-    {else}
-        {addJsDef idSelectedCountry=false}
-    {/if}
-    {if isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice}
-        {addJsDef idSelectedCountryInvoice=$guestInformations.id_country_invoice|intval}
-    {else}
-        {addJsDef idSelectedCountryInvoice=false}
-    {/if}
-    {if isset($countries)}
-        {addJsDef countries=$countries}
-    {/if}
-    {if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
-        {addJsDef vatnumber_ajax_call=$vatnumber_ajax_call}
-    {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_state) && $guestInformations.id_state}
+    {addJsDef idSelectedState=$guestInformations.id_state|intval}
+  {else}
+    {addJsDef idSelectedState=false}
+  {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_state_invoice) && $guestInformations.id_state_invoice}
+    {addJsDef idSelectedStateInvoice=$guestInformations.id_state_invoice|intval}
+  {else}
+    {addJsDef idSelectedStateInvoice=false}
+  {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country}
+    {addJsDef idSelectedCountry=$guestInformations.id_country|intval}
+  {else}
+    {addJsDef idSelectedCountry=false}
+  {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice}
+    {addJsDef idSelectedCountryInvoice=$guestInformations.id_country_invoice|intval}
+  {else}
+    {addJsDef idSelectedCountryInvoice=false}
+  {/if}
+  {if isset($countries)}
+    {addJsDef countries=$countries}
+  {/if}
+  {if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
+    {addJsDef vatnumber_ajax_call=$vatnumber_ajax_call}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/order-opc-new-account.tpl
+++ b/themes/community-theme-16/order-opc-new-account.tpl
@@ -1,428 +1,428 @@
 <div id="opc_new_account" class="opc-main-block">
-    <div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
-    <h1 class="page-heading step-num"><span>1</span> {l s='Account'}</h1>
-    <form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
-        <fieldset>
-            <h3 class="page-subheading">{l s='Already registered?'}</h3>
-            <p><a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" id="openLoginFormBlock">&raquo; {l s='Click here'}</a></p>
-            <div id="login_form_content" style="display:none;">
-                <!-- Error return block -->
-                <div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
-                <!-- END Error return block -->
-                <p class="form-group">
-                    <label for="login_email">{l s='Email address'}</label>
-                    <input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
-                </p>
-                <p class="form-group">
-                    <label for="login_passwd">{l s='Password'}</label>
-                    <input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
-                </p>
-                <a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password">{l s='Forgot your password?'}</a>
-                <p class="submit">
-                    {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
-                    <button type="submit" id="SubmitLogin" name="SubmitLogin" class="button btn btn-default button-medium"><span><i class="icon-lock left"></i>{l s='Sign in'}</span></button>
-                </p>
+  <div id="opc_new_account-overlay" class="opc-overlay" style="display: none;"></div>
+  <h1 class="page-heading step-num"><span>1</span> {l s='Account'}</h1>
+  <form action="{$link->getPageLink('authentication', true, NULL, "back=order-opc")|escape:'html':'UTF-8'}" method="post" id="login_form" class="box">
+    <fieldset>
+      <h3 class="page-subheading">{l s='Already registered?'}</h3>
+      <p><a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" id="openLoginFormBlock">&raquo; {l s='Click here'}</a></p>
+      <div id="login_form_content" style="display:none;">
+        <!-- Error return block -->
+        <div id="opc_login_errors" class="alert alert-danger" style="display:none;"></div>
+        <!-- END Error return block -->
+        <p class="form-group">
+          <label for="login_email">{l s='Email address'}</label>
+          <input type="email" class="form-control validate" id="login_email" name="email" data-validate="isEmail" />
+        </p>
+        <p class="form-group">
+          <label for="login_passwd">{l s='Password'}</label>
+          <input class="form-control validate" type="password" id="login_passwd" name="login_passwd" data-validate="isPasswd" />
+        </p>
+        <a href="{$link->getPageLink('password', true)|escape:'html':'UTF-8'}" class="lost_password">{l s='Forgot your password?'}</a>
+        <p class="submit">
+          {if isset($back)}<input type="hidden" class="hidden" name="back" value="{$back|escape:'html':'UTF-8'}" />{/if}
+          <button type="submit" id="SubmitLogin" name="SubmitLogin" class="button btn btn-default button-medium"><span><i class="icon-lock left"></i>{l s='Sign in'}</span></button>
+        </p>
+      </div>
+    </fieldset>
+  </form>
+  <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
+    <fieldset>
+      <div class="box">
+        <h3 id="new_account_title" class="page-subheading">{l s='New Customer'}</h3>
+        <div id="opc_account_choice" class="row">
+          <div class="col-xs-12 col-md-6">
+            <p class="title_block">{l s='Instant Checkout'}</p>
+            <p class="opc-button">
+              <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_guestCheckout"><span>{l s='Guest checkout'}</span></button>
+            </p>
+          </div>
+          <div class="col-xs-12 col-md-6">
+            <p class="title_block">{l s='Create your account today and enjoy:'}</p>
+            <ul class="bullet">
+              <li>- {l s='Personalized and secure access'}</li>
+              <li>- {l s='A fast and easy check out process'}</li>
+              <li>- {l s='Separate billing and shipping addresses'}</li>
+            </ul>
+            <p class="opc-button">
+              <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_createAccount"><span><i class="icon-user left"></i>{l s='Create an account'}</span></button>
+            </p>
+          </div>
+        </div>
+        <div id="opc_account_form" class="unvisible">
+          {$HOOK_CREATE_ACCOUNT_TOP}
+          <!-- Error return block -->
+          <div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
+          <!-- END Error return block -->
+          <!-- Account -->
+          <input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
+          <input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
+          <input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+          <input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
+          <p class="required"><sup>*</sup>{l s='Required field'}</p>
+          <div class="required text form-group">
+            <label for="email">{l s='Email'} <sup>*</sup></label>
+            <input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
+          </div>
+          <div class="required password is_customer_param form-group">
+            <label for="passwd">{l s='Password'} <sup>*</sup></label>
+            <input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
+            <span class="form_info">{l s='(five characters min.)'}</span>
+          </div>
+          <div class="required clearfix gender-line">
+            <label>{l s='Social title'}</label>
+            {foreach from=$genders key=k item=gender}
+              <div class="radio-inline">
+                <label for="id_gender{$gender->id_gender}" class="top">
+                  <input type="radio" name="id_gender" id="id_gender{$gender->id_gender}" value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} checked="checked"{/if} />
+                  {$gender->name}</label></div>
+            {/foreach}
+          </div>
+          <div class="required form-group">
+            <label for="firstname">{l s='First name'} <sup>*</sup></label>
+            <input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
+          </div>
+          <div class="required form-group">
+            <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+            <input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
+          </div>
+          <div class="select form-group date-select">
+            <label>{l s='Date of Birth'}</label>
+            <div class="row">
+              <div class="col-xs-4">
+                <select id="days" name="days" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$days item=day}
+                    <option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                  {/foreach}
+                </select>
+                {*
+                {l s='January'}
+                {l s='February'}
+                {l s='March'}
+                {l s='April'}
+                {l s='May'}
+                {l s='June'}
+                {l s='July'}
+                {l s='August'}
+                {l s='September'}
+                {l s='October'}
+                {l s='November'}
+                {l s='December'}
+                *}
+              </div>
+              <div class="col-xs-4">
+                <select id="months" name="months" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$months key=k item=month}
+                    <option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
+                  {/foreach}
+                </select>
+              </div>
+              <div class="col-xs-4">
+                <select id="years" name="years" class="form-control">
+                  <option value="">-</option>
+                  {foreach from=$years item=year}
+                    <option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
+                  {/foreach}
+                </select>
+              </div>
             </div>
-        </fieldset>
-    </form>
-    <form action="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" method="post" id="new_account_form" class="std" autocomplete="on" autofill="on">
-        <fieldset>
-            <div class="box">
-                <h3 id="new_account_title" class="page-subheading">{l s='New Customer'}</h3>
-                <div id="opc_account_choice" class="row">
-                    <div class="col-xs-12 col-md-6">
-                        <p class="title_block">{l s='Instant Checkout'}</p>
-                        <p class="opc-button">
-                            <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_guestCheckout"><span>{l s='Guest checkout'}</span></button>
-                        </p>
-                    </div>
-                    <div class="col-xs-12 col-md-6">
-                        <p class="title_block">{l s='Create your account today and enjoy:'}</p>
-                        <ul class="bullet">
-                            <li>- {l s='Personalized and secure access'}</li>
-                            <li>- {l s='A fast and easy check out process'}</li>
-                            <li>- {l s='Separate billing and shipping addresses'}</li>
-                        </ul>
-                        <p class="opc-button">
-                            <button type="submit" class="btn btn-default button button-medium exclusive" id="opc_createAccount"><span><i class="icon-user left"></i>{l s='Create an account'}</span></button>
-                        </p>
-                    </div>
+          </div>
+          {if isset($newsletter) && $newsletter}
+            <div class="checkbox">
+              <label for="newsletter">
+                <input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
+                {l s='Sign up for our newsletter!'}</label>
+              {if array_key_exists('newsletter', $field_required)}
+                <sup> *</sup>
+              {/if}
+            </div>
+          {/if}
+          {if isset($optin) && $optin}
+            <div class="checkbox">
+              <label for="optin">
+                <input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
+                {l s='Receive special offers from our partners!'}</label>
+              {if array_key_exists('optin', $field_required)}
+                <sup> *</sup>
+              {/if}
+            </div>
+          {/if}
+          <h3 class="page-subheading top-indent">{l s='Delivery address'}</h3>
+          {$stateExist = false}
+          {$postCodeExist = false}
+          {$dniExist = false}
+          {foreach from=$dlv_all_fields item=field_name}
+            {if $field_name eq "company"}
+              <div class="text form-group">
+                <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
+              </div>
+            {elseif $field_name eq "vat_number"}
+              <div id="vat_number_block" style="display:none;">
+                <div class="form-group">
+                  <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="text form-control" name="vat_number" id="vat_number" value="{if isset($guestInformations) && isset($guestInformations.vat_number) && $guestInformations.vat_number}{$guestInformations.vat_number}{/if}" />
                 </div>
-                <div id="opc_account_form" class="unvisible">
-                    {$HOOK_CREATE_ACCOUNT_TOP}
-                    <!-- Error return block -->
-                    <div id="opc_account_errors" class="alert alert-danger" style="display:none;"></div>
-                    <!-- END Error return block -->
-                    <!-- Account -->
-                    <input type="hidden" id="is_new_customer" name="is_new_customer" value="0" />
-                    <input type="hidden" id="opc_id_customer" name="opc_id_customer" value="{if isset($guestInformations) && isset($guestInformations.id_customer) && $guestInformations.id_customer}{$guestInformations.id_customer}{else}0{/if}" />
-                    <input type="hidden" id="opc_id_address_delivery" name="opc_id_address_delivery" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
-                    <input type="hidden" id="opc_id_address_invoice" name="opc_id_address_invoice" value="{if isset($guestInformations) && isset($guestInformations.id_address_delivery) && $guestInformations.id_address_delivery}{$guestInformations.id_address_delivery}{else}0{/if}" />
-                    <p class="required"><sup>*</sup>{l s='Required field'}</p>
-                    <div class="required text form-group">
-                        <label for="email">{l s='Email'} <sup>*</sup></label>
-                        <input type="email" class="text form-control validate" id="email" name="email" data-validate="isEmail" value="{if isset($guestInformations) && isset($guestInformations.email) && $guestInformations.email}{$guestInformations.email}{/if}" />
-                    </div>
-                    <div class="required password is_customer_param form-group">
-                        <label for="passwd">{l s='Password'} <sup>*</sup></label>
-                        <input type="password" class="text form-control validate" name="passwd" id="passwd" data-validate="isPasswd" />
-                        <span class="form_info">{l s='(five characters min.)'}</span>
-                    </div>
-                    <div class="required clearfix gender-line">
-                        <label>{l s='Social title'}</label>
-                        {foreach from=$genders key=k item=gender}
-                        <div class="radio-inline">
-                            <label for="id_gender{$gender->id_gender}" class="top">
-                            <input type="radio" name="id_gender" id="id_gender{$gender->id_gender}" value="{$gender->id_gender}"{if isset($smarty.post.id_gender) && $smarty.post.id_gender == $gender->id_gender || (isset($guestInformations) && $guestInformations.id_gender == $gender->id_gender)} checked="checked"{/if} />
-                            {$gender->name}</label></div>
-                        {/foreach}
-                    </div>
-                    <div class="required form-group">
-                        <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" id="customer_firstname" name="customer_firstname" onblur="$('#firstname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_firstname) && $guestInformations.customer_firstname}{$guestInformations.customer_firstname}{/if}" />
-                    </div>
-                    <div class="required form-group">
-                        <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                        <input type="text" class="form-control validate" id="customer_lastname" name="customer_lastname" onblur="$('#lastname').val($(this).val());" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.customer_lastname) && $guestInformations.customer_lastname}{$guestInformations.customer_lastname}{/if}" />
-                    </div>
-                    <div class="select form-group date-select">
-                        <label>{l s='Date of Birth'}</label>
-                        <div class="row">
-                            <div class="col-xs-4">
-                                <select id="days" name="days" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$days item=day}
-                                    <option value="{$day|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_day) && ($guestInformations.sl_day == $day)} selected="selected"{/if}>{$day|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                                {*
-                                {l s='January'}
-                                {l s='February'}
-                                {l s='March'}
-                                {l s='April'}
-                                {l s='May'}
-                                {l s='June'}
-                                {l s='July'}
-                                {l s='August'}
-                                {l s='September'}
-                                {l s='October'}
-                                {l s='November'}
-                                {l s='December'}
-                                *}
-                            </div>
-                            <div class="col-xs-4">
-                                <select id="months" name="months" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$months key=k item=month}
-                                    <option value="{$k|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_month) && ($guestInformations.sl_month == $k)} selected="selected"{/if}>{l s=$month}&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                            <div class="col-xs-4">
-                                <select id="years" name="years" class="form-control">
-                                    <option value="">-</option>
-                                    {foreach from=$years item=year}
-                                    <option value="{$year|escape:'html':'UTF-8'}" {if isset($guestInformations) && isset($guestInformations.sl_year) && ($guestInformations.sl_year == $year)} selected="selected"{/if}>{$year|escape:'html':'UTF-8'}&nbsp;&nbsp;</option>
-                                    {/foreach}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    {if isset($newsletter) && $newsletter}
-                    <div class="checkbox">
-                        <label for="newsletter">
-                        <input type="checkbox" name="newsletter" id="newsletter" value="1"{if isset($guestInformations) && isset($guestInformations.newsletter) && $guestInformations.newsletter} checked="checked"{/if} autocomplete="off"/>
-                        {l s='Sign up for our newsletter!'}</label>
-                        {if array_key_exists('newsletter', $field_required)}
-                            <sup> *</sup>
-                        {/if}
-                    </div>
-                    {/if}
-                    {if isset($optin) && $optin}
-                    <div class="checkbox">
-                        <label for="optin">
-                        <input type="checkbox" name="optin" id="optin" value="1"{if isset($guestInformations) && isset($guestInformations.optin) && $guestInformations.optin} checked="checked"{/if} autocomplete="off"/>
-                        {l s='Receive special offers from our partners!'}</label>
-                        {if array_key_exists('optin', $field_required)}
-                            <sup> *</sup>
-                        {/if}
-                    </div>
-                    {/if}
-                    <h3 class="page-subheading top-indent">{l s='Delivery address'}</h3>
-                    {$stateExist = false}
-                    {$postCodeExist = false}
-                    {$dniExist = false}
-                    {foreach from=$dlv_all_fields item=field_name}
-                    {if $field_name eq "company"}
-                        <div class="text form-group">
-                            <label for="company">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="text form-control validate" id="company" name="company" data-validate="isGenericName" value="{if isset($guestInformations) && isset($guestInformations.company) && $guestInformations.company}{$guestInformations.company}{/if}" />
-                        </div>
-                    {elseif $field_name eq "vat_number"}
-                    <div id="vat_number_block" style="display:none;">
-                        <div class="form-group">
-                            <label for="vat_number">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="text form-control" name="vat_number" id="vat_number" value="{if isset($guestInformations) && isset($guestInformations.vat_number) && $guestInformations.vat_number}{$guestInformations.vat_number}{/if}" />
-                        </div>
-                    </div>
-                    {elseif $field_name eq "dni"}
-                    {assign var='dniExist' value=true}
-                    <div class="required dni form-group">
-                        <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
-                        <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                    </div>
-                    {elseif $field_name eq "firstname"}
-                    <div class="required text form-group">
-                        <label for="firstname">{l s='First name'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
-                    </div>
-                    {elseif $field_name eq "lastname"}
-                    <div class="required text form-group">
-                        <label for="lastname">{l s='Last name'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
-                    </div>
-                    {elseif $field_name eq "address1"}
-                    <div class="required text form-group">
-                        <label for="address1">{l s='Address'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
-                    </div>
-                    {elseif $field_name eq "address2"}
-                    <div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group">
-                        <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                        <input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
-                    </div>
-                    {elseif $field_name eq "postcode"}
-                    {$postCodeExist = true}
-                    <div class="required postcode text form-group">
-                        <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
-                    </div>
-                    {elseif $field_name eq "city"}
-                    <div class="required text form-group">
-                        <label for="city">{l s='City'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
-                    </div>
-                    {elseif $field_name eq "country" || $field_name eq "Country:name"}
-                    <div class="required select form-group">
-                        <label for="id_country">{l s='Country'} <sup>*</sup></label>
-                        <select name="id_country" id="id_country" class="form-control">
-                            {foreach from=$countries item=v}
-                            <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
-                            {/foreach}
-                        </select>
-                    </div>
-                    {elseif $field_name eq "state" || $field_name eq 'State:name'}
-                    {$stateExist = true}
-                    <div class="required id_state form-group" style="display:none;">
-                        <label for="id_state">{l s='State'} <sup>*</sup></label>
-                        <select name="id_state" id="id_state" class="form-control">
-                            <option value="">-</option>
-                        </select>
-                    </div>
-                    {/if}
+              </div>
+            {elseif $field_name eq "dni"}
+              {assign var='dniExist' value=true}
+              <div class="required dni form-group">
+                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+              </div>
+            {elseif $field_name eq "firstname"}
+              <div class="required text form-group">
+                <label for="firstname">{l s='First name'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" id="firstname" name="firstname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname) && $guestInformations.firstname}{$guestInformations.firstname}{/if}" />
+              </div>
+            {elseif $field_name eq "lastname"}
+              <div class="required text form-group">
+                <label for="lastname">{l s='Last name'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" id="lastname" name="lastname" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname) && $guestInformations.lastname}{$guestInformations.lastname}{/if}" />
+              </div>
+            {elseif $field_name eq "address1"}
+              <div class="required text form-group">
+                <label for="address1">{l s='Address'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
+              </div>
+            {elseif $field_name eq "address2"}
+              <div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group">
+                <label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                <input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
+              </div>
+            {elseif $field_name eq "postcode"}
+              {$postCodeExist = true}
+              <div class="required postcode text form-group">
+                <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+              </div>
+            {elseif $field_name eq "city"}
+              <div class="required text form-group">
+                <label for="city">{l s='City'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="city" id="city" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city) && $guestInformations.city}{$guestInformations.city}{/if}" />
+              </div>
+            {elseif $field_name eq "country" || $field_name eq "Country:name"}
+              <div class="required select form-group">
+                <label for="id_country">{l s='Country'} <sup>*</sup></label>
+                <select name="id_country" id="id_country" class="form-control">
+                  {foreach from=$countries item=v}
+                    <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
+                  {/foreach}
+                </select>
+              </div>
+            {elseif $field_name eq "state" || $field_name eq 'State:name'}
+              {$stateExist = true}
+              <div class="required id_state form-group" style="display:none;">
+                <label for="id_state">{l s='State'} <sup>*</sup></label>
+                <select name="id_state" id="id_state" class="form-control">
+                  <option value="">-</option>
+                </select>
+              </div>
+            {/if}
+          {/foreach}
+          {if !$postCodeExist}
+            <div class="required postcode form-group unvisible">
+              <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
+              <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
+            </div>
+          {/if}
+          {if !$stateExist}
+            <div class="required id_state form-group unvisible">
+              <label for="id_state">{l s='State'} <sup>*</sup></label>
+              <select name="id_state" id="id_state" class="form-control">
+                <option value="">-</option>
+              </select>
+            </div>
+          {/if}
+          {if !$dniExist}
+            <div class="required dni form-group">
+              <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+              <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
+              <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+            </div>
+          {/if}
+          <div class="form-group is_customer_param">
+            <label for="other">{l s='Additional information'}</label>
+            <textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
+          </div>
+          <div class="form-group is_customer_param">
+            <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+            <input type="text" class="text form-control validate" name="phone" id="phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
+          </div>
+          <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+            <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
+            <input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
+          </div>
+          {if isset($one_phone_at_least) && $one_phone_at_least}
+            {assign var="atLeastOneExists" value=true}
+            <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
+          {/if}
+          <input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
+
+          <div class="checkbox">
+            <label for="invoice_address">
+              <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($guestInformations) && isset($guestInformations.invoice_address) && $guestInformations.invoice_address)} checked="checked"{/if} autocomplete="off"/>
+              {l s='Please use another address for invoice'}</label>
+          </div>
+
+          <div id="opc_invoice_address" class="is_customer_param">
+            {assign var=stateExist value=false}
+            {assign var=postCodeExist value=false}
+            {assign var='dniExist' value=false}
+            <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
+            {foreach from=$inv_all_fields item=field_name}
+              {if $field_name eq "company"}
+                <div class="form-group">
+                  <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="text form-control validate" id="company_invoice" name="company_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.company_invoice) && $guestInformations.company_invoice}{$guestInformations.company_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "vat_number"}
+                <div id="vat_number_block_invoice" class="is_customer_param" style="display:none;">
+                  <div class="form-group">
+                    <label for="vat_number_invoice">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                    <input type="text" class="form-control" id="vat_number_invoice" name="vat_number_invoice" value="{if isset($guestInformations) && isset($guestInformations.vat_number_invoice) && $guestInformations.vat_number_invoice}{$guestInformations.vat_number_invoice}{/if}" />
+                  </div>
+                </div>
+              {elseif $field_name eq "dni"}
+                {assign var='dniExist' value=true}
+                <div class="required form-group dni_invoice">
+                  <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
+                  <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+                  <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+                </div>
+              {elseif $field_name eq "firstname"}
+                <div class="required form-group">
+                  <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" id="firstname_invoice" name="firstname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname_invoice) && $guestInformations.firstname_invoice}{$guestInformations.firstname_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "lastname"}
+                <div class="required form-group">
+                  <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" id="lastname_invoice" name="lastname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname_invoice) && $guestInformations.lastname_invoice}{$guestInformations.lastname_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "address1"}
+                <div class="required form-group">
+                  <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "address2"}
+                <div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
+                  <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
+                  <input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "postcode"}
+                {$postCodeExist = true}
+                <div class="required postcode_invoice form-group">
+                  <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+                </div>
+              {elseif $field_name eq "city"}
+                <div class="required form-group">
+                  <label for="city_invoice">{l s='City'} <sup>*</sup></label>
+                  <input type="text" class="form-control validate" name="city_invoice" id="city_invoice" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city_invoice) && $guestInformations.city_invoice}{$guestInformations.city_invoice}{/if}" />
+                </div>
+              {elseif $field_name eq "country" || $field_name eq "Country:name"}
+                <div class="required form-group">
+                  <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
+                  <select name="id_country_invoice" id="id_country_invoice" class="form-control">
+                    <option value="">-</option>
+                    {foreach from=$countries item=v}
+                      <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
                     {/foreach}
-                    {if !$postCodeExist}
-                    <div class="required postcode form-group unvisible">
-                        <label for="postcode">{l s='Zip/Postal code'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" name="postcode" id="postcode" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode) && $guestInformations.postcode}{$guestInformations.postcode}{/if}"/>
-                    </div>
-                    {/if}
-                    {if !$stateExist}
-                    <div class="required id_state form-group unvisible">
-                        <label for="id_state">{l s='State'} <sup>*</sup></label>
-                        <select name="id_state" id="id_state" class="form-control">
-                            <option value="">-</option>
-                        </select>
-                    </div>
-                    {/if}
-                    {if !$dniExist}
-                    <div class="required dni form-group">
-                        <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                        <input type="text" class="text form-control validate" name="dni" id="dni" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni) && $guestInformations.dni}{$guestInformations.dni}{/if}" />
-                        <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                    </div>
-                    {/if}
-                    <div class="form-group is_customer_param">
-                        <label for="other">{l s='Additional information'}</label>
-                        <textarea class="form-control" name="other" id="other" cols="26" rows="7"></textarea>
-                    </div>
-                    <div class="form-group is_customer_param">
-                        <label for="phone">{l s='Home phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                        <input type="text" class="text form-control validate" name="phone" id="phone" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone) && $guestInformations.phone}{$guestInformations.phone}{/if}" />
-                    </div>
-                    <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                        <label for="phone_mobile">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>**</sup>{/if}</label>
-                        <input type="text" class="text form-control validate" name="phone_mobile" id="phone_mobile" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile) && $guestInformations.phone_mobile}{$guestInformations.phone_mobile}{/if}" />
-                    </div>
-                    {if isset($one_phone_at_least) && $one_phone_at_least}
-                        {assign var="atLeastOneExists" value=true}
-                        <p class="inline-infos required">** {l s='You must register at least one phone number.'}</p>
-                    {/if}
-                    <input type="hidden" name="alias" id="alias" value="{l s='My address'}"/>
-
-                    <div class="checkbox">
-                        <label for="invoice_address">
-                        <input type="checkbox" name="invoice_address" id="invoice_address"{if (isset($smarty.post.invoice_address) && $smarty.post.invoice_address) || (isset($guestInformations) && isset($guestInformations.invoice_address) && $guestInformations.invoice_address)} checked="checked"{/if} autocomplete="off"/>
-                        {l s='Please use another address for invoice'}</label>
-                    </div>
-
-                    <div id="opc_invoice_address" class="is_customer_param">
-                        {assign var=stateExist value=false}
-                        {assign var=postCodeExist value=false}
-                        {assign var='dniExist' value=false}
-                        <h3 class="page-subheading top-indent">{l s='Invoice address'}</h3>
-                        {foreach from=$inv_all_fields item=field_name}
-                        {if $field_name eq "company"}
-                        <div class="form-group">
-                            <label for="company_invoice">{l s='Company'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="text form-control validate" id="company_invoice" name="company_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.company_invoice) && $guestInformations.company_invoice}{$guestInformations.company_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "vat_number"}
-                        <div id="vat_number_block_invoice" class="is_customer_param" style="display:none;">
-                            <div class="form-group">
-                                <label for="vat_number_invoice">{l s='VAT number'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                                <input type="text" class="form-control" id="vat_number_invoice" name="vat_number_invoice" value="{if isset($guestInformations) && isset($guestInformations.vat_number_invoice) && $guestInformations.vat_number_invoice}{$guestInformations.vat_number_invoice}{/if}" />
-                            </div>
-                        </div>
-                        {elseif $field_name eq "dni"}
-                        {assign var='dniExist' value=true}
-                        <div class="required form-group dni_invoice">
-                            <label for="dni_invoice">{l s='Identification number'} <sup>*</sup></label>
-                            <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
-                            <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                        </div>
-                        {elseif $field_name eq "firstname"}
-                        <div class="required form-group">
-                            <label for="firstname_invoice">{l s='First name'} <sup>*</sup></label>
-                            <input type="text" class="form-control validate" id="firstname_invoice" name="firstname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.firstname_invoice) && $guestInformations.firstname_invoice}{$guestInformations.firstname_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "lastname"}
-                        <div class="required form-group">
-                            <label for="lastname_invoice">{l s='Last name'} <sup>*</sup></label>
-                            <input type="text" class="form-control validate" id="lastname_invoice" name="lastname_invoice" data-validate="isName" value="{if isset($guestInformations) && isset($guestInformations.lastname_invoice) && $guestInformations.lastname_invoice}{$guestInformations.lastname_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "address1"}
-                        <div class="required form-group">
-                            <label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
-                            <input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "address2"}
-                        <div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
-                            <label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "postcode"}
-                        {$postCodeExist = true}
-                        <div class="required postcode_invoice form-group">
-                            <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                            <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
-                        </div>
-                        {elseif $field_name eq "city"}
-                        <div class="required form-group">
-                            <label for="city_invoice">{l s='City'} <sup>*</sup></label>
-                            <input type="text" class="form-control validate" name="city_invoice" id="city_invoice" data-validate="isCityName" value="{if isset($guestInformations) && isset($guestInformations.city_invoice) && $guestInformations.city_invoice}{$guestInformations.city_invoice}{/if}" />
-                        </div>
-                        {elseif $field_name eq "country" || $field_name eq "Country:name"}
-                        <div class="required form-group">
-                            <label for="id_country_invoice">{l s='Country'} <sup>*</sup></label>
-                            <select name="id_country_invoice" id="id_country_invoice" class="form-control">
-                                <option value="">-</option>
-                                {foreach from=$countries item=v}
-                                <option value="{$v.id_country}"{if (isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice == $v.id_country) || (!isset($guestInformations) && $sl_country == $v.id_country)} selected="selected"{/if}>{$v.name|escape:'html':'UTF-8'}</option>
-                                {/foreach}
-                            </select>
-                        </div>
-                        {elseif $field_name eq "state" || $field_name eq 'State:name'}
-                        {$stateExist = true}
-                        <div class="required id_state_invoice form-group" style="display:none;">
-                            <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state_invoice" id="id_state_invoice" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </div>
-                        {/if}
-                        {/foreach}
-                        {if !$postCodeExist}
-                        <div class="required postcode_invoice form-group unvisible">
-                            <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
-                            <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
-                        </div>
-                        {/if}
-                        {if !$stateExist}
-                        <div class="required id_state_invoice form-group unvisible">
-                            <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
-                            <select name="id_state_invoice" id="id_state_invoice" class="form-control">
-                                <option value="">-</option>
-                            </select>
-                        </div>
-                        {/if}
-                        {if !$dniExist}
-                        <div class="required form-group dni_invoice">
-                            <label for="dni">{l s='Identification number'} <sup>*</sup></label>
-                            <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
-                            <span class="form_info">{l s='DNI / NIF / NIE'}</span>
-                        </div>
-                        {/if}
-                        <div class="form-group is_customer_param">
-                            <label for="other_invoice">{l s='Additional information'}</label>
-                            <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
-                        </div>
-                        {if isset($one_phone_at_least) && $one_phone_at_least}
-                            <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
-                        {/if}
-                        <div class="form-group is_customer_param">
-                            <label for="phone_invoice">{l s='Home phone'}</label>
-                            <input type="text" class="form-control validate" name="phone_invoice" id="phone_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_invoice) && $guestInformations.phone_invoice}{$guestInformations.phone_invoice}{/if}" />
-                        </div>
-                        <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
-                            <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
-                            <input type="text" class="form-control validate" name="phone_mobile_invoice" id="phone_mobile_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile_invoice) && $guestInformations.phone_mobile_invoice}{$guestInformations.phone_mobile_invoice}{/if}" />
-                        </div>
-                        <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
-                    </div>
-                    {$HOOK_CREATE_ACCOUNT_FORM}
-                    <div class="submit opc-add-save clearfix">
-                        <p class="required opc-required pull-right">
-                            <sup>*</sup>{l s='Required field'}
-                        </p>
-                        <button type="submit" name="submitAccount" id="submitAccount" class="btn btn-default button button-medium"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
-
-                    </div>
-                    <div style="display: none;" id="opc_account_saved" class="alert alert-success">
-                        {l s='Account information saved successfully'}
-                    </div>
-                <!-- END Account -->
+                  </select>
                 </div>
+              {elseif $field_name eq "state" || $field_name eq 'State:name'}
+                {$stateExist = true}
+                <div class="required id_state_invoice form-group" style="display:none;">
+                  <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                  <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                    <option value="">-</option>
+                  </select>
+                </div>
+              {/if}
+            {/foreach}
+            {if !$postCodeExist}
+              <div class="required postcode_invoice form-group unvisible">
+                <label for="postcode_invoice">{l s='Zip/Postal Code'} <sup>*</sup></label>
+                <input type="text" class="form-control validate" name="postcode_invoice" id="postcode_invoice" data-validate="isPostCode" value="{if isset($guestInformations) && isset($guestInformations.postcode_invoice) && $guestInformations.postcode_invoice}{$guestInformations.postcode_invoice}{/if}"/>
+              </div>
+            {/if}
+            {if !$stateExist}
+              <div class="required id_state_invoice form-group unvisible">
+                <label for="id_state_invoice">{l s='State'} <sup>*</sup></label>
+                <select name="id_state_invoice" id="id_state_invoice" class="form-control">
+                  <option value="">-</option>
+                </select>
+              </div>
+            {/if}
+            {if !$dniExist}
+              <div class="required form-group dni_invoice">
+                <label for="dni">{l s='Identification number'} <sup>*</sup></label>
+                <input type="text" class="text form-control validate" name="dni_invoice" id="dni_invoice" data-validate="isDniLite" value="{if isset($guestInformations) && isset($guestInformations.dni_invoice) && $guestInformations.dni_invoice}{$guestInformations.dni_invoice}{/if}" />
+                <span class="form_info">{l s='DNI / NIF / NIE'}</span>
+              </div>
+            {/if}
+            <div class="form-group is_customer_param">
+              <label for="other_invoice">{l s='Additional information'}</label>
+              <textarea class="form-control" name="other_invoice" id="other_invoice" cols="26" rows="3"></textarea>
             </div>
-        </fieldset>
-    </form>
+            {if isset($one_phone_at_least) && $one_phone_at_least}
+              <p class="inline-infos required is_customer_param">{l s='You must register at least one phone number.'}</p>
+            {/if}
+            <div class="form-group is_customer_param">
+              <label for="phone_invoice">{l s='Home phone'}</label>
+              <input type="text" class="form-control validate" name="phone_invoice" id="phone_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_invoice) && $guestInformations.phone_invoice}{$guestInformations.phone_invoice}{/if}" />
+            </div>
+            <div class="{if isset($one_phone_at_least) && $one_phone_at_least}required {/if}form-group">
+              <label for="phone_mobile_invoice">{l s='Mobile phone'}{if isset($one_phone_at_least) && $one_phone_at_least} <sup>*</sup>{/if}</label>
+              <input type="text" class="form-control validate" name="phone_mobile_invoice" id="phone_mobile_invoice" data-validate="isPhoneNumber" value="{if isset($guestInformations) && isset($guestInformations.phone_mobile_invoice) && $guestInformations.phone_mobile_invoice}{$guestInformations.phone_mobile_invoice}{/if}" />
+            </div>
+            <input type="hidden" name="alias_invoice" id="alias_invoice" value="{l s='My Invoice address'}" />
+          </div>
+          {$HOOK_CREATE_ACCOUNT_FORM}
+          <div class="submit opc-add-save clearfix">
+            <p class="required opc-required pull-right">
+              <sup>*</sup>{l s='Required field'}
+            </p>
+            <button type="submit" name="submitAccount" id="submitAccount" class="btn btn-default button button-medium"><span>{l s='Save'}<i class="icon-chevron-right right"></i></span></button>
+
+          </div>
+          <div style="display: none;" id="opc_account_saved" class="alert alert-success">
+            {l s='Account information saved successfully'}
+          </div>
+          <!-- END Account -->
+        </div>
+      </div>
+    </fieldset>
+  </form>
 </div>
 {strip}
-{if isset($guestInformations) && isset($guestInformations.id_state) && $guestInformations.id_state}
+  {if isset($guestInformations) && isset($guestInformations.id_state) && $guestInformations.id_state}
     {addJsDef idSelectedState=$guestInformations.id_state|intval}
-{else}
+  {else}
     {addJsDef idSelectedState=false}
-{/if}
-{if isset($guestInformations) && isset($guestInformations.id_state_invoice) && $guestInformations.id_state_invoice}
+  {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_state_invoice) && $guestInformations.id_state_invoice}
     {addJsDef idSelectedStateInvoice=$guestInformations.id_state_invoice|intval}
-{else}
+  {else}
     {addJsDef idSelectedStateInvoice=false}
-{/if}
-{if isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country}
+  {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_country) && $guestInformations.id_country}
     {addJsDef idSelectedCountry=$guestInformations.id_country|intval}
-{else}
+  {else}
     {addJsDef idSelectedCountry=false}
-{/if}
-{if isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice}
+  {/if}
+  {if isset($guestInformations) && isset($guestInformations.id_country_invoice) && $guestInformations.id_country_invoice}
     {addJsDef idSelectedCountryInvoice=$guestInformations.id_country_invoice|intval}
-{else}
+  {else}
     {addJsDef idSelectedCountryInvoice=false}
-{/if}
-{if isset($countries)}
+  {/if}
+  {if isset($countries)}
     {addJsDef countries=$countries}
-{/if}
-{if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
+  {/if}
+  {if isset($vatnumber_ajax_call) && $vatnumber_ajax_call}
     {addJsDef vatnumber_ajax_call=$vatnumber_ajax_call}
-{/if}
+  {/if}
 {/strip}

--- a/themes/community-theme-16/order-opc.tpl
+++ b/themes/community-theme-16/order-opc.tpl
@@ -24,90 +24,90 @@
 *}
 
 {if $opc}
-    {assign var="back_order_page" value="order-opc.php"}
-    {else}
-    {assign var="back_order_page" value="order.php"}
+  {assign var="back_order_page" value="order-opc.php"}
+{else}
+  {assign var="back_order_page" value="order.php"}
 {/if}
 
 {if $PS_CATALOG_MODE}
-    {capture name=path}{l s='Your shopping cart'}{/capture}
-    <h2 id="cart_title">{l s='Your shopping cart'}</h2>
-    <p class="alert alert-warning">{l s='Your new order was not accepted.'}</p>
+  {capture name=path}{l s='Your shopping cart'}{/capture}
+  <h2 id="cart_title">{l s='Your shopping cart'}</h2>
+  <p class="alert alert-warning">{l s='Your new order was not accepted.'}</p>
 {else}
-    {if $productNumber}
-        <!-- Shopping Cart -->
+  {if $productNumber}
+    <!-- Shopping Cart -->
 
-        {include file="$tpl_dir./shopping-cart.tpl"}
-        <!-- End Shopping Cart -->
-        {if $is_logged AND !$is_guest}
-            {include file="$tpl_dir./order-address.tpl"}
-        {else}
-            <!-- Create account / Guest account / Login block -->
-            {include file="$tpl_dir./order-opc-new-account.tpl"}
-            <!-- END Create account / Guest account / Login block -->
-        {/if}
-        <!-- Carrier -->
-        {include file="$tpl_dir./order-carrier.tpl"}
-        <!-- END Carrier -->
-
-        <!-- Payment -->
-        {include file="$tpl_dir./order-payment.tpl"}
-        <!-- END Payment -->
+    {include file="$tpl_dir./shopping-cart.tpl"}
+    <!-- End Shopping Cart -->
+    {if $is_logged AND !$is_guest}
+      {include file="$tpl_dir./order-address.tpl"}
     {else}
-        {capture name=path}{l s='Your shopping cart'}{/capture}
-        <h2 class="page-heading">{l s='Your shopping cart'}</h2>
-        {include file="$tpl_dir./errors.tpl"}
-        <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+      <!-- Create account / Guest account / Login block -->
+      {include file="$tpl_dir./order-opc-new-account.tpl"}
+      <!-- END Create account / Guest account / Login block -->
     {/if}
-{strip}
-{addJsDef imgDir=$img_dir}
-{addJsDef authenticationUrl=$link->getPageLink("authentication", true)|escape:'quotes':'UTF-8'}
-{addJsDef orderOpcUrl=$link->getPageLink("order-opc", true)|escape:'quotes':'UTF-8'}
-{addJsDef historyUrl=$link->getPageLink("history", true)|escape:'quotes':'UTF-8'}
-{addJsDef guestTrackingUrl=$link->getPageLink("guest-tracking", true)|escape:'quotes':'UTF-8'}
-{addJsDef addressUrl=$link->getPageLink("address", true, NULL, "back={$back_order_page}")|escape:'quotes':'UTF-8'}
-{addJsDef orderProcess='order-opc'}
-{addJsDef guestCheckoutEnabled=$PS_GUEST_CHECKOUT_ENABLED|intval}
-{addJsDef displayPrice=$priceDisplay}
-{addJsDef taxEnabled=$use_taxes}
-{addJsDef conditionEnabled=$conditions|intval}
-{addJsDef vat_management=$vat_management|intval}
-{addJsDef errorCarrier=$errorCarrier|@addcslashes:'\''}
-{addJsDef errorTOS=$errorTOS|@addcslashes:'\''}
-{addJsDef checkedCarrier=$checked|intval}
-{addJsDef addresses=array()}
-{addJsDef isVirtualCart=$isVirtualCart|intval}
-{addJsDef isPaymentStep=$isPaymentStep|intval}
-{addJsDefL name=txtWithTax}{l s='(tax incl.)' js=1}{/addJsDefL}
-{addJsDefL name=txtWithoutTax}{l s='(tax excl.)' js=1}{/addJsDefL}
-{addJsDefL name=txtHasBeenSelected}{l s='has been selected' js=1}{/addJsDefL}
-{addJsDefL name=txtNoCarrierIsSelected}{l s='No carrier has been selected' js=1}{/addJsDefL}
-{addJsDefL name=txtNoCarrierIsNeeded}{l s='No carrier is needed for this order' js=1}{/addJsDefL}
-{addJsDefL name=txtConditionsIsNotNeeded}{l s='You do not need to accept the Terms of Service for this order.' js=1}{/addJsDefL}
-{addJsDefL name=txtTOSIsAccepted}{l s='The service terms have been accepted' js=1}{/addJsDefL}
-{addJsDefL name=txtTOSIsNotAccepted}{l s='The service terms have not been accepted' js=1}{/addJsDefL}
-{addJsDefL name=txtThereis}{l s='There is' js=1}{/addJsDefL}
-{addJsDefL name=txtErrors}{l s='Error(s)' js=1}{/addJsDefL}
-{addJsDefL name=txtDeliveryAddress}{l s='Delivery address' js=1}{/addJsDefL}
-{addJsDefL name=txtInvoiceAddress}{l s='Invoice address' js=1}{/addJsDefL}
-{addJsDefL name=txtModifyMyAddress}{l s='Modify my address' js=1}{/addJsDefL}
-{addJsDefL name=txtInstantCheckout}{l s='Instant checkout' js=1}{/addJsDefL}
-{addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address.' js=1}{/addJsDefL}
-{addJsDefL name=txtFree}{l s='Free' js=1}{/addJsDefL}
+    <!-- Carrier -->
+    {include file="$tpl_dir./order-carrier.tpl"}
+    <!-- END Carrier -->
 
-{capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
-{capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
-{addJsDef addressUrl=$smarty.capture.addressUrl}
-{capture}{'&multi-shipping=1'|urlencode}{/capture}
-{addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
-{capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
-{addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
-{addJsDef opc=$opc|boolval}
-{capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
-{addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
-{addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
-{addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
-{/strip}
+    <!-- Payment -->
+    {include file="$tpl_dir./order-payment.tpl"}
+    <!-- END Payment -->
+  {else}
+    {capture name=path}{l s='Your shopping cart'}{/capture}
+    <h2 class="page-heading">{l s='Your shopping cart'}</h2>
+    {include file="$tpl_dir./errors.tpl"}
+    <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+  {/if}
+  {strip}
+    {addJsDef imgDir=$img_dir}
+    {addJsDef authenticationUrl=$link->getPageLink("authentication", true)|escape:'quotes':'UTF-8'}
+    {addJsDef orderOpcUrl=$link->getPageLink("order-opc", true)|escape:'quotes':'UTF-8'}
+    {addJsDef historyUrl=$link->getPageLink("history", true)|escape:'quotes':'UTF-8'}
+    {addJsDef guestTrackingUrl=$link->getPageLink("guest-tracking", true)|escape:'quotes':'UTF-8'}
+    {addJsDef addressUrl=$link->getPageLink("address", true, NULL, "back={$back_order_page}")|escape:'quotes':'UTF-8'}
+    {addJsDef orderProcess='order-opc'}
+    {addJsDef guestCheckoutEnabled=$PS_GUEST_CHECKOUT_ENABLED|intval}
+    {addJsDef displayPrice=$priceDisplay}
+    {addJsDef taxEnabled=$use_taxes}
+    {addJsDef conditionEnabled=$conditions|intval}
+    {addJsDef vat_management=$vat_management|intval}
+    {addJsDef errorCarrier=$errorCarrier|@addcslashes:'\''}
+    {addJsDef errorTOS=$errorTOS|@addcslashes:'\''}
+    {addJsDef checkedCarrier=$checked|intval}
+    {addJsDef addresses=array()}
+    {addJsDef isVirtualCart=$isVirtualCart|intval}
+    {addJsDef isPaymentStep=$isPaymentStep|intval}
+    {addJsDefL name=txtWithTax}{l s='(tax incl.)' js=1}{/addJsDefL}
+    {addJsDefL name=txtWithoutTax}{l s='(tax excl.)' js=1}{/addJsDefL}
+    {addJsDefL name=txtHasBeenSelected}{l s='has been selected' js=1}{/addJsDefL}
+    {addJsDefL name=txtNoCarrierIsSelected}{l s='No carrier has been selected' js=1}{/addJsDefL}
+    {addJsDefL name=txtNoCarrierIsNeeded}{l s='No carrier is needed for this order' js=1}{/addJsDefL}
+    {addJsDefL name=txtConditionsIsNotNeeded}{l s='You do not need to accept the Terms of Service for this order.' js=1}{/addJsDefL}
+    {addJsDefL name=txtTOSIsAccepted}{l s='The service terms have been accepted' js=1}{/addJsDefL}
+    {addJsDefL name=txtTOSIsNotAccepted}{l s='The service terms have not been accepted' js=1}{/addJsDefL}
+    {addJsDefL name=txtThereis}{l s='There is' js=1}{/addJsDefL}
+    {addJsDefL name=txtErrors}{l s='Error(s)' js=1}{/addJsDefL}
+    {addJsDefL name=txtDeliveryAddress}{l s='Delivery address' js=1}{/addJsDefL}
+    {addJsDefL name=txtInvoiceAddress}{l s='Invoice address' js=1}{/addJsDefL}
+    {addJsDefL name=txtModifyMyAddress}{l s='Modify my address' js=1}{/addJsDefL}
+    {addJsDefL name=txtInstantCheckout}{l s='Instant checkout' js=1}{/addJsDefL}
+    {addJsDefL name=txtSelectAnAddressFirst}{l s='Please start by selecting an address.' js=1}{/addJsDefL}
+    {addJsDefL name=txtFree}{l s='Free' js=1}{/addJsDefL}
+
+    {capture}{if $back}&mod={$back|urlencode}{/if}{/capture}
+    {capture name=addressUrl}{$link->getPageLink('address', true, NULL, 'back='|cat:$back_order_page|cat:'?step=1'|cat:$smarty.capture.default)|escape:'quotes':'UTF-8'}{/capture}
+    {addJsDef addressUrl=$smarty.capture.addressUrl}
+    {capture}{'&multi-shipping=1'|urlencode}{/capture}
+    {addJsDef addressMultishippingUrl=$smarty.capture.addressUrl|cat:$smarty.capture.default}
+    {capture name=addressUrlAdd}{$smarty.capture.addressUrl|cat:'&id_address='}{/capture}
+    {addJsDef addressUrlAdd=$smarty.capture.addressUrlAdd}
+    {addJsDef opc=$opc|boolval}
+    {capture}<h3 class="page-subheading">{l s='Your billing address' js=1}</h3>{/capture}
+    {addJsDefL name=titleInvoice}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+    {capture}<h3 class="page-subheading">{l s='Your delivery address' js=1}</h3>{/capture}
+    {addJsDefL name=titleDelivery}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+    {capture}<a class="button button-small btn btn-default" href="{$smarty.capture.addressUrlAdd}" title="{l s='Update' js=1}"><span>{l s='Update' js=1}<i class="icon-chevron-right right"></i></span></a>{/capture}
+    {addJsDefL name=liUpdate}{$smarty.capture.default|@addcslashes:'\''}{/addJsDefL}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/order-payment-advanced.tpl
+++ b/themes/community-theme-16/order-payment-advanced.tpl
@@ -23,24 +23,24 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !isset($addresses_style)}
-    {$addresses_style.company = 'address_company'}
-    {$addresses_style.vat_number = 'address_company'}
-    {$addresses_style.firstname = 'address_name'}
-    {$addresses_style.lastname = 'address_name'}
-    {$addresses_style.address1 = 'address_address1'}
-    {$addresses_style.address2 = 'address_address2'}
-    {$addresses_style.city = 'address_city'}
-    {$addresses_style.country = 'address_country'}
-    {$addresses_style.phone = 'address_phone'}
-    {$addresses_style.phone_mobile = 'address_phone_mobile'}
-    {$addresses_style.alias = 'address_title'}
+  {$addresses_style.company = 'address_company'}
+  {$addresses_style.vat_number = 'address_company'}
+  {$addresses_style.firstname = 'address_name'}
+  {$addresses_style.lastname = 'address_name'}
+  {$addresses_style.address1 = 'address_address1'}
+  {$addresses_style.address2 = 'address_address2'}
+  {$addresses_style.city = 'address_city'}
+  {$addresses_style.country = 'address_country'}
+  {$addresses_style.phone = 'address_phone'}
+  {$addresses_style.phone_mobile = 'address_phone_mobile'}
+  {$addresses_style.alias = 'address_title'}
 {/if}
 {assign var='have_non_virtual_products' value=false}
 {foreach $products as $product}
-    {if $product.is_virtual == 0}
-        {assign var='have_non_virtual_products' value=true}
-        {break}
-    {/if}
+  {if $product.is_virtual == 0}
+    {assign var='have_non_virtual_products' value=true}
+    {break}
+  {/if}
 {/foreach}
 
 {addJsDefL name=txtProduct}{l s='Product' js=1}{/addJsDefL}
@@ -48,97 +48,97 @@
 {capture name=path}{l s='Your shopping cart'}{/capture}
 
 {if $productNumber == 0}
-<p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+  <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
 {elseif $PS_CATALOG_MODE}
-<p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
+  <p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
 {else}
-    <p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
-    <h2>{l s='Payment Options'}</h2>
-    <!-- HOOK_ADVANCED_PAYMENT -->
-    <div id="HOOK_ADVANCED_PAYMENT">
-        <div class="row">
-        <!-- Should get a collection of "PaymentOption" object -->
-        {assign var='adv_payment_empty' value=true}
-        {foreach from=$HOOK_ADVANCED_PAYMENT item=pay_option key=key}
-            {if $pay_option}
-                {assign var='adv_payment_empty' value=false}
-            {/if}
-        {/foreach}
-        {if $HOOK_ADVANCED_PAYMENT && !$adv_payment_empty}
-            {foreach $HOOK_ADVANCED_PAYMENT as $advanced_payment_opt_list}
-                {foreach $advanced_payment_opt_list as $paymentOption}
-                    <div class="col-xs-6 col-md-6">
-                        <p class="payment_module pointer-box">
-                            <a class="payment_module_adv">
-                                <img class="payment_option_logo" src="{$paymentOption->getLogo()}"/>
-                                <span class="payment_option_cta">
-                                    {$paymentOption->getCallToActionText()}
-                                </span>
-                                <span class="pull-right payment_option_selected">
-                                    <i class="icon-check"></i>
-                                </span>
-                            </a>
-
-                        </p>
-                        <div class="payment_option_form">
-                            {if $paymentOption->getForm()}
-                                {$paymentOption->getForm()}
-                            {else}
-                                <form method="{if $paymentOption->getMethod()}{$paymentOption->getMethod()}{else}POST{/if}" action="{$paymentOption->getAction()}">
-                                    {if $paymentOption->getInputs()}
-                                        {foreach from=$paymentOption->getInputs() item=value key=name}
-                                            <input type="hidden" name="{$name}" value="{$value}">
-                                        {/foreach}
-                                    {/if}
-                                </form>
-                            {/if}
-                        </div>
-                    </div>
-                {/foreach}
-            {/foreach}
-        </div>
-        {else}
-        <div class="col-xs-12 col-md-12">
-            <p class="alert alert-warning ">{l s='Unable to find any available payment option for your cart. Please contact us if the problem persists'}</p>
-        </div>
+  <p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
+  <h2>{l s='Payment Options'}</h2>
+  <!-- HOOK_ADVANCED_PAYMENT -->
+  <div id="HOOK_ADVANCED_PAYMENT">
+    <div class="row">
+      <!-- Should get a collection of "PaymentOption" object -->
+      {assign var='adv_payment_empty' value=true}
+      {foreach from=$HOOK_ADVANCED_PAYMENT item=pay_option key=key}
+        {if $pay_option}
+          {assign var='adv_payment_empty' value=false}
         {/if}
-    </div>
-    <!-- end HOOK_ADVANCED_PAYMENT -->
+      {/foreach}
+      {if $HOOK_ADVANCED_PAYMENT && !$adv_payment_empty}
+      {foreach $HOOK_ADVANCED_PAYMENT as $advanced_payment_opt_list}
+        {foreach $advanced_payment_opt_list as $paymentOption}
+          <div class="col-xs-6 col-md-6">
+            <p class="payment_module pointer-box">
+              <a class="payment_module_adv">
+                <img class="payment_option_logo" src="{$paymentOption->getLogo()}"/>
+                  <span class="payment_option_cta">
+                    {$paymentOption->getCallToActionText()}
+                  </span>
+                  <span class="pull-right payment_option_selected">
+                    <i class="icon-check"></i>
+                  </span>
+              </a>
 
-    {if $opc}
-        <!-- Carrier -->
-        {include file="$tpl_dir./order-carrier-advanced.tpl"}
-        <!-- END Carrier -->
-    {/if}
-
-    {if $is_logged AND !$is_guest}
-        {include file="$tpl_dir./order-address-advanced.tpl"}
-    {elseif $opc}
-        <!-- Create account / Guest account / Login block -->
-        {include file="$tpl_dir./order-opc-new-account-advanced.tpl"}
-        <!-- END Create account / Guest account / Login block -->
-    {/if}
-
-    <!-- TNC -->
-    {if $conditions AND $cms_id}
-        {if $override_tos_display }
-            {$override_tos_display}
-        {else}
-            <div class="row">
-                <div class="col-xs-12 col-md-12">
-                    <h2>{l s='Terms and Conditions'}</h2>
-                    <div class="box">
-                        <p class="checkbox">
-                            <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
-                            <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
-                            <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
-                        </p>
-                    </div>
-                </div>
+            </p>
+            <div class="payment_option_form">
+              {if $paymentOption->getForm()}
+                {$paymentOption->getForm()}
+              {else}
+                <form method="{if $paymentOption->getMethod()}{$paymentOption->getMethod()}{else}POST{/if}" action="{$paymentOption->getAction()}">
+                  {if $paymentOption->getInputs()}
+                    {foreach from=$paymentOption->getInputs() item=value key=name}
+                      <input type="hidden" name="{$name}" value="{$value}">
+                    {/foreach}
+                  {/if}
+                </form>
+              {/if}
             </div>
-        {/if}
+          </div>
+        {/foreach}
+      {/foreach}
+    </div>
+    {else}
+    <div class="col-xs-12 col-md-12">
+      <p class="alert alert-warning ">{l s='Unable to find any available payment option for your cart. Please contact us if the problem persists'}</p>
+    </div>
     {/if}
-    <!-- end TNC -->
+  </div>
+  <!-- end HOOK_ADVANCED_PAYMENT -->
 
-    {include file="$tpl_dir./shopping-cart-advanced.tpl"}
+  {if $opc}
+    <!-- Carrier -->
+    {include file="$tpl_dir./order-carrier-advanced.tpl"}
+    <!-- END Carrier -->
+  {/if}
+
+  {if $is_logged AND !$is_guest}
+    {include file="$tpl_dir./order-address-advanced.tpl"}
+  {elseif $opc}
+    <!-- Create account / Guest account / Login block -->
+    {include file="$tpl_dir./order-opc-new-account-advanced.tpl"}
+    <!-- END Create account / Guest account / Login block -->
+  {/if}
+
+  <!-- TNC -->
+  {if $conditions AND $cms_id}
+    {if $override_tos_display }
+      {$override_tos_display}
+    {else}
+      <div class="row">
+        <div class="col-xs-12 col-md-12">
+          <h2>{l s='Terms and Conditions'}</h2>
+          <div class="box">
+            <p class="checkbox">
+              <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
+              <label for="cgv">{l s='I agree to the terms of service and will adhere to them unconditionally.'}</label>
+              <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)'}</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    {/if}
+  {/if}
+  <!-- end TNC -->
+
+  {include file="$tpl_dir./shopping-cart-advanced.tpl"}
 {/if}

--- a/themes/community-theme-16/order-payment-classic.tpl
+++ b/themes/community-theme-16/order-payment-classic.tpl
@@ -23,296 +23,296 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <div class="paiement_block">
-    <div id="HOOK_TOP_PAYMENT">{$HOOK_TOP_PAYMENT}</div>
-    {if $HOOK_PAYMENT}
-        {if !$opc}
-            <div id="order-detail-content" class="table_block table-responsive">
-                <table id="cart_summary" class="table table-bordered">
-                    <thead>
-                    <tr>
-                        <th class="cart_product first_item">{l s='Product'}</th>
-                        <th class="cart_description item">{l s='Description'}</th>
-                        {if $PS_STOCK_MANAGEMENT}
-                            <th class="cart_availability item text-center">{l s='Availability'}</th>
-                        {/if}
-                        <th class="cart_unit item text-right">{l s='Unit price'}</th>
-                        <th class="cart_quantity item text-center">{l s='Qty'}</th>
-                        <th class="cart_total last_item text-right">{l s='Total'}</th>
-                    </tr>
-                    </thead>
-                    <tfoot>
-                    {if $use_taxes}
-                        {if $priceDisplay}
-                            <tr class="cart_total_price">
-                                <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
-                                <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
-                            </tr>
-                        {else}
-                            <tr class="cart_total_price">
-                                <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
-                                <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
-                            </tr>
-                        {/if}
-                    {else}
-                        <tr class="cart_total_price">
-                            <td colspan="4" class="text-right">{l s='Total products'}</td>
-                            <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
-                        </tr>
-                    {/if}
-                    <tr class="cart_total_voucher" {if $total_wrapping == 0}style="display:none"{/if}>
-                        <td colspan="4" class="text-right">
-                            {if $use_taxes}
-                                {if $priceDisplay}
-                                    {if $display_tax_label}{l s='Total gift wrapping (tax excl.):'}{else}{l s='Total gift wrapping cost:'}{/if}
-                                {else}
-                                    {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift wrapping cost:'}{/if}
-                                {/if}
-                            {else}
-                                {l s='Total gift wrapping cost:'}
-                            {/if}
-                        </td>
-                        <td colspan="2" class="price-discount price" id="total_wrapping">
-                            {if $use_taxes}
-                                {if $priceDisplay}
-                                    {displayPrice price=$total_wrapping_tax_exc}
-                                {else}
-                                    {displayPrice price=$total_wrapping}
-                                {/if}
-                            {else}
-                                {displayPrice price=$total_wrapping_tax_exc}
-                            {/if}
-                        </td>
-                    </tr>
-                    {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
-                        <tr class="cart_total_delivery">
-                            <td colspan="4" class="text-right">{l s='Total shipping'}</td>
-                            <td colspan="2" class="price" id="total_shipping">{l s='Free Shipping!'}</td>
-                        </tr>
-                    {else}
-                        {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
-                            {if $priceDisplay}
-                                <tr class="cart_total_delivery" {if $shippingCost <= 0} style="display:none"{/if}>
-                                    <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
-                                    <td colspan="2" class="price" id="total_shipping">{displayPrice price=$shippingCostTaxExc}</td>
-                                </tr>
-                            {else}
-                                <tr class="cart_total_delivery"{if $shippingCost <= 0} style="display:none"{/if}>
-                                    <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
-                                    <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$shippingCost}</td>
-                                </tr>
-                            {/if}
-                        {else}
-                            <tr class="cart_total_delivery"{if $shippingCost <= 0} style="display:none"{/if}>
-                                <td colspan="4" class="text-right">{l s='Total shipping'}</td>
-                                <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$shippingCostTaxExc}</td>
-                            </tr>
-                        {/if}
-                    {/if}
-                    <tr class="cart_total_voucher" {if $total_discounts == 0}style="display:none"{/if}>
-                        <td colspan="4" class="text-right">
-                            {if $use_taxes}
-                                {if $priceDisplay}
-                                    {if $display_tax_label && $show_taxes}{l s='Total vouchers (tax excl.)'}{else}{l s='Total vouchers'}{/if}
-                                {else}
-                                    {if $display_tax_label && $show_taxes}{l s='Total vouchers (tax incl.)'}{else}{l s='Total vouchers'}{/if}
-                                {/if}
-                            {else}
-                                {l s='Total vouchers'}
-                            {/if}
-                        </td>
-                        <td colspan="2" class="price-discount price" id="total_discount">
-                            {if $use_taxes}
-                                {if $priceDisplay}
-                                    {displayPrice price=$total_discounts_tax_exc*-1}
-                                {else}
-                                    {displayPrice price=$total_discounts*-1}
-                                {/if}
-                            {else}
-                                {displayPrice price=$total_discounts_tax_exc*-1}
-                            {/if}
-                        </td>
-                    </tr>
-                    {if $use_taxes}
-                        {if $total_tax != 0 && $show_taxes}
-                            {if $priceDisplay != 0}
-                                <tr class="cart_total_price">
-                                    <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
-                                    <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
-                                </tr>
-                            {/if}
-                            <tr class="cart_total_tax">
-                                <td colspan="4" class="text-right">{l s='Tax'}</td>
-                                <td colspan="2" class="price" id="total_tax" >{displayPrice price=$total_tax}</td>
-                            </tr>
-                        {/if}
-                        <tr class="cart_total_price">
-                            <td colspan="4" class="total_price_container text-right"><span>{l s='Total'}</span></td>
-                            <td colspan="2" class="price" id="total_price_container">
-                                <span id="total_price" data-selenium-total-price="{$total_price}">{displayPrice price=$total_price}</span>
-                            </td>
-                        </tr>
-                    {else}
-                        <tr class="cart_total_price">
-                            {if $voucherAllowed}
-                                <td colspan="2" id="cart_voucher" class="cart_voucher">
-                                    <div id="cart_voucher" class="table_block">
-                                        {if $voucherAllowed}
-                                            <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                                                <fieldset>
-                                                    <h4>{l s='Vouchers'}</h4>
-                                                    <input type="text" id="discount_name" class="form-control" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                                    <input type="hidden" name="submitDiscount" />
-                                                    <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='ok'}</span></button>
-                                                    {if $displayVouchers}
-                                                        <p id="title" class="title_offers">{l s='Take advantage of our offers:'}</p>
-                                                        <div id="display_cart_vouchers">
-                                                            {foreach from=$displayVouchers item=voucher}
-                                                                <span onclick="$('#discount_name').val('{$voucher.name}');return false;" class="voucher_name">{$voucher.name}</span> - {$voucher.description} <br />
-                                                            {/foreach}
-                                                        </div>
-                                                    {/if}
-                                                </fieldset>
-                                            </form>
-                                        {/if}
-                                    </div>
-                                </td>
-                            {/if}
-                            <td colspan="{if !$voucherAllowed}4{else}2{/if}" class="text-right total_price_container">
-                                <span>{l s='Total'}</span>
-                            </td>
-                            <td colspan="2" class="price total_price_container" id="total_price_container">
-                                <span id="total_price" data-selenium-total-price="{$total_price_without_tax}">{displayPrice price=$total_price_without_tax}</span>
-                            </td>
-                        </tr>
-                    {/if}
-                    </tfoot>
-
-                    <tbody>
-                    {foreach from=$products item=product name=productLoop}
-                        {assign var='productId' value=$product.id_product}
-                        {assign var='productAttributeId' value=$product.id_product_attribute}
-                        {assign var='quantityDisplayed' value=0}
-                        {assign var='cannotModify' value=1}
-                        {assign var='odd' value=$product@iteration%2}
-                        {assign var='noDeleteButton' value=1}
-
-                        {* Display the product line *}
-                        {include file="$tpl_dir./shopping-cart-product-line.tpl"}
-
-                        {* Then the customized datas ones*}
-                        {if isset($customizedDatas.$productId.$productAttributeId)}
-                            {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization'}
-                                <tr id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}" class="alternate_item cart_item">
-                                    <td colspan="4">
-                                        {foreach from=$customization.datas key='type' item='datas'}
-                                            {if $type == $CUSTOMIZE_FILE}
-                                                <div class="customizationUploaded">
-                                                    <ul class="customizationUploaded">
-                                                        {foreach from=$datas item='picture'}
-                                                            <li>
-                                                                <img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" />
-                                                            </li>
-                                                        {/foreach}
-                                                    </ul>
-                                                </div>
-                                            {elseif $type == $CUSTOMIZE_TEXTFIELD}
-                                                <ul class="typedText">
-                                                    {foreach from=$datas item='textField' name='typedText'}
-                                                        <li>
-                                                            {if $textField.name}
-                                                                {l s='%s:' sprintf=$textField.name}
-                                                            {else}
-                                                                {l s='Text #%s:' sprintf=$smarty.foreach.typedText.index+1}
-                                                            {/if}
-                                                            {$textField.value}
-                                                        </li>
-                                                    {/foreach}
-                                                </ul>
-                                            {/if}
-                                        {/foreach}
-                                    </td>
-                                    <td class="cart_quantity text-center">
-                                        {$customization.quantity}
-                                    </td>
-                                    <td class="cart_total"></td>
-                                </tr>
-                                {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
-                            {/foreach}
-                            {* If it exists also some uncustomized products *}
-                            {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl"}{/if}
-                        {/if}
-                    {/foreach}
-                    {assign var='last_was_odd' value=$product@iteration%2}
-                    {foreach $gift_products as $product}
-                        {assign var='productId' value=$product.id_product}
-                        {assign var='productAttributeId' value=$product.id_product_attribute}
-                        {assign var='quantityDisplayed' value=0}
-                        {assign var='odd' value=($product@iteration+$last_was_odd)%2}
-                        {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
-                        {assign var='cannotModify' value=1}
-                        {* Display the gift product line *}
-                        {include file="./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
-                    {/foreach}
-                    </tbody>
-
-                    {if count($discounts)}
-                        <tbody>
-                        {foreach from=$discounts item=discount name=discountLoop}
-                            {if (float)$discount.value_real == 0}
-                                {continue}
-                            {/if}
-                            <tr class="cart_discount {if $smarty.foreach.discountLoop.last}last_item{elseif $smarty.foreach.discountLoop.first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
-                                <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
-                                <td class="cart_discount_price">
-                                                    <span class="price-discount">
-                                                        {if $discount.value_real > 0}
-                                                            {if !$priceDisplay}
-                                                                {displayPrice price=$discount.value_real*-1}
-                                                            {else}
-                                                                {displayPrice price=$discount.value_tax_exc*-1}
-                                                            {/if}
-                                                        {/if}
-                                                    </span>
-                                </td>
-                                <td class="cart_discount_delete">1</td>
-                                <td class="cart_discount_price">
-                                                    <span class="price-discount">
-                                                        {if $discount.value_real > 0}
-                                                            {if !$priceDisplay}
-                                                                {displayPrice price=$discount.value_real*-1}
-                                                            {else}
-                                                                {displayPrice price=$discount.value_tax_exc*-1}
-                                                            {/if}
-                                                        {/if}
-                                                    </span>
-                                </td>
-                            </tr>
-                        {/foreach}
-                        </tbody>
-                    {/if}
-                </table>
-            </div> <!-- end order-detail-content -->
-        {/if}
-        {if $opc}
-            <div id="opc_payment_methods-content">
-        {/if}
-        <div id="HOOK_PAYMENT">
-            {$HOOK_PAYMENT}
-        </div>
-        {if $opc}
-            </div> <!-- end opc_payment_methods-content -->
-        {/if}
-    {else}
-        <p class="alert alert-warning">{l s='No payment modules have been installed.'}</p>
-    {/if}
+  <div id="HOOK_TOP_PAYMENT">{$HOOK_TOP_PAYMENT}</div>
+  {if $HOOK_PAYMENT}
     {if !$opc}
-    <p class="cart_navigation clearfix">
-        <a href="{$link->getPageLink('order', true, NULL, "step=2")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-            <i class="icon-chevron-left"></i>
-            {l s='Continue shopping'}
-        </a>
-    </p>
-    {else}
+      <div id="order-detail-content" class="table_block table-responsive">
+        <table id="cart_summary" class="table table-bordered">
+          <thead>
+          <tr>
+            <th class="cart_product first_item">{l s='Product'}</th>
+            <th class="cart_description item">{l s='Description'}</th>
+            {if $PS_STOCK_MANAGEMENT}
+              <th class="cart_availability item text-center">{l s='Availability'}</th>
+            {/if}
+            <th class="cart_unit item text-right">{l s='Unit price'}</th>
+            <th class="cart_quantity item text-center">{l s='Qty'}</th>
+            <th class="cart_total last_item text-right">{l s='Total'}</th>
+          </tr>
+          </thead>
+          <tfoot>
+          {if $use_taxes}
+            {if $priceDisplay}
+              <tr class="cart_total_price">
+                <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
+                <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+              </tr>
+            {else}
+              <tr class="cart_total_price">
+                <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
+                <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
+              </tr>
+            {/if}
+          {else}
+            <tr class="cart_total_price">
+              <td colspan="4" class="text-right">{l s='Total products'}</td>
+              <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+            </tr>
+          {/if}
+          <tr class="cart_total_voucher" {if $total_wrapping == 0}style="display:none"{/if}>
+            <td colspan="4" class="text-right">
+              {if $use_taxes}
+                {if $priceDisplay}
+                  {if $display_tax_label}{l s='Total gift wrapping (tax excl.):'}{else}{l s='Total gift wrapping cost:'}{/if}
+                {else}
+                  {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift wrapping cost:'}{/if}
+                {/if}
+              {else}
+                {l s='Total gift wrapping cost:'}
+              {/if}
+            </td>
+            <td colspan="2" class="price-discount price" id="total_wrapping">
+              {if $use_taxes}
+                {if $priceDisplay}
+                  {displayPrice price=$total_wrapping_tax_exc}
+                {else}
+                  {displayPrice price=$total_wrapping}
+                {/if}
+              {else}
+                {displayPrice price=$total_wrapping_tax_exc}
+              {/if}
+            </td>
+          </tr>
+          {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
+            <tr class="cart_total_delivery">
+              <td colspan="4" class="text-right">{l s='Total shipping'}</td>
+              <td colspan="2" class="price" id="total_shipping">{l s='Free Shipping!'}</td>
+            </tr>
+          {else}
+            {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+              {if $priceDisplay}
+                <tr class="cart_total_delivery" {if $shippingCost <= 0} style="display:none"{/if}>
+                  <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
+                  <td colspan="2" class="price" id="total_shipping">{displayPrice price=$shippingCostTaxExc}</td>
+                </tr>
+              {else}
+                <tr class="cart_total_delivery"{if $shippingCost <= 0} style="display:none"{/if}>
+                  <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
+                  <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$shippingCost}</td>
+                </tr>
+              {/if}
+            {else}
+              <tr class="cart_total_delivery"{if $shippingCost <= 0} style="display:none"{/if}>
+                <td colspan="4" class="text-right">{l s='Total shipping'}</td>
+                <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$shippingCostTaxExc}</td>
+              </tr>
+            {/if}
+          {/if}
+          <tr class="cart_total_voucher" {if $total_discounts == 0}style="display:none"{/if}>
+            <td colspan="4" class="text-right">
+              {if $use_taxes}
+                {if $priceDisplay}
+                  {if $display_tax_label && $show_taxes}{l s='Total vouchers (tax excl.)'}{else}{l s='Total vouchers'}{/if}
+                {else}
+                  {if $display_tax_label && $show_taxes}{l s='Total vouchers (tax incl.)'}{else}{l s='Total vouchers'}{/if}
+                {/if}
+              {else}
+                {l s='Total vouchers'}
+              {/if}
+            </td>
+            <td colspan="2" class="price-discount price" id="total_discount">
+              {if $use_taxes}
+                {if $priceDisplay}
+                  {displayPrice price=$total_discounts_tax_exc*-1}
+                {else}
+                  {displayPrice price=$total_discounts*-1}
+                {/if}
+              {else}
+                {displayPrice price=$total_discounts_tax_exc*-1}
+              {/if}
+            </td>
+          </tr>
+          {if $use_taxes}
+            {if $total_tax != 0 && $show_taxes}
+              {if $priceDisplay != 0}
+                <tr class="cart_total_price">
+                  <td colspan="4" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
+                  <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
+                </tr>
+              {/if}
+              <tr class="cart_total_tax">
+                <td colspan="4" class="text-right">{l s='Tax'}</td>
+                <td colspan="2" class="price" id="total_tax" >{displayPrice price=$total_tax}</td>
+              </tr>
+            {/if}
+            <tr class="cart_total_price">
+              <td colspan="4" class="total_price_container text-right"><span>{l s='Total'}</span></td>
+              <td colspan="2" class="price" id="total_price_container">
+                <span id="total_price" data-selenium-total-price="{$total_price}">{displayPrice price=$total_price}</span>
+              </td>
+            </tr>
+          {else}
+            <tr class="cart_total_price">
+              {if $voucherAllowed}
+                <td colspan="2" id="cart_voucher" class="cart_voucher">
+                  <div id="cart_voucher" class="table_block">
+                    {if $voucherAllowed}
+                      <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                        <fieldset>
+                          <h4>{l s='Vouchers'}</h4>
+                          <input type="text" id="discount_name" class="form-control" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                          <input type="hidden" name="submitDiscount" />
+                          <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='ok'}</span></button>
+                          {if $displayVouchers}
+                            <p id="title" class="title_offers">{l s='Take advantage of our offers:'}</p>
+                            <div id="display_cart_vouchers">
+                              {foreach from=$displayVouchers item=voucher}
+                                <span onclick="$('#discount_name').val('{$voucher.name}');return false;" class="voucher_name">{$voucher.name}</span> - {$voucher.description} <br />
+                              {/foreach}
+                            </div>
+                          {/if}
+                        </fieldset>
+                      </form>
+                    {/if}
+                  </div>
+                </td>
+              {/if}
+              <td colspan="{if !$voucherAllowed}4{else}2{/if}" class="text-right total_price_container">
+                <span>{l s='Total'}</span>
+              </td>
+              <td colspan="2" class="price total_price_container" id="total_price_container">
+                <span id="total_price" data-selenium-total-price="{$total_price_without_tax}">{displayPrice price=$total_price_without_tax}</span>
+              </td>
+            </tr>
+          {/if}
+          </tfoot>
+
+          <tbody>
+          {foreach from=$products item=product name=productLoop}
+            {assign var='productId' value=$product.id_product}
+            {assign var='productAttributeId' value=$product.id_product_attribute}
+            {assign var='quantityDisplayed' value=0}
+            {assign var='cannotModify' value=1}
+            {assign var='odd' value=$product@iteration%2}
+            {assign var='noDeleteButton' value=1}
+
+            {* Display the product line *}
+            {include file="$tpl_dir./shopping-cart-product-line.tpl"}
+
+            {* Then the customized datas ones*}
+            {if isset($customizedDatas.$productId.$productAttributeId)}
+              {foreach from=$customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] key='id_customization' item='customization'}
+                <tr id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}" class="alternate_item cart_item">
+                  <td colspan="4">
+                    {foreach from=$customization.datas key='type' item='datas'}
+                      {if $type == $CUSTOMIZE_FILE}
+                        <div class="customizationUploaded">
+                          <ul class="customizationUploaded">
+                            {foreach from=$datas item='picture'}
+                              <li>
+                                <img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" />
+                              </li>
+                            {/foreach}
+                          </ul>
+                        </div>
+                      {elseif $type == $CUSTOMIZE_TEXTFIELD}
+                        <ul class="typedText">
+                          {foreach from=$datas item='textField' name='typedText'}
+                            <li>
+                              {if $textField.name}
+                                {l s='%s:' sprintf=$textField.name}
+                              {else}
+                                {l s='Text #%s:' sprintf=$smarty.foreach.typedText.index+1}
+                              {/if}
+                              {$textField.value}
+                            </li>
+                          {/foreach}
+                        </ul>
+                      {/if}
+                    {/foreach}
+                  </td>
+                  <td class="cart_quantity text-center">
+                    {$customization.quantity}
+                  </td>
+                  <td class="cart_total"></td>
+                </tr>
+                {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
+              {/foreach}
+              {* If it exists also some uncustomized products *}
+              {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl"}{/if}
+            {/if}
+          {/foreach}
+          {assign var='last_was_odd' value=$product@iteration%2}
+          {foreach $gift_products as $product}
+            {assign var='productId' value=$product.id_product}
+            {assign var='productAttributeId' value=$product.id_product_attribute}
+            {assign var='quantityDisplayed' value=0}
+            {assign var='odd' value=($product@iteration+$last_was_odd)%2}
+            {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
+            {assign var='cannotModify' value=1}
+            {* Display the gift product line *}
+            {include file="./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
+          {/foreach}
+          </tbody>
+
+          {if count($discounts)}
+            <tbody>
+            {foreach from=$discounts item=discount name=discountLoop}
+              {if (float)$discount.value_real == 0}
+                {continue}
+              {/if}
+              <tr class="cart_discount {if $smarty.foreach.discountLoop.last}last_item{elseif $smarty.foreach.discountLoop.first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
+                <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
+                <td class="cart_discount_price">
+                  <span class="price-discount">
+                    {if $discount.value_real > 0}
+                      {if !$priceDisplay}
+                        {displayPrice price=$discount.value_real*-1}
+                      {else}
+                        {displayPrice price=$discount.value_tax_exc*-1}
+                      {/if}
+                    {/if}
+                  </span>
+                </td>
+                <td class="cart_discount_delete">1</td>
+                <td class="cart_discount_price">
+                  <span class="price-discount">
+                    {if $discount.value_real > 0}
+                      {if !$priceDisplay}
+                        {displayPrice price=$discount.value_real*-1}
+                      {else}
+                        {displayPrice price=$discount.value_tax_exc*-1}
+                      {/if}
+                    {/if}
+                  </span>
+                </td>
+              </tr>
+            {/foreach}
+            </tbody>
+          {/if}
+        </table>
+      </div> <!-- end order-detail-content -->
+    {/if}
+    {if $opc}
+      <div id="opc_payment_methods-content">
+    {/if}
+    <div id="HOOK_PAYMENT">
+      {$HOOK_PAYMENT}
+    </div>
+    {if $opc}
+      </div> <!-- end opc_payment_methods-content -->
+    {/if}
+  {else}
+    <p class="alert alert-warning">{l s='No payment modules have been installed.'}</p>
+  {/if}
+  {if !$opc}
+  <p class="cart_navigation clearfix">
+    <a href="{$link->getPageLink('order', true, NULL, "step=2")|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+      <i class="icon-chevron-left"></i>
+      {l s='Continue shopping'}
+    </a>
+  </p>
+  {else}
 </div> <!-- end opc_payment_methods -->
 {/if}
 </div> <!-- end HOOK_TOP_PAYMENT -->

--- a/themes/community-theme-16/order-payment.tpl
+++ b/themes/community-theme-16/order-payment.tpl
@@ -23,31 +23,31 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if !$opc}
-    {addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
-    {addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
-    {capture name=path}{l s='Your payment method'}{/capture}
-    <h1 class="page-heading">{l s='Please choose your payment method'}
-        {if !isset($empty) && !$PS_CATALOG_MODE}
-            <span class="heading-counter">{l s='Your shopping cart contains:'}
-                <span id="summary_products_quantity">{$productNumber} {if $productNumber == 1}{l s='product'}{else}{l s='products'}{/if}</span>
-            </span>
-        {/if}
-    </h1>
+  {addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
+  {addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
+  {capture name=path}{l s='Your payment method'}{/capture}
+  <h1 class="page-heading">{l s='Please choose your payment method'}
+    {if !isset($empty) && !$PS_CATALOG_MODE}
+      <span class="heading-counter">{l s='Your shopping cart contains:'}
+        <span id="summary_products_quantity">{$productNumber} {if $productNumber == 1}{l s='product'}{else}{l s='products'}{/if}</span>
+      </span>
+    {/if}
+  </h1>
 {else}
-    <h1 class="page-heading step-num"><span>3</span> {l s='Please choose your payment method'}</h1>
+  <h1 class="page-heading step-num"><span>3</span> {l s='Please choose your payment method'}</h1>
 {/if}
 
 {if !$opc}
-    {assign var='current_step' value='payment'}
-    {include file="$tpl_dir./order-steps.tpl"}
-    {include file="$tpl_dir./errors.tpl"}
+  {assign var='current_step' value='payment'}
+  {include file="$tpl_dir./order-steps.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
 {else}
-    <div id="opc_payment_methods" class="opc-main-block">
-        <div id="opc_payment_methods-overlay" class="opc-overlay" style="display: none;"></div>
-{/if}
+<div id="opc_payment_methods" class="opc-main-block">
+  <div id="opc_payment_methods-overlay" class="opc-overlay" style="display: none;"></div>
+  {/if}
 
-{if $advanced_payment_api}
-    {include file="$tpl_dir./order-payment-advanced.tpl"}
-{else}
-    {include file = "$tpl_dir./order-payment-classic.tpl"}
+  {if $advanced_payment_api}
+  {include file="$tpl_dir./order-payment-advanced.tpl"}
+  {else}
+  {include file = "$tpl_dir./order-payment-classic.tpl"}
 {/if}

--- a/themes/community-theme-16/order-return.tpl
+++ b/themes/community-theme-16/order-return.tpl
@@ -24,88 +24,88 @@
 *}
 {include file="./errors.tpl"}
 {if isset($orderRet)}
-    <div class="box">
-        <h2 class="page-subheading">{l s='RE#'}{$orderRet->id|string_format:"%06d"} {l s='on'} {dateFormat date=$order->date_add full=0}</h2>
-        <p class="bold">{l s='We have logged your return request.'}</p>
-        <p>{l s='Your package must be returned to us within'} {$nbdaysreturn} {l s='days of receiving your order.'}</p>
-        <p>{l s='The current status of your merchandise return is:'} <span class="bold">{$state_name|escape:'html':'UTF-8'}</span></p>
-        <p>{l s='List of items to be returned:'}</p>
-    </div>
-    <div id="order-detail-content" class="table_block">
-        <table class="table table-bordered">
-            <thead>
-                <tr>
-                    <th class="first_item">{l s='Reference'}</th>
-                    <th class="item">{l s='Product'}</th>
-                    <th class="last_item">{l s='Quantity'}</th>
-                </tr>
-            </thead>
-            <tbody>
-            {foreach from=$products item=product name=products}
+  <div class="box">
+    <h2 class="page-subheading">{l s='RE#'}{$orderRet->id|string_format:"%06d"} {l s='on'} {dateFormat date=$order->date_add full=0}</h2>
+    <p class="bold">{l s='We have logged your return request.'}</p>
+    <p>{l s='Your package must be returned to us within'} {$nbdaysreturn} {l s='days of receiving your order.'}</p>
+    <p>{l s='The current status of your merchandise return is:'} <span class="bold">{$state_name|escape:'html':'UTF-8'}</span></p>
+    <p>{l s='List of items to be returned:'}</p>
+  </div>
+  <div id="order-detail-content" class="table_block">
+    <table class="table table-bordered">
+      <thead>
+      <tr>
+        <th class="first_item">{l s='Reference'}</th>
+        <th class="item">{l s='Product'}</th>
+        <th class="last_item">{l s='Quantity'}</th>
+      </tr>
+      </thead>
+      <tbody>
+      {foreach from=$products item=product name=products}
 
-                {assign var='quantityDisplayed' value=0}
-                {foreach from=$returnedCustomizations item='customization' name=products}
-                    {if $customization.product_id == $product.product_id}
-                        <tr class="{if $smarty.foreach.products.first}first_item{/if} {if $smarty.foreach.products.index % 2}alternate_item{else}item{/if}">
-                            <td>{if $customization.reference}{$customization.reference|escape:'html':'UTF-8'}{else}--{/if}</td>
-                            <td class="bold">{$customization.name|escape:'html':'UTF-8'}</td>
-                            <td><span class="order_qte_span editable">{$customization.product_quantity|intval}</span></td>
-                        </tr>
-                        {assign var='productId' value=$customization.product_id}
-                        {assign var='productAttributeId' value=$customization.product_attribute_id}
-                        {assign var='customizationId' value=$customization.id_customization}
-                        {assign var='addressDeliveryId' value=$customization.id_address_delivery}
-                        {foreach from=$customizedDatas.$productId.$productAttributeId.$addressDeliveryId.$customizationId.datas key='type' item='datas'}
-                            <tr class="alternate_item">
-                                <td colspan="3">
-                                    {if $type == Product::CUSTOMIZE_FILE}
-                                    <ul class="customizationUploaded">
-                                        {foreach from=$datas item='data'}
-                                            <li><img src="{$pic_dir}{$data.value}_small" alt="" class="customizationUploaded" /></li>
-                                        {/foreach}
-                                    </ul>
-                                    {elseif $type == Product::CUSTOMIZE_TEXTFIELD}
-                                    <ul class="typedText">{counter start=0 print=false}
-                                        {foreach from=$datas item='data'}
-                                            {assign var='customizationFieldName' value="Text #"|cat:$data.id_customization_field}
-                                            <li>{l s='%s:' sprintf=$data.name|default:$customizationFieldName} {$data.value}</li>
-                                        {/foreach}
-                                    </ul>
-                                    {/if}
-                                </td>
-                            </tr>
-                        {/foreach}
-                        {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.product_quantity}
-                    {/if}
-                {/foreach}
-
-                {if $product.product_quantity > $quantityDisplayed}
-                    <tr class="{if $smarty.foreach.products.first}first_item{/if} {if $smarty.foreach.products.index % 2}alternate_item{else}item{/if}">
-                        <td>{if $product.product_reference}{$product.product_reference|escape:'html':'UTF-8'}{else}--{/if}</td>
-                        <td class="bold">{$product.product_name|escape:'html':'UTF-8'}</td>
-                        <td><span class="order_qte_span editable">{$product.product_quantity|intval}</span></td>
-                    </tr>
-                {/if}
+        {assign var='quantityDisplayed' value=0}
+        {foreach from=$returnedCustomizations item='customization' name=products}
+          {if $customization.product_id == $product.product_id}
+            <tr class="{if $smarty.foreach.products.first}first_item{/if} {if $smarty.foreach.products.index % 2}alternate_item{else}item{/if}">
+              <td>{if $customization.reference}{$customization.reference|escape:'html':'UTF-8'}{else}--{/if}</td>
+              <td class="bold">{$customization.name|escape:'html':'UTF-8'}</td>
+              <td><span class="order_qte_span editable">{$customization.product_quantity|intval}</span></td>
+            </tr>
+            {assign var='productId' value=$customization.product_id}
+            {assign var='productAttributeId' value=$customization.product_attribute_id}
+            {assign var='customizationId' value=$customization.id_customization}
+            {assign var='addressDeliveryId' value=$customization.id_address_delivery}
+            {foreach from=$customizedDatas.$productId.$productAttributeId.$addressDeliveryId.$customizationId.datas key='type' item='datas'}
+              <tr class="alternate_item">
+                <td colspan="3">
+                  {if $type == Product::CUSTOMIZE_FILE}
+                    <ul class="customizationUploaded">
+                      {foreach from=$datas item='data'}
+                        <li><img src="{$pic_dir}{$data.value}_small" alt="" class="customizationUploaded" /></li>
+                      {/foreach}
+                    </ul>
+                  {elseif $type == Product::CUSTOMIZE_TEXTFIELD}
+                    <ul class="typedText">{counter start=0 print=false}
+                      {foreach from=$datas item='data'}
+                        {assign var='customizationFieldName' value="Text #"|cat:$data.id_customization_field}
+                        <li>{l s='%s:' sprintf=$data.name|default:$customizationFieldName} {$data.value}</li>
+                      {/foreach}
+                    </ul>
+                  {/if}
+                </td>
+              </tr>
             {/foreach}
-            </tbody>
-        </table>
-    </div>
+            {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.product_quantity}
+          {/if}
+        {/foreach}
 
-    {if $orderRet->state == 2}
+        {if $product.product_quantity > $quantityDisplayed}
+          <tr class="{if $smarty.foreach.products.first}first_item{/if} {if $smarty.foreach.products.index % 2}alternate_item{else}item{/if}">
+            <td>{if $product.product_reference}{$product.product_reference|escape:'html':'UTF-8'}{else}--{/if}</td>
+            <td class="bold">{$product.product_name|escape:'html':'UTF-8'}</td>
+            <td><span class="order_qte_span editable">{$product.product_quantity|intval}</span></td>
+          </tr>
+        {/if}
+      {/foreach}
+      </tbody>
+    </table>
+  </div>
+
+  {if $orderRet->state == 2}
     <div class="box">
-        <h3 class="page-subheading">{l s='Reminder'}</h3>
-        <ul>
-            <li>{l s='All merchandise must be returned in its original packaging and in its original state.'}</li>
-            <li>{l s='Please print out the'} <a href="{$link->getPageLink('pdf-order-return', true, NULL, "id_order_return={$orderRet->id|intval}")|escape:'html':'UTF-8'}">{l s='PDF return slip'}</a> {l s='and include it with your package.'}</li>
-            <li>{l s='Please see the PDF return slip'} (<a href="{$link->getPageLink('pdf-order-return', true, NULL, "id_order_return={$orderRet->id|intval}")|escape:'html':'UTF-8'}">{l s='for the correct address.'}</a>)</li>
-        </ul>
-        {l s='When we receive your package, we will notify you by email. We will then begin processing order reimbursement.'}
-        <br /><br /><a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='Please let us know if you have any questions.'}</a>
-        <br />
-        <p class="bold">{l s='If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.'}</p>
+      <h3 class="page-subheading">{l s='Reminder'}</h3>
+      <ul>
+        <li>{l s='All merchandise must be returned in its original packaging and in its original state.'}</li>
+        <li>{l s='Please print out the'} <a href="{$link->getPageLink('pdf-order-return', true, NULL, "id_order_return={$orderRet->id|intval}")|escape:'html':'UTF-8'}">{l s='PDF return slip'}</a> {l s='and include it with your package.'}</li>
+        <li>{l s='Please see the PDF return slip'} (<a href="{$link->getPageLink('pdf-order-return', true, NULL, "id_order_return={$orderRet->id|intval}")|escape:'html':'UTF-8'}">{l s='for the correct address.'}</a>)</li>
+      </ul>
+      {l s='When we receive your package, we will notify you by email. We will then begin processing order reimbursement.'}
+      <br /><br /><a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='Please let us know if you have any questions.'}</a>
+      <br />
+      <p class="bold">{l s='If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.'}</p>
     </div>
-    {elseif $orderRet->state == 1}
-        <p class="bold">{l s='You must wait for confirmation before returning any merchandise.'}</p>
-    {/if}
+  {elseif $orderRet->state == 1}
+    <p class="bold">{l s='You must wait for confirmation before returning any merchandise.'}</p>
+  {/if}
 {/if}
 

--- a/themes/community-theme-16/order-slip.tpl
+++ b/themes/community-theme-16/order-slip.tpl
@@ -26,66 +26,66 @@
 {capture name=path}<a href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">{l s='My account'}</a><span class="navigation-pipe">{$navigationPipe}</span><span class="navigation_page">{l s='Credit slips'}</span>{/capture}
 
 <h1 class="page-heading bottom-indent">
-    {l s='Credit slips'}
+  {l s='Credit slips'}
 </h1>
 <p class="info-title">
-    {l s='Credit slips you have received after canceled orders'}.
+  {l s='Credit slips you have received after canceled orders'}.
 </p>
 <div class="block-center" id="block-history">
-    {if $ordersSlip && count($ordersSlip)}
-        <table id="order-list" class="table table-bordered footab">
-            <thead>
-                <tr>
-                    <th data-sort-ignore="true" class="first_item">{l s='Credit slip'}</th>
-                    <th data-sort-ignore="true" class="item">{l s='Order'}</th>
-                    <th class="item">{l s='Date issued'}</th>
-                    <th data-sort-ignore="true" data-hide="phone" class="last_item">{l s='View credit slip'}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {foreach from=$ordersSlip item=slip name=myLoop}
-                    <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
-                        <td class="bold">
-                            <span class="color-myaccount">
-                                {l s='#%s' sprintf=$slip.id_order_slip|string_format:"%06d"}
-                            </span>
-                        </td>
-                        <td class="history_method">
-                            <a class="color-myaccount" href="javascript:showOrder(1, {$slip.id_order|intval}, '{$link->getPageLink('order-detail')|escape:'html':'UTF-8'}');">
-                                {l s='#%s' sprintf=$slip.id_order|string_format:"%06d"}
-                            </a>
-                        </td>
-                        <td class="bold"  data-value="{$slip.date_add|regex_replace:"/[\-\:\ ]/":""}">
-                            {dateFormat date=$slip.date_add full=0}
-                        </td>
-                        <td class="history_invoice">
-                            <a class="link-button" href="{$link->getPageLink('pdf-order-slip', true, NULL, "id_order_slip={$slip.id_order_slip|intval}")|escape:'html':'UTF-8'}" title="{l s='Credit slip'} {l s='#%s' sprintf=$slip.id_order_slip|string_format:"%06d"}">
-                                <i class="icon-file-text large"></i>{l s='PDF'}
-                            </a>
-                        </td>
-                    </tr>
-                {/foreach}
-            </tbody>
-        </table>
-        <div id="block-order-detail" class="unvisible">&nbsp;</div>
-    {else}
-        <p class="alert alert-warning">{l s='You have not received any credit slips.'}</p>
-    {/if}
+  {if $ordersSlip && count($ordersSlip)}
+    <table id="order-list" class="table table-bordered footab">
+      <thead>
+      <tr>
+        <th data-sort-ignore="true" class="first_item">{l s='Credit slip'}</th>
+        <th data-sort-ignore="true" class="item">{l s='Order'}</th>
+        <th class="item">{l s='Date issued'}</th>
+        <th data-sort-ignore="true" data-hide="phone" class="last_item">{l s='View credit slip'}</th>
+      </tr>
+      </thead>
+      <tbody>
+      {foreach from=$ordersSlip item=slip name=myLoop}
+        <tr class="{if $smarty.foreach.myLoop.first}first_item{elseif $smarty.foreach.myLoop.last}last_item{else}item{/if} {if $smarty.foreach.myLoop.index % 2}alternate_item{/if}">
+          <td class="bold">
+            <span class="color-myaccount">
+              {l s='#%s' sprintf=$slip.id_order_slip|string_format:"%06d"}
+            </span>
+          </td>
+          <td class="history_method">
+            <a class="color-myaccount" href="javascript:showOrder(1, {$slip.id_order|intval}, '{$link->getPageLink('order-detail')|escape:'html':'UTF-8'}');">
+              {l s='#%s' sprintf=$slip.id_order|string_format:"%06d"}
+            </a>
+          </td>
+          <td class="bold"  data-value="{$slip.date_add|regex_replace:"/[\-\:\ ]/":""}">
+            {dateFormat date=$slip.date_add full=0}
+          </td>
+          <td class="history_invoice">
+            <a class="link-button" href="{$link->getPageLink('pdf-order-slip', true, NULL, "id_order_slip={$slip.id_order_slip|intval}")|escape:'html':'UTF-8'}" title="{l s='Credit slip'} {l s='#%s' sprintf=$slip.id_order_slip|string_format:"%06d"}">
+              <i class="icon-file-text large"></i>{l s='PDF'}
+            </a>
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    </table>
+    <div id="block-order-detail" class="unvisible">&nbsp;</div>
+  {else}
+    <p class="alert alert-warning">{l s='You have not received any credit slips.'}</p>
+  {/if}
 </div><!-- #block-history -->
 
 <ul class="footer_links clearfix">
-    <li>
-        <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Back to your account'}
-            </span>
-        </a>
-    </li>
-    <li>
-        <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-            <span>
-                <i class="icon-chevron-left"></i> {l s='Home'}
-            </span>
-        </a>
-    </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Back to your account'}
+      </span>
+    </a>
+  </li>
+  <li>
+    <a class="btn btn-default button button-small" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+      <span>
+        <i class="icon-chevron-left"></i> {l s='Home'}
+      </span>
+    </a>
+  </li>
 </ul>

--- a/themes/community-theme-16/order-steps.tpl
+++ b/themes/community-theme-16/order-steps.tpl
@@ -25,55 +25,55 @@
 
 {* Assign a value to 'current_step' to display current style *}
 {capture name="url_back"}
-{if isset($back) && $back}back={$back}{/if}
+  {if isset($back) && $back}back={$back}{/if}
 {/capture}
 
 {if !isset($multi_shipping)}
-    {assign var='multi_shipping' value='0'}
+  {assign var='multi_shipping' value='0'}
 {/if}
 
 {if !$opc && ((!isset($back) || empty($back)) || (isset($back) && preg_match("/[&?]step=/", $back)))}
-<!-- Steps -->
-<ul class="step clearfix" id="order_step">
+  <!-- Steps -->
+  <ul class="step clearfix" id="order_step">
     <li class="{if $current_step=='summary'}step_current {elseif $current_step=='login'}step_done_last step_done{else}{if $current_step=='payment' || $current_step=='shipping' || $current_step=='address' || $current_step=='login'}step_done{else}step_todo{/if}{/if} first">
-        {if $current_step=='payment' || $current_step=='shipping' || $current_step=='address' || $current_step=='login'}
+      {if $current_step=='payment' || $current_step=='shipping' || $current_step=='address' || $current_step=='login'}
         <a href="{$link->getPageLink('order', true)}">
-            <em>01.</em> {l s='Summary'}
+          <em>01.</em> {l s='Summary'}
         </a>
-        {else}
-            <span><em>01.</em> {l s='Summary'}</span>
-        {/if}
+      {else}
+        <span><em>01.</em> {l s='Summary'}</span>
+      {/if}
     </li>
     <li class="{if $current_step=='login'}step_current{elseif $current_step=='address'}step_done step_done_last{else}{if $current_step=='payment' || $current_step=='shipping' || $current_step=='address'}step_done{else}step_todo{/if}{/if} second">
-        {if $current_step=='payment' || $current_step=='shipping' || $current_step=='address'}
+      {if $current_step=='payment' || $current_step=='shipping' || $current_step=='address'}
         <a href="{$link->getPageLink('order', true, NULL, "{$smarty.capture.url_back}&step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}">
-            <em>02.</em> {l s='Sign in'}
+          <em>02.</em> {l s='Sign in'}
         </a>
-        {else}
-            <span><em>02.</em> {l s='Sign in'}</span>
-        {/if}
+      {else}
+        <span><em>02.</em> {l s='Sign in'}</span>
+      {/if}
     </li>
     <li class="{if $current_step=='address'}step_current{elseif $current_step=='shipping'}step_done step_done_last{else}{if $current_step=='payment' || $current_step=='shipping'}step_done{else}step_todo{/if}{/if} third">
-        {if $current_step=='payment' || $current_step=='shipping'}
+      {if $current_step=='payment' || $current_step=='shipping'}
         <a href="{$link->getPageLink('order', true, NULL, "{$smarty.capture.url_back}&step=1{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}">
-            <em>03.</em> {l s='Address'}
+          <em>03.</em> {l s='Address'}
         </a>
-        {else}
-            <span><em>03.</em> {l s='Address'}</span>
-        {/if}
+      {else}
+        <span><em>03.</em> {l s='Address'}</span>
+      {/if}
     </li>
     <li class="{if $current_step=='shipping'}step_current{else}{if $current_step=='payment'}step_done step_done_last{else}step_todo{/if}{/if} four">
-        {if $current_step=='payment'}
+      {if $current_step=='payment'}
         <a href="{$link->getPageLink('order', true, NULL, "{$smarty.capture.url_back}&step=2{if $multi_shipping}&multi-shipping={$multi_shipping}{/if}")|escape:'html':'UTF-8'}">
-            <em>04.</em> {l s='Shipping'}
+          <em>04.</em> {l s='Shipping'}
         </a>
-        {else}
-            <span><em>04.</em> {l s='Shipping'}</span>
-        {/if}
+      {else}
+        <span><em>04.</em> {l s='Shipping'}</span>
+      {/if}
     </li>
     <li id="step_end" class="{if $current_step=='payment'}step_current{else}step_todo{/if} last">
-        <span><em>05.</em> {l s='Payment'}</span>
+      <span><em>05.</em> {l s='Payment'}</span>
     </li>
-</ul>
-<!-- /Steps -->
+  </ul>
+  <!-- /Steps -->
 {/if}

--- a/themes/community-theme-16/pagination.tpl
+++ b/themes/community-theme-16/pagination.tpl
@@ -24,184 +24,184 @@
 *}
 
 {if isset($no_follow) AND $no_follow}
-    {assign var='no_follow_text' value=' rel="nofollow"'}
+  {assign var='no_follow_text' value=' rel="nofollow"'}
 {else}
-    {assign var='no_follow_text' value=''}
+  {assign var='no_follow_text' value=''}
 {/if}
 
 {if isset($p) AND $p}
-    {if isset($smarty.get.id_category) && $smarty.get.id_category && isset($category)}
-        {if !isset($current_url)}
-            {assign var='requestPage' value=$link->getPaginationLink('category', $category, false, false, true, false)}
-        {else}
-            {assign var='requestPage' value=$current_url}
-        {/if}
-        {assign var='requestNb' value=$link->getPaginationLink('category', $category, true, false, false, true)}
-    {elseif isset($smarty.get.id_manufacturer) && $smarty.get.id_manufacturer && isset($manufacturer)}
-        {assign var='requestPage' value=$link->getPaginationLink('manufacturer', $manufacturer, false, false, true, false)}
-        {assign var='requestNb' value=$link->getPaginationLink('manufacturer', $manufacturer, true, false, false, true)}
-    {elseif isset($smarty.get.id_supplier) && $smarty.get.id_supplier && isset($supplier)}
-        {assign var='requestPage' value=$link->getPaginationLink('supplier', $supplier, false, false, true, false)}
-        {assign var='requestNb' value=$link->getPaginationLink('supplier', $supplier, true, false, false, true)}
+  {if isset($smarty.get.id_category) && $smarty.get.id_category && isset($category)}
+    {if !isset($current_url)}
+      {assign var='requestPage' value=$link->getPaginationLink('category', $category, false, false, true, false)}
     {else}
-        {if !isset($current_url)}
-            {assign var='requestPage' value=$link->getPaginationLink(false, false, false, false, true, false)}
-        {else}
-            {assign var='requestPage' value=$current_url}
-        {/if}
-        {assign var='requestNb' value=$link->getPaginationLink(false, false, true, false, false, true)}
+      {assign var='requestPage' value=$current_url}
     {/if}
-    <!-- Pagination -->
-    <div id="pagination{if isset($paginationId)}_{$paginationId}{/if}" class="pagination clearfix">
-        {if $nb_products > $products_per_page && $start!=$stop}
-            <form class="showall" action="{if !is_array($requestNb)}{$requestNb}{else}{$requestNb.requestUrl}{/if}" method="get">
-                <div>
-                    {if isset($search_query) AND $search_query}
-                        <input type="hidden" name="search_query" value="{$search_query|escape:'html':'UTF-8'}" />
-                    {/if}
-                    {if isset($tag) AND $tag AND !is_array($tag)}
-                        <input type="hidden" name="tag" value="{$tag|escape:'html':'UTF-8'}" />
-                    {/if}
-                    <button type="submit" class="btn btn-default button exclusive-medium">
-                        <span>{l s='Show all'}</span>
-                    </button>
-                    {if is_array($requestNb)}
-                        {foreach from=$requestNb item=requestValue key=requestKey}
-                            {if $requestKey != 'requestUrl' && $requestKey != 'p'}
-                                <input type="hidden" name="{$requestKey|escape:'html':'UTF-8'}" value="{$requestValue|escape:'html':'UTF-8'}" />
-                            {/if}
-                        {/foreach}
-                    {/if}
-                    <input name="n" id="nb_item" class="hidden" value="{$nb_products}" />
-                </div>
-            </form>
-        {/if}
-        {if $start!=$stop}
-            <ul class="pagination">
-                {if $p != 1}
-                    {assign var='p_previous' value=$p-1}
-                    <li id="pagination_previous{if isset($paginationId)}_{$paginationId}{/if}" class="pagination_previous">
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, $p_previous)}" rel="prev">
-                            <i class="icon-chevron-left"></i> <b>{l s='Previous'}</b>
-                        </a>
-                    </li>
-                {else}
-                    <li id="pagination_previous{if isset($paginationId)}_{$paginationId}{/if}" class="disabled pagination_previous">
-                        <span>
-                            <i class="icon-chevron-left"></i> <b>{l s='Previous'}</b>
-                        </span>
-                    </li>
-                {/if}
-                {if $start==3}
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, 1)}">
-                            <span>1</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, 2)}">
-                            <span>2</span>
-                        </a>
-                    </li>
-                {/if}
-                {if $start==2}
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, 1)}">
-                            <span>1</span>
-                        </a>
-                    </li>
-                {/if}
-                {if $start>3}
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, 1)}">
-                            <span>1</span>
-                        </a>
-                    </li>
-                    <li class="truncate">
-                        <span>
-                            <span>...</span>
-                        </span>
-                    </li>
-                {/if}
-                {section name=pagination start=$start loop=$stop+1 step=1}
-                    {if $p == $smarty.section.pagination.index}
-                        <li class="active current">
-                            <span>
-                                <span>{$p|escape:'html':'UTF-8'}</span>
-                            </span>
-                        </li>
-                    {else}
-                        <li>
-                            <a{$no_follow_text} href="{$link->goPage($requestPage, $smarty.section.pagination.index)}">
-                                <span>{$smarty.section.pagination.index|escape:'html':'UTF-8'}</span>
-                            </a>
-                        </li>
-                    {/if}
-                {/section}
-                {if $pages_nb>$stop+2}
-                    <li class="truncate">
-                        <span>
-                            <span>...</span>
-                        </span>
-                    </li>
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb)}">
-                            <span>{$pages_nb|intval}</span>
-                        </a>
-                    </li>
-                {/if}
-                {if $pages_nb==$stop+1}
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb)}">
-                            <span>{$pages_nb|intval}</span>
-                        </a>
-                    </li>
-                {/if}
-                {if $pages_nb==$stop+2}
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb-1)}">
-                            <span>{$pages_nb-1|intval}</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb)}">
-                            <span>{$pages_nb|intval}</span>
-                        </a>
-                    </li>
-                {/if}
-                {if $pages_nb > 1 AND $p != $pages_nb}
-                    {assign var='p_next' value=$p+1}
-                    <li id="pagination_next{if isset($paginationId)}_{$paginationId}{/if}" class="pagination_next">
-                        <a{$no_follow_text} href="{$link->goPage($requestPage, $p_next)}" rel="next">
-                            <b>{l s='Next'}</b> <i class="icon-chevron-right"></i>
-                        </a>
-                    </li>
-                {else}
-                    <li id="pagination_next{if isset($paginationId)}_{$paginationId}{/if}" class="disabled pagination_next">
-                        <span>
-                            <b>{l s='Next'}</b> <i class="icon-chevron-right"></i>
-                        </span>
-                    </li>
-                {/if}
-            </ul>
-        {/if}
-    </div>
-    <div class="product-count">
-        {if ($n*$p) < $nb_products }
-            {assign var='productShowing' value=$n*$p}
+    {assign var='requestNb' value=$link->getPaginationLink('category', $category, true, false, false, true)}
+  {elseif isset($smarty.get.id_manufacturer) && $smarty.get.id_manufacturer && isset($manufacturer)}
+    {assign var='requestPage' value=$link->getPaginationLink('manufacturer', $manufacturer, false, false, true, false)}
+    {assign var='requestNb' value=$link->getPaginationLink('manufacturer', $manufacturer, true, false, false, true)}
+  {elseif isset($smarty.get.id_supplier) && $smarty.get.id_supplier && isset($supplier)}
+    {assign var='requestPage' value=$link->getPaginationLink('supplier', $supplier, false, false, true, false)}
+    {assign var='requestNb' value=$link->getPaginationLink('supplier', $supplier, true, false, false, true)}
+  {else}
+    {if !isset($current_url)}
+      {assign var='requestPage' value=$link->getPaginationLink(false, false, false, false, true, false)}
+    {else}
+      {assign var='requestPage' value=$current_url}
+    {/if}
+    {assign var='requestNb' value=$link->getPaginationLink(false, false, true, false, false, true)}
+  {/if}
+  <!-- Pagination -->
+  <div id="pagination{if isset($paginationId)}_{$paginationId}{/if}" class="pagination clearfix">
+    {if $nb_products > $products_per_page && $start!=$stop}
+      <form class="showall" action="{if !is_array($requestNb)}{$requestNb}{else}{$requestNb.requestUrl}{/if}" method="get">
+        <div>
+          {if isset($search_query) AND $search_query}
+            <input type="hidden" name="search_query" value="{$search_query|escape:'html':'UTF-8'}" />
+          {/if}
+          {if isset($tag) AND $tag AND !is_array($tag)}
+            <input type="hidden" name="tag" value="{$tag|escape:'html':'UTF-8'}" />
+          {/if}
+          <button type="submit" class="btn btn-default button exclusive-medium">
+            <span>{l s='Show all'}</span>
+          </button>
+          {if is_array($requestNb)}
+            {foreach from=$requestNb item=requestValue key=requestKey}
+              {if $requestKey != 'requestUrl' && $requestKey != 'p'}
+                <input type="hidden" name="{$requestKey|escape:'html':'UTF-8'}" value="{$requestValue|escape:'html':'UTF-8'}" />
+              {/if}
+            {/foreach}
+          {/if}
+          <input name="n" id="nb_item" class="hidden" value="{$nb_products}" />
+        </div>
+      </form>
+    {/if}
+    {if $start!=$stop}
+      <ul class="pagination">
+        {if $p != 1}
+          {assign var='p_previous' value=$p-1}
+          <li id="pagination_previous{if isset($paginationId)}_{$paginationId}{/if}" class="pagination_previous">
+            <a{$no_follow_text} href="{$link->goPage($requestPage, $p_previous)}" rel="prev">
+              <i class="icon-chevron-left"></i> <b>{l s='Previous'}</b>
+            </a>
+          </li>
         {else}
-            {assign var='productShowing' value=($n*$p-$nb_products-$n*$p)*-1}
+          <li id="pagination_previous{if isset($paginationId)}_{$paginationId}{/if}" class="disabled pagination_previous">
+            <span>
+              <i class="icon-chevron-left"></i> <b>{l s='Previous'}</b>
+            </span>
+          </li>
         {/if}
-        {if $p==1}
-            {assign var='productShowingStart' value=1}
+        {if $start==3}
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, 1)}">
+              <span>1</span>
+            </a>
+          </li>
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, 2)}">
+              <span>2</span>
+            </a>
+          </li>
+        {/if}
+        {if $start==2}
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, 1)}">
+              <span>1</span>
+            </a>
+          </li>
+        {/if}
+        {if $start>3}
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, 1)}">
+              <span>1</span>
+            </a>
+          </li>
+          <li class="truncate">
+            <span>
+              <span>...</span>
+            </span>
+          </li>
+        {/if}
+        {section name=pagination start=$start loop=$stop+1 step=1}
+          {if $p == $smarty.section.pagination.index}
+            <li class="active current">
+              <span>
+                <span>{$p|escape:'html':'UTF-8'}</span>
+              </span>
+            </li>
+          {else}
+            <li>
+              <a{$no_follow_text} href="{$link->goPage($requestPage, $smarty.section.pagination.index)}">
+                <span>{$smarty.section.pagination.index|escape:'html':'UTF-8'}</span>
+              </a>
+            </li>
+          {/if}
+        {/section}
+        {if $pages_nb>$stop+2}
+          <li class="truncate">
+            <span>
+              <span>...</span>
+            </span>
+          </li>
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb)}">
+              <span>{$pages_nb|intval}</span>
+            </a>
+          </li>
+        {/if}
+        {if $pages_nb==$stop+1}
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb)}">
+              <span>{$pages_nb|intval}</span>
+            </a>
+          </li>
+        {/if}
+        {if $pages_nb==$stop+2}
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb-1)}">
+              <span>{$pages_nb-1|intval}</span>
+            </a>
+          </li>
+          <li>
+            <a{$no_follow_text} href="{$link->goPage($requestPage, $pages_nb)}">
+              <span>{$pages_nb|intval}</span>
+            </a>
+          </li>
+        {/if}
+        {if $pages_nb > 1 AND $p != $pages_nb}
+          {assign var='p_next' value=$p+1}
+          <li id="pagination_next{if isset($paginationId)}_{$paginationId}{/if}" class="pagination_next">
+            <a{$no_follow_text} href="{$link->goPage($requestPage, $p_next)}" rel="next">
+              <b>{l s='Next'}</b> <i class="icon-chevron-right"></i>
+            </a>
+          </li>
         {else}
-            {assign var='productShowingStart' value=$n*$p-$n+1}
+          <li id="pagination_next{if isset($paginationId)}_{$paginationId}{/if}" class="disabled pagination_next">
+            <span>
+              <b>{l s='Next'}</b> <i class="icon-chevron-right"></i>
+            </span>
+          </li>
         {/if}
-        {if $nb_products > 1}
-            {l s='Showing %1$d - %2$d of %3$d items' sprintf=[$productShowingStart, $productShowing, $nb_products]}
-        {else}
-            {l s='Showing %1$d - %2$d of 1 item' sprintf=[$productShowingStart, $productShowing]}
-        {/if}
-    </div>
-    <!-- /Pagination -->
+      </ul>
+    {/if}
+  </div>
+  <div class="product-count">
+    {if ($n*$p) < $nb_products }
+      {assign var='productShowing' value=$n*$p}
+    {else}
+      {assign var='productShowing' value=($n*$p-$nb_products-$n*$p)*-1}
+    {/if}
+    {if $p==1}
+      {assign var='productShowingStart' value=1}
+    {else}
+      {assign var='productShowingStart' value=$n*$p-$n+1}
+    {/if}
+    {if $nb_products > 1}
+      {l s='Showing %1$d - %2$d of %3$d items' sprintf=[$productShowingStart, $productShowing, $nb_products]}
+    {else}
+      {l s='Showing %1$d - %2$d of 1 item' sprintf=[$productShowingStart, $productShowing]}
+    {/if}
+  </div>
+  <!-- /Pagination -->
 {/if}

--- a/themes/community-theme-16/password.tpl
+++ b/themes/community-theme-16/password.tpl
@@ -25,29 +25,29 @@
 
 {capture name=path}<a href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" title="{l s='Authentication'}" rel="nofollow">{l s='Authentication'}</a><span class="navigation-pipe">{$navigationPipe}</span>{l s='Forgot your password'}{/capture}
 <div class="box">
-<h1 class="page-subheading">{l s='Forgot your password?'}</h1>
+  <h1 class="page-subheading">{l s='Forgot your password?'}</h1>
 
-{include file="$tpl_dir./errors.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
 
-{if isset($confirmation) && $confirmation == 1}
-<p class="alert alert-success">{l s='Your password has been successfully reset and a confirmation has been sent to your email address:'} {if isset($customer_email)}{$customer_email|escape:'html':'UTF-8'|stripslashes}{/if}</p>
-{elseif isset($confirmation) && $confirmation == 2}
-<p class="alert alert-success">{l s='A confirmation email has been sent to your address:'} {if isset($customer_email)}{$customer_email|escape:'html':'UTF-8'|stripslashes}{/if}</p>
-{else}
-<p>{l s='Please enter the email address you used to register. We will then send you a new password. '}</p>
-<form action="{$request_uri|escape:'html':'UTF-8'}" method="post" class="std" id="form_forgotpassword">
-    <fieldset>
+  {if isset($confirmation) && $confirmation == 1}
+    <p class="alert alert-success">{l s='Your password has been successfully reset and a confirmation has been sent to your email address:'} {if isset($customer_email)}{$customer_email|escape:'html':'UTF-8'|stripslashes}{/if}</p>
+  {elseif isset($confirmation) && $confirmation == 2}
+    <p class="alert alert-success">{l s='A confirmation email has been sent to your address:'} {if isset($customer_email)}{$customer_email|escape:'html':'UTF-8'|stripslashes}{/if}</p>
+  {else}
+    <p>{l s='Please enter the email address you used to register. We will then send you a new password. '}</p>
+    <form action="{$request_uri|escape:'html':'UTF-8'}" method="post" class="std" id="form_forgotpassword">
+      <fieldset>
         <div class="form-group">
-            <label for="email">{l s='Email address'}</label>
-            <input class="form-control" type="email" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'|stripslashes}{/if}" />
+          <label for="email">{l s='Email address'}</label>
+          <input class="form-control" type="email" id="email" name="email" value="{if isset($smarty.post.email)}{$smarty.post.email|escape:'html':'UTF-8'|stripslashes}{/if}" />
         </div>
         <p class="submit">
-            <button type="submit" class="btn btn-default button button-medium"><span>{l s='Retrieve Password'}<i class="icon-chevron-right right"></i></span></button>
+          <button type="submit" class="btn btn-default button button-medium"><span>{l s='Retrieve Password'}<i class="icon-chevron-right right"></i></span></button>
         </p>
-    </fieldset>
-</form>
-{/if}
+      </fieldset>
+    </form>
+  {/if}
 </div>
 <ul class="clearfix footer_links">
-    <li><a class="btn btn-default button button-small" href="{$link->getPageLink('authentication')|escape:'html':'UTF-8'}" title="{l s='Back to Login'}" rel="nofollow"><span><i class="icon-chevron-left"></i>{l s='Back to Login'}</span></a></li>
+  <li><a class="btn btn-default button button-small" href="{$link->getPageLink('authentication')|escape:'html':'UTF-8'}" title="{l s='Back to Login'}" rel="nofollow"><span><i class="icon-chevron-left"></i>{l s='Back to Login'}</span></a></li>
 </ul>

--- a/themes/community-theme-16/prices-drop.tpl
+++ b/themes/community-theme-16/prices-drop.tpl
@@ -28,25 +28,25 @@
 <h1 class="page-heading product-listing">{l s='Price drop'}</h1>
 
 {if $products}
-    <div class="content_sortPagiBar">
-        <div class="sortPagiBar clearfix">
-            {include file="./product-sort.tpl"}
-            {include file="./nbr-product-page.tpl"}
-        </div>
-        <div class="top-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {include file="$tpl_dir./pagination.tpl" no_follow=1}
-        </div>
+  <div class="content_sortPagiBar">
+    <div class="sortPagiBar clearfix">
+      {include file="./product-sort.tpl"}
+      {include file="./nbr-product-page.tpl"}
     </div>
-
-    {include file="./product-list.tpl" products=$products}
-
-    <div class="content_sortPagiBar">
-        <div class="bottom-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {include file="./pagination.tpl" no_follow=1 paginationId='bottom'}
-        </div>
+    <div class="top-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {include file="$tpl_dir./pagination.tpl" no_follow=1}
     </div>
-    {else}
-    <p class="alert alert-warning">{l s='No price drop'}</p>
+  </div>
+
+  {include file="./product-list.tpl" products=$products}
+
+  <div class="content_sortPagiBar">
+    <div class="bottom-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {include file="./pagination.tpl" no_follow=1 paginationId='bottom'}
+    </div>
+  </div>
+{else}
+  <p class="alert alert-warning">{l s='No price drop'}</p>
 {/if}

--- a/themes/community-theme-16/product-compare.tpl
+++ b/themes/community-theme-16/product-compare.tpl
@@ -23,17 +23,17 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if $comparator_max_item}
-    <form method="post" action="{$link->getPageLink('products-comparison')|escape:'html':'UTF-8'}" class="compare-form">
-        <button type="submit" class="btn btn-default button button-medium bt_compare bt_compare{if isset($paginationId)}_{$paginationId}{/if}" disabled="disabled">
-            <span>{l s='Compare'} (<strong class="total-compare-val">{count($compared_products)}</strong>)<i class="icon-chevron-right right"></i></span>
-        </button>
-        <input type="hidden" name="compare_product_count" class="compare_product_count" value="{count($compared_products)}" />
-        <input type="hidden" name="compare_product_list" class="compare_product_list" value="" />
-    </form>
-    {if !isset($paginationId) || $paginationId == ''}
-        {addJsDefL name=min_item}{l s='Please select at least one product' js=1}{/addJsDefL}
-        {addJsDefL name=max_item}{l s='You cannot add more than %d product(s) to the product comparison' sprintf=$comparator_max_item js=1}{/addJsDefL}
-        {addJsDef comparator_max_item=$comparator_max_item}
-        {addJsDef comparedProductsIds=$compared_products}
-    {/if}
+  <form method="post" action="{$link->getPageLink('products-comparison')|escape:'html':'UTF-8'}" class="compare-form">
+    <button type="submit" class="btn btn-default button button-medium bt_compare bt_compare{if isset($paginationId)}_{$paginationId}{/if}" disabled="disabled">
+      <span>{l s='Compare'} (<strong class="total-compare-val">{count($compared_products)}</strong>)<i class="icon-chevron-right right"></i></span>
+    </button>
+    <input type="hidden" name="compare_product_count" class="compare_product_count" value="{count($compared_products)}" />
+    <input type="hidden" name="compare_product_list" class="compare_product_list" value="" />
+  </form>
+  {if !isset($paginationId) || $paginationId == ''}
+    {addJsDefL name=min_item}{l s='Please select at least one product' js=1}{/addJsDefL}
+    {addJsDefL name=max_item}{l s='You cannot add more than %d product(s) to the product comparison' sprintf=$comparator_max_item js=1}{/addJsDefL}
+    {addJsDef comparator_max_item=$comparator_max_item}
+    {addJsDef comparedProductsIds=$compared_products}
+  {/if}
 {/if}

--- a/themes/community-theme-16/product-list-colors.tpl
+++ b/themes/community-theme-16/product-list-colors.tpl
@@ -23,18 +23,18 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($colors_list)}
-<ul class="color_to_pick_list clearfix">
+  <ul class="color_to_pick_list clearfix">
     {foreach from=$colors_list item='color'}
-        {if isset($col_img_dir)}
-            {assign var='img_color_exists' value=file_exists($col_img_dir|cat:$color.id_attribute|cat:'.jpg')}
-            <li>
-                <a href="{$link->getProductLink($color.id_product, null, null, null, null, null, $color.id_product_attribute, Configuration::get('PS_REWRITING_SETTINGS'), false, true)|escape:'html':'UTF-8'}" id="color_{$color.id_product_attribute|intval}" class="color_pick"{if !$img_color_exists && isset($color.color) && $color.color} style="background:{$color.color};"{/if}>
-                    {if $img_color_exists}
-                        <img src="{$img_col_dir}{$color.id_attribute|intval}.jpg" alt="{$color.name|escape:'html':'UTF-8'}" title="{$color.name|escape:'html':'UTF-8'}" width="20" height="20" />
-                    {/if}
-                </a>
-            </li>
-        {/if}
+      {if isset($col_img_dir)}
+        {assign var='img_color_exists' value=file_exists($col_img_dir|cat:$color.id_attribute|cat:'.jpg')}
+        <li>
+          <a href="{$link->getProductLink($color.id_product, null, null, null, null, null, $color.id_product_attribute, Configuration::get('PS_REWRITING_SETTINGS'), false, true)|escape:'html':'UTF-8'}" id="color_{$color.id_product_attribute|intval}" class="color_pick"{if !$img_color_exists && isset($color.color) && $color.color} style="background:{$color.color};"{/if}>
+            {if $img_color_exists}
+              <img src="{$img_col_dir}{$color.id_attribute|intval}.jpg" alt="{$color.name|escape:'html':'UTF-8'}" title="{$color.name|escape:'html':'UTF-8'}" width="20" height="20" />
+            {/if}
+          </a>
+        </li>
+      {/if}
     {/foreach}
-</ul>
+  </ul>
 {/if}

--- a/themes/community-theme-16/product-list.tpl
+++ b/themes/community-theme-16/product-list.tpl
@@ -23,67 +23,67 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($products) && $products}
-    {*define number of products per line in other page for desktop*}
-    {if $page_name !='index' && $page_name !='product'}
-        {assign var='nbItemsPerLine' value=3}
-        {assign var='nbItemsPerLineTablet' value=2}
-        {assign var='nbItemsPerLineMobile' value=3}
-    {else}
-        {assign var='nbItemsPerLine' value=4}
-        {assign var='nbItemsPerLineTablet' value=3}
-        {assign var='nbItemsPerLineMobile' value=2}
-    {/if}
-    {*define numbers of product per line in other page for tablet*}
-    {assign var='nbLi' value=$products|@count}
-    {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
-    {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
-    <!-- Products list -->
-    <ul{if isset($id) && $id} id="{$id}"{/if} class="product_list grid row{if isset($class) && $class} {$class}{/if}">
+  {*define number of products per line in other page for desktop*}
+  {if $page_name !='index' && $page_name !='product'}
+    {assign var='nbItemsPerLine' value=3}
+    {assign var='nbItemsPerLineTablet' value=2}
+    {assign var='nbItemsPerLineMobile' value=3}
+  {else}
+    {assign var='nbItemsPerLine' value=4}
+    {assign var='nbItemsPerLineTablet' value=3}
+    {assign var='nbItemsPerLineMobile' value=2}
+  {/if}
+  {*define numbers of product per line in other page for tablet*}
+  {assign var='nbLi' value=$products|@count}
+  {math equation="nbLi/nbItemsPerLine" nbLi=$nbLi nbItemsPerLine=$nbItemsPerLine assign=nbLines}
+  {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
+  <!-- Products list -->
+  <ul{if isset($id) && $id} id="{$id}"{/if} class="product_list grid row{if isset($class) && $class} {$class}{/if}">
     {foreach from=$products item=product name=products}
-        {math equation="(total%perLine)" total=$smarty.foreach.products.total perLine=$nbItemsPerLine assign=totModulo}
-        {math equation="(total%perLineT)" total=$smarty.foreach.products.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
-        {math equation="(total%perLineT)" total=$smarty.foreach.products.total perLineT=$nbItemsPerLineMobile assign=totModuloMobile}
-        {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
-        {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
-        {if $totModuloMobile == 0}{assign var='totModuloMobile' value=$nbItemsPerLineMobile}{/if}
-        <li class="ajax_block_product{if $page_name == 'index' || $page_name == 'product'} col-xs-12 col-sm-4 col-md-3{else} col-xs-12 col-sm-6 col-md-4{/if}{if $smarty.foreach.products.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.products.iteration%$nbItemsPerLine == 1} first-in-line{/if}{if $smarty.foreach.products.iteration > ($smarty.foreach.products.total - $totModulo)} last-line{/if}{if $smarty.foreach.products.iteration%$nbItemsPerLineTablet == 0} last-item-of-tablet-line{elseif $smarty.foreach.products.iteration%$nbItemsPerLineTablet == 1} first-item-of-tablet-line{/if}{if $smarty.foreach.products.iteration%$nbItemsPerLineMobile == 0} last-item-of-mobile-line{elseif $smarty.foreach.products.iteration%$nbItemsPerLineMobile == 1} first-item-of-mobile-line{/if}{if $smarty.foreach.products.iteration > ($smarty.foreach.products.total - $totModuloMobile)} last-mobile-line{/if}">
-            <div class="product-container" itemscope itemtype="https://schema.org/Product">
-                <div class="left-block">
-                    <div class="product-image-container">
-                        <a class="product_img_link" href="{$product.link|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}" itemprop="url">
-                            <img class="replace-2x img-responsive" src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'home_default')|escape:'html':'UTF-8'}" alt="{if !empty($product.legend)}{$product.legend|escape:'html':'UTF-8'}{else}{$product.name|escape:'html':'UTF-8'}{/if}" title="{if !empty($product.legend)}{$product.legend|escape:'html':'UTF-8'}{else}{$product.name|escape:'html':'UTF-8'}{/if}" {if isset($homeSize)} width="{$homeSize.width}" height="{$homeSize.height}"{/if} itemprop="image" />
-                        </a>
-                        {if isset($quick_view) && $quick_view}
-                            <div class="quick-view-wrapper-mobile">
-                            <a class="quick-view-mobile" href="{$product.link|escape:'html':'UTF-8'}" rel="{$product.link|escape:'html':'UTF-8'}">
-                                <i class="icon-eye-open"></i>
-                            </a>
-                        </div>
-                        <a class="quick-view" href="{$product.link|escape:'html':'UTF-8'}" rel="{$product.link|escape:'html':'UTF-8'}">
-                            <span>{l s='Quick view'}</span>
-                        </a>
-                        {/if}
-                        {if (!$PS_CATALOG_MODE && ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
-                            <div class="content_price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                                {if isset($product.show_price) && $product.show_price && !isset($restricted_country_mode)}
-                                    <span itemprop="price" class="price product-price">
+      {math equation="(total%perLine)" total=$smarty.foreach.products.total perLine=$nbItemsPerLine assign=totModulo}
+      {math equation="(total%perLineT)" total=$smarty.foreach.products.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
+      {math equation="(total%perLineT)" total=$smarty.foreach.products.total perLineT=$nbItemsPerLineMobile assign=totModuloMobile}
+      {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
+      {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
+      {if $totModuloMobile == 0}{assign var='totModuloMobile' value=$nbItemsPerLineMobile}{/if}
+      <li class="ajax_block_product{if $page_name == 'index' || $page_name == 'product'} col-xs-12 col-sm-4 col-md-3{else} col-xs-12 col-sm-6 col-md-4{/if}{if $smarty.foreach.products.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.products.iteration%$nbItemsPerLine == 1} first-in-line{/if}{if $smarty.foreach.products.iteration > ($smarty.foreach.products.total - $totModulo)} last-line{/if}{if $smarty.foreach.products.iteration%$nbItemsPerLineTablet == 0} last-item-of-tablet-line{elseif $smarty.foreach.products.iteration%$nbItemsPerLineTablet == 1} first-item-of-tablet-line{/if}{if $smarty.foreach.products.iteration%$nbItemsPerLineMobile == 0} last-item-of-mobile-line{elseif $smarty.foreach.products.iteration%$nbItemsPerLineMobile == 1} first-item-of-mobile-line{/if}{if $smarty.foreach.products.iteration > ($smarty.foreach.products.total - $totModuloMobile)} last-mobile-line{/if}">
+        <div class="product-container" itemscope itemtype="https://schema.org/Product">
+          <div class="left-block">
+            <div class="product-image-container">
+              <a class="product_img_link" href="{$product.link|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}" itemprop="url">
+                <img class="replace-2x img-responsive" src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'home_default')|escape:'html':'UTF-8'}" alt="{if !empty($product.legend)}{$product.legend|escape:'html':'UTF-8'}{else}{$product.name|escape:'html':'UTF-8'}{/if}" title="{if !empty($product.legend)}{$product.legend|escape:'html':'UTF-8'}{else}{$product.name|escape:'html':'UTF-8'}{/if}" {if isset($homeSize)} width="{$homeSize.width}" height="{$homeSize.height}"{/if} itemprop="image" />
+              </a>
+              {if isset($quick_view) && $quick_view}
+                <div class="quick-view-wrapper-mobile">
+                  <a class="quick-view-mobile" href="{$product.link|escape:'html':'UTF-8'}" rel="{$product.link|escape:'html':'UTF-8'}">
+                    <i class="icon-eye-open"></i>
+                  </a>
+                </div>
+                <a class="quick-view" href="{$product.link|escape:'html':'UTF-8'}" rel="{$product.link|escape:'html':'UTF-8'}">
+                  <span>{l s='Quick view'}</span>
+                </a>
+              {/if}
+              {if (!$PS_CATALOG_MODE && ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
+                <div class="content_price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+                  {if isset($product.show_price) && $product.show_price && !isset($restricted_country_mode)}
+                    <span itemprop="price" class="price product-price">
                                         {hook h="displayProductPriceBlock" product=$product type="before_price"}
-                                        {if !$priceDisplay}{convertPrice price=$product.price}{else}{convertPrice price=$product.price_tax_exc}{/if}
+                      {if !$priceDisplay}{convertPrice price=$product.price}{else}{convertPrice price=$product.price_tax_exc}{/if}
                                     </span>
-                                    <meta itemprop="priceCurrency" content="{$currency->iso_code}" />
-                                    {if $product.price_without_reduction > 0 && isset($product.specific_prices) && $product.specific_prices && isset($product.specific_prices.reduction) && $product.specific_prices.reduction > 0}
-                                        {hook h="displayProductPriceBlock" product=$product type="old_price"}
-                                        <span class="old-price product-price">
+                    <meta itemprop="priceCurrency" content="{$currency->iso_code}" />
+                    {if $product.price_without_reduction > 0 && isset($product.specific_prices) && $product.specific_prices && isset($product.specific_prices.reduction) && $product.specific_prices.reduction > 0}
+                      {hook h="displayProductPriceBlock" product=$product type="old_price"}
+                      <span class="old-price product-price">
                                             {displayWtPrice p=$product.price_without_reduction}
                                         </span>
-                                        {if $product.specific_prices.reduction_type == 'percentage'}
-                                            <span class="price-percent-reduction">-{$product.specific_prices.reduction * 100}%</span>
-                                        {/if}
-                                    {/if}
-                                    {if $PS_STOCK_MANAGEMENT && isset($product.available_for_order) && $product.available_for_order && !isset($restricted_country_mode)}
-                                        <span class="unvisible">
+                      {if $product.specific_prices.reduction_type == 'percentage'}
+                        <span class="price-percent-reduction">-{$product.specific_prices.reduction * 100}%</span>
+                      {/if}
+                    {/if}
+                    {if $PS_STOCK_MANAGEMENT && isset($product.available_for_order) && $product.available_for_order && !isset($restricted_country_mode)}
+                      <span class="unvisible">
                                             {if ($product.allow_oosp || $product.quantity > 0)}
-                                                    <link itemprop="availability" href="https://schema.org/InStock" />{if $product.quantity <= 0}{if $product.allow_oosp}{if isset($product.available_later) && $product.available_later}{$product.available_later}{else}{l s='In Stock'}{/if}{/if}{else}{if isset($product.available_now) && $product.available_now}{$product.available_now}{else}{l s='In Stock'}{/if}{/if}
+                                              <link itemprop="availability" href="https://schema.org/InStock" />{if $product.quantity <= 0}{if $product.allow_oosp}{if isset($product.available_later) && $product.available_later}{$product.available_later}{else}{l s='In Stock'}{/if}{/if}{else}{if isset($product.available_now) && $product.available_now}{$product.available_now}{else}{l s='In Stock'}{/if}{/if}
                                             {elseif (isset($product.quantity_all_versions) && $product.quantity_all_versions > 0)}
                                                     <link itemprop="availability" href="https://schema.org/LimitedAvailability" />{l s='Product available with different options'}
 
@@ -91,101 +91,101 @@
                                                     <link itemprop="availability" href="https://schema.org/OutOfStock" />{l s='Out of stock'}
                                             {/if}
                                         </span>
-                                    {/if}
-                                    {hook h="displayProductPriceBlock" product=$product type="price"}
-                                    {hook h="displayProductPriceBlock" product=$product type="unit_price"}
-                                {/if}
-                            </div>
-                        {/if}
-                        {if isset($product.new) && $product.new == 1}
-                            <a class="new-box" href="{$product.link|escape:'html':'UTF-8'}">
-                                <span class="new-label">{l s='New'}</span>
-                            </a>
-                        {/if}
-                        {if isset($product.on_sale) && $product.on_sale && isset($product.show_price) && $product.show_price && !$PS_CATALOG_MODE}
-                            <a class="sale-box" href="{$product.link|escape:'html':'UTF-8'}">
-                                <span class="sale-label">{l s='Sale!'}</span>
-                            </a>
-                        {/if}
-                    </div>
-                    {if isset($product.is_virtual) && !$product.is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
-                    {hook h="displayProductPriceBlock" product=$product type="weight"}
-                </div>
-                <div class="right-block">
-                    <h5 itemprop="name">
-                        {if isset($product.pack_quantity) && $product.pack_quantity}{$product.pack_quantity|intval|cat:' x '}{/if}
-                        <a class="product-name" href="{$product.link|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}" itemprop="url" >
-                            {$product.name|truncate:45:'...'|escape:'html':'UTF-8'}
-                        </a>
-                    </h5>
-                    {capture name='displayProductListReviews'}{hook h='displayProductListReviews' product=$product}{/capture}
-                    {if $smarty.capture.displayProductListReviews}
-                        <div class="hook-reviews">
-                        {hook h='displayProductListReviews' product=$product}
-                        </div>
                     {/if}
-                    <p class="product-desc" itemprop="description">
-                        {$product.description_short|strip_tags:'UTF-8'|truncate:360:'...'}
-                    </p>
-                    {if (!$PS_CATALOG_MODE AND ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
-                    <div class="content_price">
-                        {if isset($product.show_price) && $product.show_price && !isset($restricted_country_mode)}
-                            {hook h="displayProductPriceBlock" product=$product type='before_price'}
-                            <span class="price product-price">
+                    {hook h="displayProductPriceBlock" product=$product type="price"}
+                    {hook h="displayProductPriceBlock" product=$product type="unit_price"}
+                  {/if}
+                </div>
+              {/if}
+              {if isset($product.new) && $product.new == 1}
+                <a class="new-box" href="{$product.link|escape:'html':'UTF-8'}">
+                  <span class="new-label">{l s='New'}</span>
+                </a>
+              {/if}
+              {if isset($product.on_sale) && $product.on_sale && isset($product.show_price) && $product.show_price && !$PS_CATALOG_MODE}
+                <a class="sale-box" href="{$product.link|escape:'html':'UTF-8'}">
+                  <span class="sale-label">{l s='Sale!'}</span>
+                </a>
+              {/if}
+            </div>
+            {if isset($product.is_virtual) && !$product.is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
+            {hook h="displayProductPriceBlock" product=$product type="weight"}
+          </div>
+          <div class="right-block">
+            <h5 itemprop="name">
+              {if isset($product.pack_quantity) && $product.pack_quantity}{$product.pack_quantity|intval|cat:' x '}{/if}
+              <a class="product-name" href="{$product.link|escape:'html':'UTF-8'}" title="{$product.name|escape:'html':'UTF-8'}" itemprop="url" >
+                {$product.name|truncate:45:'...'|escape:'html':'UTF-8'}
+              </a>
+            </h5>
+            {capture name='displayProductListReviews'}{hook h='displayProductListReviews' product=$product}{/capture}
+            {if $smarty.capture.displayProductListReviews}
+              <div class="hook-reviews">
+                {hook h='displayProductListReviews' product=$product}
+              </div>
+            {/if}
+            <p class="product-desc" itemprop="description">
+              {$product.description_short|strip_tags:'UTF-8'|truncate:360:'...'}
+            </p>
+            {if (!$PS_CATALOG_MODE AND ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
+              <div class="content_price">
+                {if isset($product.show_price) && $product.show_price && !isset($restricted_country_mode)}
+                  {hook h="displayProductPriceBlock" product=$product type='before_price'}
+                  <span class="price product-price">
                                 {if !$priceDisplay}{convertPrice price=$product.price}{else}{convertPrice price=$product.price_tax_exc}{/if}
                             </span>
-                            {if $product.price_without_reduction > 0 && isset($product.specific_prices) && $product.specific_prices && isset($product.specific_prices.reduction) && $product.specific_prices.reduction > 0}
-                                {hook h="displayProductPriceBlock" product=$product type="old_price"}
-                                <span class="old-price product-price">
+                  {if $product.price_without_reduction > 0 && isset($product.specific_prices) && $product.specific_prices && isset($product.specific_prices.reduction) && $product.specific_prices.reduction > 0}
+                    {hook h="displayProductPriceBlock" product=$product type="old_price"}
+                    <span class="old-price product-price">
                                     {displayWtPrice p=$product.price_without_reduction}
                                 </span>
-                                {hook h="displayProductPriceBlock" id_product=$product.id_product type="old_price"}
-                                {if $product.specific_prices.reduction_type == 'percentage'}
-                                    <span class="price-percent-reduction">-{$product.specific_prices.reduction * 100}%</span>
-                                {/if}
-                            {/if}
-                            {hook h="displayProductPriceBlock" product=$product type="price"}
-                            {hook h="displayProductPriceBlock" product=$product type="unit_price"}
-                            {hook h="displayProductPriceBlock" product=$product type='after_price'}
-                        {/if}
-                    </div>
+                    {hook h="displayProductPriceBlock" id_product=$product.id_product type="old_price"}
+                    {if $product.specific_prices.reduction_type == 'percentage'}
+                      <span class="price-percent-reduction">-{$product.specific_prices.reduction * 100}%</span>
                     {/if}
-                    <div class="button-container">
-                        {if ($product.id_product_attribute == 0 || (isset($add_prod_display) && ($add_prod_display == 1))) && $product.available_for_order && !isset($restricted_country_mode) && $product.customizable != 2 && !$PS_CATALOG_MODE}
-                            {if (!isset($product.customization_required) || !$product.customization_required) && ($product.allow_oosp || $product.quantity > 0)}
-                                {capture}add=1&amp;id_product={$product.id_product|intval}{if isset($product.id_product_attribute) && $product.id_product_attribute}&amp;ipa={$product.id_product_attribute|intval}{/if}{if isset($static_token)}&amp;token={$static_token}{/if}{/capture}
-                                <a class="button ajax_add_to_cart_button btn btn-default" href="{$link->getPageLink('cart', true, NULL, $smarty.capture.default, false)|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Add to cart'}" data-id-product-attribute="{$product.id_product_attribute|intval}" data-id-product="{$product.id_product|intval}" data-minimal_quantity="{if isset($product.product_attribute_minimal_quantity) && $product.product_attribute_minimal_quantity >= 1}{$product.product_attribute_minimal_quantity|intval}{else}{$product.minimal_quantity|intval}{/if}">
-                                    <span>{l s='Add to cart'}</span>
-                                </a>
-                            {else}
-                                <span class="button ajax_add_to_cart_button btn btn-default disabled">
+                  {/if}
+                  {hook h="displayProductPriceBlock" product=$product type="price"}
+                  {hook h="displayProductPriceBlock" product=$product type="unit_price"}
+                  {hook h="displayProductPriceBlock" product=$product type='after_price'}
+                {/if}
+              </div>
+            {/if}
+            <div class="button-container">
+              {if ($product.id_product_attribute == 0 || (isset($add_prod_display) && ($add_prod_display == 1))) && $product.available_for_order && !isset($restricted_country_mode) && $product.customizable != 2 && !$PS_CATALOG_MODE}
+                {if (!isset($product.customization_required) || !$product.customization_required) && ($product.allow_oosp || $product.quantity > 0)}
+                  {capture}add=1&amp;id_product={$product.id_product|intval}{if isset($product.id_product_attribute) && $product.id_product_attribute}&amp;ipa={$product.id_product_attribute|intval}{/if}{if isset($static_token)}&amp;token={$static_token}{/if}{/capture}
+                  <a class="button ajax_add_to_cart_button btn btn-default" href="{$link->getPageLink('cart', true, NULL, $smarty.capture.default, false)|escape:'html':'UTF-8'}" rel="nofollow" title="{l s='Add to cart'}" data-id-product-attribute="{$product.id_product_attribute|intval}" data-id-product="{$product.id_product|intval}" data-minimal_quantity="{if isset($product.product_attribute_minimal_quantity) && $product.product_attribute_minimal_quantity >= 1}{$product.product_attribute_minimal_quantity|intval}{else}{$product.minimal_quantity|intval}{/if}">
+                    <span>{l s='Add to cart'}</span>
+                  </a>
+                {else}
+                  <span class="button ajax_add_to_cart_button btn btn-default disabled">
                                     <span>{l s='Add to cart'}</span>
                                 </span>
-                            {/if}
-                        {/if}
-                        <a class="button lnk_view btn btn-default" href="{$product.link|escape:'html':'UTF-8'}" title="{l s='View'}">
-                            <span>{if (isset($product.customization_required) && $product.customization_required)}{l s='Customize'}{else}{l s='More'}{/if}</span>
-                        </a>
-                    </div>
-                    {if isset($product.color_list)}
-                        <div class="color-list-container">{$product.color_list}</div>
-                    {/if}
-                    <div class="product-flags">
-                        {if (!$PS_CATALOG_MODE AND ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
-                            {if isset($product.online_only) && $product.online_only}
-                                <span class="online_only">{l s='Online only'}</span>
-                            {/if}
-                        {/if}
-                        {if isset($product.on_sale) && $product.on_sale && isset($product.show_price) && $product.show_price && !$PS_CATALOG_MODE}
-                            {elseif isset($product.reduction) && $product.reduction && isset($product.show_price) && $product.show_price && !$PS_CATALOG_MODE}
-                                <span class="discount">{l s='Reduced price!'}</span>
-                            {/if}
-                    </div>
-                    {if (!$PS_CATALOG_MODE && $PS_STOCK_MANAGEMENT && ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
-                        {if isset($product.available_for_order) && $product.available_for_order && !isset($restricted_country_mode)}
-                            <span class="availability">
+                {/if}
+              {/if}
+              <a class="button lnk_view btn btn-default" href="{$product.link|escape:'html':'UTF-8'}" title="{l s='View'}">
+                <span>{if (isset($product.customization_required) && $product.customization_required)}{l s='Customize'}{else}{l s='More'}{/if}</span>
+              </a>
+            </div>
+            {if isset($product.color_list)}
+              <div class="color-list-container">{$product.color_list}</div>
+            {/if}
+            <div class="product-flags">
+              {if (!$PS_CATALOG_MODE AND ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
+                {if isset($product.online_only) && $product.online_only}
+                  <span class="online_only">{l s='Online only'}</span>
+                {/if}
+              {/if}
+              {if isset($product.on_sale) && $product.on_sale && isset($product.show_price) && $product.show_price && !$PS_CATALOG_MODE}
+              {elseif isset($product.reduction) && $product.reduction && isset($product.show_price) && $product.show_price && !$PS_CATALOG_MODE}
+                <span class="discount">{l s='Reduced price!'}</span>
+              {/if}
+            </div>
+            {if (!$PS_CATALOG_MODE && $PS_STOCK_MANAGEMENT && ((isset($product.show_price) && $product.show_price) || (isset($product.available_for_order) && $product.available_for_order)))}
+              {if isset($product.available_for_order) && $product.available_for_order && !isset($restricted_country_mode)}
+                <span class="availability">
                                 {if ($product.allow_oosp || $product.quantity > 0)}
-                                    <span class="{if $product.quantity <= 0 && isset($product.allow_oosp) && !$product.allow_oosp} label-danger{elseif $product.quantity <= 0} label-warning{else} label-success{/if}">
+                                  <span class="{if $product.quantity <= 0 && isset($product.allow_oosp) && !$product.allow_oosp} label-danger{elseif $product.quantity <= 0} label-warning{else} label-success{/if}">
                                         {if $product.quantity <= 0}{if $product.allow_oosp}{if isset($product.available_later) && $product.available_later}{$product.available_later}{else}{l s='In Stock'}{/if}{else}{l s='Out of stock'}{/if}{else}{if isset($product.available_now) && $product.available_now}{$product.available_now}{else}{l s='In Stock'}{/if}{/if}
                                     </span>
                                 {elseif (isset($product.quantity_all_versions) && $product.quantity_all_versions > 0)}
@@ -198,25 +198,25 @@
                                     </span>
                                 {/if}
                             </span>
-                        {/if}
-                    {/if}
+              {/if}
+            {/if}
+          </div>
+          {if $page_name != 'index'}
+            <div class="functional-buttons clearfix">
+              {hook h='displayProductListFunctionalButtons' product=$product}
+              {if isset($comparator_max_item) && $comparator_max_item}
+                <div class="compare">
+                  <a class="add_to_compare" href="{$product.link|escape:'html':'UTF-8'}" data-id-product="{$product.id_product}">{l s='Add to Compare'}</a>
                 </div>
-                {if $page_name != 'index'}
-                    <div class="functional-buttons clearfix">
-                        {hook h='displayProductListFunctionalButtons' product=$product}
-                        {if isset($comparator_max_item) && $comparator_max_item}
-                            <div class="compare">
-                                <a class="add_to_compare" href="{$product.link|escape:'html':'UTF-8'}" data-id-product="{$product.id_product}">{l s='Add to Compare'}</a>
-                            </div>
-                        {/if}
-                    </div>
-                {/if}
-            </div><!-- .product-container> -->
-        </li>
+              {/if}
+            </div>
+          {/if}
+        </div><!-- .product-container> -->
+      </li>
     {/foreach}
-    </ul>
-{addJsDefL name=min_item}{l s='Please select at least one product' js=1}{/addJsDefL}
-{addJsDefL name=max_item}{l s='You cannot add more than %d product(s) to the product comparison' sprintf=$comparator_max_item js=1}{/addJsDefL}
-{addJsDef comparator_max_item=$comparator_max_item}
-{addJsDef comparedProductsIds=$compared_products}
+  </ul>
+  {addJsDefL name=min_item}{l s='Please select at least one product' js=1}{/addJsDefL}
+  {addJsDefL name=max_item}{l s='You cannot add more than %d product(s) to the product comparison' sprintf=$comparator_max_item js=1}{/addJsDefL}
+  {addJsDef comparator_max_item=$comparator_max_item}
+  {addJsDef comparedProductsIds=$compared_products}
 {/if}

--- a/themes/community-theme-16/product-sort.tpl
+++ b/themes/community-theme-16/product-sort.tpl
@@ -23,46 +23,46 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if isset($orderby) AND isset($orderway)}
-<ul class="display hidden-xs">
+  <ul class="display hidden-xs">
     <li class="display-title">{l s='View:'}</li>
     <li id="grid"><a rel="nofollow" href="#" title="{l s='Grid'}"><i class="icon-th-large"></i>{l s='Grid'}</a></li>
     <li id="list"><a rel="nofollow" href="#" title="{l s='List'}"><i class="icon-th-list"></i>{l s='List'}</a></li>
-</ul>
-{* On 1.5 the var request is setted on the front controller. The next lines assure the retrocompatibility with some modules *}
-{if !isset($request)}
+  </ul>
+  {* On 1.5 the var request is setted on the front controller. The next lines assure the retrocompatibility with some modules *}
+  {if !isset($request)}
     <!-- Sort products -->
     {if isset($smarty.get.id_category) && $smarty.get.id_category}
-        {assign var='request' value=$link->getPaginationLink('category', $category, false, true)}
+      {assign var='request' value=$link->getPaginationLink('category', $category, false, true)}
     {elseif isset($smarty.get.id_manufacturer) && $smarty.get.id_manufacturer}
-        {assign var='request' value=$link->getPaginationLink('manufacturer', $manufacturer, false, true)}
+      {assign var='request' value=$link->getPaginationLink('manufacturer', $manufacturer, false, true)}
     {elseif isset($smarty.get.id_supplier) && $smarty.get.id_supplier}
-        {assign var='request' value=$link->getPaginationLink('supplier', $supplier, false, true)}
+      {assign var='request' value=$link->getPaginationLink('supplier', $supplier, false, true)}
     {else}
-        {assign var='request' value=$link->getPaginationLink(false, false, false, true)}
+      {assign var='request' value=$link->getPaginationLink(false, false, false, true)}
     {/if}
-{/if}
-{if $page_name == 'best-sales' && (!isset($smarty.get.orderby) || empty($smarty.get.orderby))}{$orderby = ''}{$orderbydefault = ''}{/if}
-<form id="productsSortForm{if isset($paginationId)}_{$paginationId}{/if}" action="{$request|escape:'html':'UTF-8'}" class="productsSortForm">
+  {/if}
+  {if $page_name == 'best-sales' && (!isset($smarty.get.orderby) || empty($smarty.get.orderby))}{$orderby = ''}{$orderbydefault = ''}{/if}
+  <form id="productsSortForm{if isset($paginationId)}_{$paginationId}{/if}" action="{$request|escape:'html':'UTF-8'}" class="productsSortForm">
     <div class="select selector1">
-        <label for="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}">{l s='Sort by'}</label>
-        <select id="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}" class="selectProductSort form-control">
-            <option value="{if $page_name != 'best-sales'}{$orderbydefault|escape:'html':'UTF-8'}:{$orderwaydefault|escape:'html':'UTF-8'}{/if}"{if !in_array($orderby, array('price', 'name', 'quantity', 'reference')) && $orderby eq $orderbydefault} selected="selected"{/if}>--</option>
-            {if !$PS_CATALOG_MODE}
-                <option value="price:asc"{if $orderby eq 'price' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Price: Lowest first'}</option>
-                <option value="price:desc"{if $orderby eq 'price' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Price: Highest first'}</option>
-            {/if}
-            <option value="name:asc"{if $orderby eq 'name' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Product Name: A to Z'}</option>
-            <option value="name:desc"{if $orderby eq 'name' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Product Name: Z to A'}</option>
-            {if $PS_STOCK_MANAGEMENT && !$PS_CATALOG_MODE}
-                <option value="quantity:desc"{if $orderby eq 'quantity' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='In stock'}</option>
-            {/if}
-            <option value="reference:asc"{if $orderby eq 'reference' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Reference: Lowest first'}</option>
-            <option value="reference:desc"{if $orderby eq 'reference' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Reference: Highest first'}</option>
-        </select>
+      <label for="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}">{l s='Sort by'}</label>
+      <select id="selectProductSort{if isset($paginationId)}_{$paginationId}{/if}" class="selectProductSort form-control">
+        <option value="{if $page_name != 'best-sales'}{$orderbydefault|escape:'html':'UTF-8'}:{$orderwaydefault|escape:'html':'UTF-8'}{/if}"{if !in_array($orderby, array('price', 'name', 'quantity', 'reference')) && $orderby eq $orderbydefault} selected="selected"{/if}>--</option>
+        {if !$PS_CATALOG_MODE}
+          <option value="price:asc"{if $orderby eq 'price' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Price: Lowest first'}</option>
+          <option value="price:desc"{if $orderby eq 'price' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Price: Highest first'}</option>
+        {/if}
+        <option value="name:asc"{if $orderby eq 'name' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Product Name: A to Z'}</option>
+        <option value="name:desc"{if $orderby eq 'name' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Product Name: Z to A'}</option>
+        {if $PS_STOCK_MANAGEMENT && !$PS_CATALOG_MODE}
+          <option value="quantity:desc"{if $orderby eq 'quantity' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='In stock'}</option>
+        {/if}
+        <option value="reference:asc"{if $orderby eq 'reference' AND $orderway eq 'asc'} selected="selected"{/if}>{l s='Reference: Lowest first'}</option>
+        <option value="reference:desc"{if $orderby eq 'reference' AND $orderway eq 'desc'} selected="selected"{/if}>{l s='Reference: Highest first'}</option>
+      </select>
     </div>
-</form>
-<!-- /Sort products -->
-    {if !isset($paginationId) || $paginationId == ''}
-        {addJsDef request=$request}
-    {/if}
+  </form>
+  <!-- /Sort products -->
+  {if !isset($paginationId) || $paginationId == ''}
+    {addJsDef request=$request}
+  {/if}
 {/if}

--- a/themes/community-theme-16/product.tpl
+++ b/themes/community-theme-16/product.tpl
@@ -24,754 +24,754 @@
 *}
 {include file="$tpl_dir./errors.tpl"}
 {if $errors|@count == 0}
-    {if !isset($priceDisplayPrecision)}
-        {assign var='priceDisplayPrecision' value=2}
-    {/if}
-    {if !$priceDisplay || $priceDisplay == 2}
-        {assign var='productPrice' value=$product->getPrice(true, $smarty.const.NULL, 6)}
-        {assign var='productPriceWithoutReduction' value=$product->getPriceWithoutReduct(false, $smarty.const.NULL)}
-    {elseif $priceDisplay == 1}
-        {assign var='productPrice' value=$product->getPrice(false, $smarty.const.NULL, 6)}
-        {assign var='productPriceWithoutReduction' value=$product->getPriceWithoutReduct(true, $smarty.const.NULL)}
-    {/if}
-<div itemscope itemtype="https://schema.org/Product">
+  {if !isset($priceDisplayPrecision)}
+    {assign var='priceDisplayPrecision' value=2}
+  {/if}
+  {if !$priceDisplay || $priceDisplay == 2}
+    {assign var='productPrice' value=$product->getPrice(true, $smarty.const.NULL, 6)}
+    {assign var='productPriceWithoutReduction' value=$product->getPriceWithoutReduct(false, $smarty.const.NULL)}
+  {elseif $priceDisplay == 1}
+    {assign var='productPrice' value=$product->getPrice(false, $smarty.const.NULL, 6)}
+    {assign var='productPriceWithoutReduction' value=$product->getPriceWithoutReduct(true, $smarty.const.NULL)}
+  {/if}
+  <div itemscope itemtype="https://schema.org/Product">
     <meta itemprop="url" content="{$link->getProductLink($product)}">
     <div class="primary_block row">
-        {if !$content_only}
-            <div class="container">
-                <div class="top-hr"></div>
-            </div>
-        {/if}
-        {if isset($adminActionDisplay) && $adminActionDisplay}
-            <div id="admin-action" class="container">
-                <p class="alert alert-info">{l s='This product is not visible to your customers.'}
-                    <input type="hidden" id="admin-action-product-id" value="{$product->id}" />
-                    <a id="publish_button" class="btn btn-default button button-small" href="#">
-                        <span>{l s='Publish'}</span>
-                    </a>
-                    <a id="lnk_view" class="btn btn-default button button-small" href="#">
-                        <span>{l s='Back'}</span>
-                    </a>
-                </p>
-                <p id="admin-action-result"></p>
-            </div>
-        {/if}
-        {if isset($confirmation) && $confirmation}
-            <p class="confirmation">
-                {$confirmation}
-            </p>
-        {/if}
-        <!-- left infos-->
-        <div class="pb-left-column col-xs-12 col-sm-4 col-md-5">
-            <!-- product img-->
-            <div id="image-block" class="clearfix">
-                {if $product->new}
-                    <span class="new-box">
-                        <span class="new-label">{l s='New'}</span>
-                    </span>
-                {/if}
-                {if $product->on_sale}
-                    <span class="sale-box no-print">
-                        <span class="sale-label">{l s='Sale!'}</span>
-                    </span>
-                {elseif $product->specificPrice && $product->specificPrice.reduction && $productPriceWithoutReduction > $productPrice}
-                    <span class="discount">{l s='Reduced price!'}</span>
-                {/if}
-                {if $have_image}
-                    <span id="view_full_size">
-                        {if $jqZoomEnabled && $have_image && !$content_only}
-                            <a class="jqzoom" title="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" rel="gal1" href="{$link->getImageLink($product->link_rewrite, $cover.id_image, 'thickbox_default')|escape:'html':'UTF-8'}">
-                                <img itemprop="image" src="{$link->getImageLink($product->link_rewrite, $cover.id_image, 'large_default')|escape:'html':'UTF-8'}" title="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" alt="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}"/>
-                            </a>
-                        {else}
-                            <img id="bigpic" itemprop="image" src="{$link->getImageLink($product->link_rewrite, $cover.id_image, 'large_default')|escape:'html':'UTF-8'}" title="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" alt="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" width="{$largeSize.width}" height="{$largeSize.height}"/>
-                            {if !$content_only}
-                                <span class="span_link no-print">{l s='View larger'}</span>
-                            {/if}
-                        {/if}
-                    </span>
-                {else}
-                    <span id="view_full_size">
-                        <img itemprop="image" src="{$img_prod_dir}{$lang_iso}-default-large_default.jpg" id="bigpic" alt="" title="{$product->name|escape:'html':'UTF-8'}" width="{$largeSize.width}" height="{$largeSize.height}"/>
-                        {if !$content_only}
-                            <span class="span_link">
-                                {l s='View larger'}
-                            </span>
-                        {/if}
-                    </span>
-                {/if}
-            </div> <!-- end image-block -->
-            {if isset($images) && count($images) > 0}
-                <!-- thumbnails -->
-                <div id="views_block" class="clearfix {if isset($images) && count($images) < 2}hidden{/if}">
-                    {if isset($images) && count($images) > 2}
-                        <span class="view_scroll_spacer">
-                            <a id="view_scroll_left" class="" title="{l s='Other views'}" href="javascript:{ldelim}{rdelim}">
-                                {l s='Previous'}
-                            </a>
-                        </span>
-                    {/if}
-                    <div id="thumbs_list">
-                        <ul id="thumbs_list_frame">
-                        {if isset($images)}
-                            {foreach from=$images item=image name=thumbnails}
-                                {assign var=imageIds value="`$product->id`-`$image.id_image`"}
-                                {if !empty($image.legend)}
-                                    {assign var=imageTitle value=$image.legend|escape:'html':'UTF-8'}
-                                {else}
-                                    {assign var=imageTitle value=$product->name|escape:'html':'UTF-8'}
-                                {/if}
-                                <li id="thumbnail_{$image.id_image}"{if $smarty.foreach.thumbnails.last} class="last"{/if}>
-                                    <a{if $jqZoomEnabled && $have_image && !$content_only} href="javascript:void(0);" rel="{literal}{{/literal}gallery: 'gal1', smallimage: '{$link->getImageLink($product->link_rewrite, $imageIds, 'large_default')|escape:'html':'UTF-8'}',largeimage: '{$link->getImageLink($product->link_rewrite, $imageIds, 'thickbox_default')|escape:'html':'UTF-8'}'{literal}}{/literal}"{else} href="{$link->getImageLink($product->link_rewrite, $imageIds, 'thickbox_default')|escape:'html':'UTF-8'}" data-fancybox-group="other-views" class="fancybox{if $image.id_image == $cover.id_image} shown{/if}"{/if} title="{$imageTitle}">
-                                        <img class="img-responsive" id="thumb_{$image.id_image}" src="{$link->getImageLink($product->link_rewrite, $imageIds, 'cart_default')|escape:'html':'UTF-8'}" alt="{$imageTitle}" title="{$imageTitle}"{if isset($cartSize)} height="{$cartSize.height}" width="{$cartSize.width}"{/if} itemprop="image" />
-                                    </a>
-                                </li>
-                            {/foreach}
-                        {/if}
-                        </ul>
-                    </div> <!-- end thumbs_list -->
-                    {if isset($images) && count($images) > 2}
-                        <a id="view_scroll_right" title="{l s='Other views'}" href="javascript:{ldelim}{rdelim}">
-                            {l s='Next'}
-                        </a>
-                    {/if}
-                </div> <!-- end views-block -->
-                <!-- end thumbnails -->
-            {/if}
-            {if isset($images) && count($images) > 1}
-                <p class="resetimg clear no-print">
-                    <span id="wrapResetImages" style="display: none;">
-                        <a href="{$link->getProductLink($product)|escape:'html':'UTF-8'}" data-id="resetImages">
-                            <i class="icon-repeat"></i>
-                            {l s='Display all pictures'}
-                        </a>
-                    </span>
-                </p>
-            {/if}
-        </div> <!-- end pb-left-column -->
-        <!-- end left infos-->
-        <!-- center infos -->
-        <div class="pb-center-column col-xs-12 col-sm-4">
-            {if $product->online_only}
-                <p class="online_only">{l s='Online only'}</p>
-            {/if}
-            <h1 itemprop="name">{$product->name|escape:'html':'UTF-8'}</h1>
-            <p id="product_reference"{if empty($product->reference) || !$product->reference} style="display: none;"{/if}>
-                <label>{l s='Reference:'} </label>
-                <span class="editable" itemprop="sku"{if !empty($product->reference) && $product->reference} content="{$product->reference}"{/if}>{if !isset($groups)}{$product->reference|escape:'html':'UTF-8'}{/if}</span>
-            </p>
-            {if !$product->is_virtual && $product->condition}
-            <p id="product_condition">
-                <label>{l s='Condition:'} </label>
-                {if $product->condition == 'new'}
-                    <link itemprop="itemCondition" href="https://schema.org/NewCondition"/>
-                    <span class="editable">{l s='New product'}</span>
-                {elseif $product->condition == 'used'}
-                    <link itemprop="itemCondition" href="https://schema.org/UsedCondition"/>
-                    <span class="editable">{l s='Used'}</span>
-                {elseif $product->condition == 'refurbished'}
-                    <link itemprop="itemCondition" href="https://schema.org/RefurbishedCondition"/>
-                    <span class="editable">{l s='Refurbished'}</span>
-                {/if}
-            </p>
-            {/if}
-            {if $product->description_short || $packItems|@count > 0}
-                <div id="short_description_block">
-                    {if $product->description_short}
-                        <div id="short_description_content" class="rte align_justify" itemprop="description">{$product->description_short}</div>
-                    {/if}
-
-                    {if $product->description}
-                        <p class="buttons_bottom_block">
-                            <a href="javascript:{ldelim}{rdelim}" class="button">
-                                {l s='More details'}
-                            </a>
-                        </p>
-                    {/if}
-                    <!--{if $packItems|@count > 0}
-                        <div class="short_description_pack">
-                        <h3>{l s='Pack content'}</h3>
-                            {foreach from=$packItems item=packItem}
-
-                            <div class="pack_content">
-                                {$packItem.pack_quantity} x <a href="{$link->getProductLink($packItem.id_product, $packItem.link_rewrite, $packItem.category)|escape:'html':'UTF-8'}">{$packItem.name|escape:'html':'UTF-8'}</a>
-                                <p>{$packItem.description_short}</p>
-                            </div>
-                            {/foreach}
-                        </div>
-                    {/if}-->
-                </div> <!-- end short_description_block -->
-            {/if}
-            {if ($display_qties == 1 && !$PS_CATALOG_MODE && $PS_STOCK_MANAGEMENT && $product->available_for_order)}
-                <!-- number of item in stock -->
-                <p id="pQuantityAvailable"{if $product->quantity <= 0} style="display: none;"{/if}>
-                    <span id="quantityAvailable">{$product->quantity|intval}</span>
-                    <span {if $product->quantity > 1} style="display: none;"{/if} id="quantityAvailableTxt">{l s='Item'}</span>
-                    <span {if $product->quantity == 1} style="display: none;"{/if} id="quantityAvailableTxtMultiple">{l s='Items'}</span>
-                </p>
-            {/if}
-            <!-- availability or doesntExist -->
-            <p id="availability_statut"{if !$PS_STOCK_MANAGEMENT || ($product->quantity <= 0 && !$product->available_later && $allow_oosp) || ($product->quantity > 0 && !$product->available_now) || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
-                {*<span id="availability_label">{l s='Availability:'}</span>*}
-                <span id="availability_value" class="label{if $product->quantity <= 0 && !$allow_oosp} label-danger{elseif $product->quantity <= 0} label-warning{else} label-success{/if}">{if $product->quantity <= 0}{if $PS_STOCK_MANAGEMENT && $allow_oosp}{$product->available_later}{else}{l s='This product is no longer in stock'}{/if}{elseif $PS_STOCK_MANAGEMENT}{$product->available_now}{/if}</span>
-            </p>
-            {if $PS_STOCK_MANAGEMENT}
-                {if !$product->is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
-                <p class="warning_inline" id="last_quantities"{if ($product->quantity > $last_qties || $product->quantity <= 0) || $allow_oosp || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none"{/if} >{l s='Warning: Last items in stock!'}</p>
-            {/if}
-            <p id="availability_date"{if ($product->quantity > 0) || !$product->available_for_order || $PS_CATALOG_MODE || !isset($product->available_date) || $product->available_date < $smarty.now|date_format:'%Y-%m-%d'} style="display: none;"{/if}>
-                <span id="availability_date_label">{l s='Availability date:'}</span>
-                <span id="availability_date_value">{if Validate::isDate($product->available_date)}{dateFormat date=$product->available_date full=false}{/if}</span>
-            </p>
-            <!-- Out of stock hook -->
-            <div id="oosHook"{if $product->quantity > 0} style="display: none;"{/if}>
-                {$HOOK_PRODUCT_OOS}
-            </div>
-            {if isset($HOOK_EXTRA_RIGHT) && $HOOK_EXTRA_RIGHT}{$HOOK_EXTRA_RIGHT}{/if}
-            {if !$content_only}
-                <!-- usefull links-->
-                <ul id="usefull_link_block" class="clearfix no-print">
-                    {if $HOOK_EXTRA_LEFT}{$HOOK_EXTRA_LEFT}{/if}
-                    <li class="print">
-                        <a href="javascript:print();">
-                            {l s='Print'}
-                        </a>
-                    </li>
-                </ul>
-            {/if}
+      {if !$content_only}
+        <div class="container">
+          <div class="top-hr"></div>
         </div>
-        <!-- end center infos-->
-        <!-- pb-right-column-->
-        <div class="pb-right-column col-xs-12 col-sm-4 col-md-3">
-            {if ($product->show_price && !isset($restricted_country_mode)) || isset($groups) || $product->reference || (isset($HOOK_PRODUCT_ACTIONS) && $HOOK_PRODUCT_ACTIONS)}
-            <!-- add to cart form-->
-            <form id="buy_block"{if $PS_CATALOG_MODE && !isset($groups) && $product->quantity > 0} class="hidden"{/if} action="{$link->getPageLink('cart')|escape:'html':'UTF-8'}" method="post">
-                <!-- hidden datas -->
-                <p class="hidden">
-                    <input type="hidden" name="token" value="{$static_token}" />
-                    <input type="hidden" name="id_product" value="{$product->id|intval}" id="product_page_product_id" />
-                    <input type="hidden" name="add" value="1" />
-                    <input type="hidden" name="id_product_attribute" id="idCombination" value="" />
-                </p>
-                <div class="box-info-product">
-                    <div class="content_prices clearfix">
-                        {if $product->show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
-                            <!-- prices -->
-                            <div>
-                                <p class="our_price_display" itemprop="offers" itemscope itemtype="https://schema.org/Offer">{strip}
-                                    {if $product->quantity > 0}<link itemprop="availability" href="https://schema.org/InStock"/>{/if}
-                                    {if $priceDisplay >= 0 && $priceDisplay <= 2}
-                                        <span id="our_price_display" class="price" itemprop="price" content="{$productPrice}">{convertPrice price=$productPrice|floatval}</span>
-                                        {if $tax_enabled  && ((isset($display_tax_label) && $display_tax_label == 1) || !isset($display_tax_label))}
-                                            {if $priceDisplay == 1} {l s='tax excl.'}{else} {l s='tax incl.'}{/if}
-                                        {/if}
-                                        <meta itemprop="priceCurrency" content="{$currency->iso_code}" />
-                                        {hook h="displayProductPriceBlock" product=$product type="price"}
-                                    {/if}
-                                {/strip}</p>
-                                <p id="reduction_percent" {if $productPriceWithoutReduction <= 0 || !$product->specificPrice || $product->specificPrice.reduction_type != 'percentage'} style="display:none;"{/if}>{strip}
-                                    <span id="reduction_percent_display">
+      {/if}
+      {if isset($adminActionDisplay) && $adminActionDisplay}
+        <div id="admin-action" class="container">
+          <p class="alert alert-info">{l s='This product is not visible to your customers.'}
+            <input type="hidden" id="admin-action-product-id" value="{$product->id}" />
+            <a id="publish_button" class="btn btn-default button button-small" href="#">
+              <span>{l s='Publish'}</span>
+            </a>
+            <a id="lnk_view" class="btn btn-default button button-small" href="#">
+              <span>{l s='Back'}</span>
+            </a>
+          </p>
+          <p id="admin-action-result"></p>
+        </div>
+      {/if}
+      {if isset($confirmation) && $confirmation}
+        <p class="confirmation">
+          {$confirmation}
+        </p>
+      {/if}
+      <!-- left infos-->
+      <div class="pb-left-column col-xs-12 col-sm-4 col-md-5">
+        <!-- product img-->
+        <div id="image-block" class="clearfix">
+          {if $product->new}
+            <span class="new-box">
+              <span class="new-label">{l s='New'}</span>
+            </span>
+          {/if}
+          {if $product->on_sale}
+            <span class="sale-box no-print">
+              <span class="sale-label">{l s='Sale!'}</span>
+            </span>
+          {elseif $product->specificPrice && $product->specificPrice.reduction && $productPriceWithoutReduction > $productPrice}
+            <span class="discount">{l s='Reduced price!'}</span>
+          {/if}
+          {if $have_image}
+            <span id="view_full_size">
+              {if $jqZoomEnabled && $have_image && !$content_only}
+                <a class="jqzoom" title="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" rel="gal1" href="{$link->getImageLink($product->link_rewrite, $cover.id_image, 'thickbox_default')|escape:'html':'UTF-8'}">
+                  <img itemprop="image" src="{$link->getImageLink($product->link_rewrite, $cover.id_image, 'large_default')|escape:'html':'UTF-8'}" title="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" alt="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}"/>
+                </a>
+              {else}
+                <img id="bigpic" itemprop="image" src="{$link->getImageLink($product->link_rewrite, $cover.id_image, 'large_default')|escape:'html':'UTF-8'}" title="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" alt="{if !empty($cover.legend)}{$cover.legend|escape:'html':'UTF-8'}{else}{$product->name|escape:'html':'UTF-8'}{/if}" width="{$largeSize.width}" height="{$largeSize.height}"/>
+                {if !$content_only}
+                  <span class="span_link no-print">{l s='View larger'}</span>
+                {/if}
+              {/if}
+            </span>
+          {else}
+            <span id="view_full_size">
+              <img itemprop="image" src="{$img_prod_dir}{$lang_iso}-default-large_default.jpg" id="bigpic" alt="" title="{$product->name|escape:'html':'UTF-8'}" width="{$largeSize.width}" height="{$largeSize.height}"/>
+              {if !$content_only}
+                <span class="span_link">
+                  {l s='View larger'}
+                </span>
+              {/if}
+            </span>
+          {/if}
+        </div> <!-- end image-block -->
+        {if isset($images) && count($images) > 0}
+          <!-- thumbnails -->
+          <div id="views_block" class="clearfix {if isset($images) && count($images) < 2}hidden{/if}">
+            {if isset($images) && count($images) > 2}
+              <span class="view_scroll_spacer">
+                <a id="view_scroll_left" class="" title="{l s='Other views'}" href="javascript:{ldelim}{rdelim}">
+                  {l s='Previous'}
+                </a>
+              </span>
+            {/if}
+            <div id="thumbs_list">
+              <ul id="thumbs_list_frame">
+                {if isset($images)}
+                  {foreach from=$images item=image name=thumbnails}
+                    {assign var=imageIds value="`$product->id`-`$image.id_image`"}
+                    {if !empty($image.legend)}
+                      {assign var=imageTitle value=$image.legend|escape:'html':'UTF-8'}
+                    {else}
+                      {assign var=imageTitle value=$product->name|escape:'html':'UTF-8'}
+                    {/if}
+                    <li id="thumbnail_{$image.id_image}"{if $smarty.foreach.thumbnails.last} class="last"{/if}>
+                      <a{if $jqZoomEnabled && $have_image && !$content_only} href="javascript:void(0);" rel="{literal}{{/literal}gallery: 'gal1', smallimage: '{$link->getImageLink($product->link_rewrite, $imageIds, 'large_default')|escape:'html':'UTF-8'}',largeimage: '{$link->getImageLink($product->link_rewrite, $imageIds, 'thickbox_default')|escape:'html':'UTF-8'}'{literal}}{/literal}"{else} href="{$link->getImageLink($product->link_rewrite, $imageIds, 'thickbox_default')|escape:'html':'UTF-8'}" data-fancybox-group="other-views" class="fancybox{if $image.id_image == $cover.id_image} shown{/if}"{/if} title="{$imageTitle}">
+                        <img class="img-responsive" id="thumb_{$image.id_image}" src="{$link->getImageLink($product->link_rewrite, $imageIds, 'cart_default')|escape:'html':'UTF-8'}" alt="{$imageTitle}" title="{$imageTitle}"{if isset($cartSize)} height="{$cartSize.height}" width="{$cartSize.width}"{/if} itemprop="image" />
+                      </a>
+                    </li>
+                  {/foreach}
+                {/if}
+              </ul>
+            </div> <!-- end thumbs_list -->
+            {if isset($images) && count($images) > 2}
+              <a id="view_scroll_right" title="{l s='Other views'}" href="javascript:{ldelim}{rdelim}">
+                {l s='Next'}
+              </a>
+            {/if}
+          </div> <!-- end views-block -->
+          <!-- end thumbnails -->
+        {/if}
+        {if isset($images) && count($images) > 1}
+          <p class="resetimg clear no-print">
+            <span id="wrapResetImages" style="display: none;">
+              <a href="{$link->getProductLink($product)|escape:'html':'UTF-8'}" data-id="resetImages">
+                <i class="icon-repeat"></i>
+                {l s='Display all pictures'}
+              </a>
+            </span>
+          </p>
+        {/if}
+      </div> <!-- end pb-left-column -->
+      <!-- end left infos-->
+      <!-- center infos -->
+      <div class="pb-center-column col-xs-12 col-sm-4">
+        {if $product->online_only}
+          <p class="online_only">{l s='Online only'}</p>
+        {/if}
+        <h1 itemprop="name">{$product->name|escape:'html':'UTF-8'}</h1>
+        <p id="product_reference"{if empty($product->reference) || !$product->reference} style="display: none;"{/if}>
+          <label>{l s='Reference:'} </label>
+          <span class="editable" itemprop="sku"{if !empty($product->reference) && $product->reference} content="{$product->reference}"{/if}>{if !isset($groups)}{$product->reference|escape:'html':'UTF-8'}{/if}</span>
+        </p>
+        {if !$product->is_virtual && $product->condition}
+          <p id="product_condition">
+            <label>{l s='Condition:'} </label>
+            {if $product->condition == 'new'}
+              <link itemprop="itemCondition" href="https://schema.org/NewCondition"/>
+              <span class="editable">{l s='New product'}</span>
+            {elseif $product->condition == 'used'}
+              <link itemprop="itemCondition" href="https://schema.org/UsedCondition"/>
+              <span class="editable">{l s='Used'}</span>
+            {elseif $product->condition == 'refurbished'}
+              <link itemprop="itemCondition" href="https://schema.org/RefurbishedCondition"/>
+              <span class="editable">{l s='Refurbished'}</span>
+            {/if}
+          </p>
+        {/if}
+        {if $product->description_short || $packItems|@count > 0}
+          <div id="short_description_block">
+            {if $product->description_short}
+              <div id="short_description_content" class="rte align_justify" itemprop="description">{$product->description_short}</div>
+            {/if}
+
+            {if $product->description}
+              <p class="buttons_bottom_block">
+                <a href="javascript:{ldelim}{rdelim}" class="button">
+                  {l s='More details'}
+                </a>
+              </p>
+            {/if}
+            <!--{if $packItems|@count > 0}
+                <div class="short_description_pack">
+                <h3>{l s='Pack content'}</h3>
+                  {foreach from=$packItems item=packItem}
+
+                  <div class="pack_content">
+                      {$packItem.pack_quantity} x <a href="{$link->getProductLink($packItem.id_product, $packItem.link_rewrite, $packItem.category)|escape:'html':'UTF-8'}">{$packItem.name|escape:'html':'UTF-8'}</a>
+                      <p>{$packItem.description_short}</p>
+                  </div>
+                  {/foreach}
+                </div>
+              {/if}-->
+          </div> <!-- end short_description_block -->
+        {/if}
+        {if ($display_qties == 1 && !$PS_CATALOG_MODE && $PS_STOCK_MANAGEMENT && $product->available_for_order)}
+          <!-- number of item in stock -->
+          <p id="pQuantityAvailable"{if $product->quantity <= 0} style="display: none;"{/if}>
+            <span id="quantityAvailable">{$product->quantity|intval}</span>
+            <span {if $product->quantity > 1} style="display: none;"{/if} id="quantityAvailableTxt">{l s='Item'}</span>
+            <span {if $product->quantity == 1} style="display: none;"{/if} id="quantityAvailableTxtMultiple">{l s='Items'}</span>
+          </p>
+        {/if}
+        <!-- availability or doesntExist -->
+        <p id="availability_statut"{if !$PS_STOCK_MANAGEMENT || ($product->quantity <= 0 && !$product->available_later && $allow_oosp) || ($product->quantity > 0 && !$product->available_now) || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
+          {*<span id="availability_label">{l s='Availability:'}</span>*}
+          <span id="availability_value" class="label{if $product->quantity <= 0 && !$allow_oosp} label-danger{elseif $product->quantity <= 0} label-warning{else} label-success{/if}">{if $product->quantity <= 0}{if $PS_STOCK_MANAGEMENT && $allow_oosp}{$product->available_later}{else}{l s='This product is no longer in stock'}{/if}{elseif $PS_STOCK_MANAGEMENT}{$product->available_now}{/if}</span>
+        </p>
+        {if $PS_STOCK_MANAGEMENT}
+          {if !$product->is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
+          <p class="warning_inline" id="last_quantities"{if ($product->quantity > $last_qties || $product->quantity <= 0) || $allow_oosp || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none"{/if} >{l s='Warning: Last items in stock!'}</p>
+        {/if}
+        <p id="availability_date"{if ($product->quantity > 0) || !$product->available_for_order || $PS_CATALOG_MODE || !isset($product->available_date) || $product->available_date < $smarty.now|date_format:'%Y-%m-%d'} style="display: none;"{/if}>
+          <span id="availability_date_label">{l s='Availability date:'}</span>
+          <span id="availability_date_value">{if Validate::isDate($product->available_date)}{dateFormat date=$product->available_date full=false}{/if}</span>
+        </p>
+        <!-- Out of stock hook -->
+        <div id="oosHook"{if $product->quantity > 0} style="display: none;"{/if}>
+          {$HOOK_PRODUCT_OOS}
+        </div>
+        {if isset($HOOK_EXTRA_RIGHT) && $HOOK_EXTRA_RIGHT}{$HOOK_EXTRA_RIGHT}{/if}
+        {if !$content_only}
+          <!-- usefull links-->
+          <ul id="usefull_link_block" class="clearfix no-print">
+            {if $HOOK_EXTRA_LEFT}{$HOOK_EXTRA_LEFT}{/if}
+            <li class="print">
+              <a href="javascript:print();">
+                {l s='Print'}
+              </a>
+            </li>
+          </ul>
+        {/if}
+      </div>
+      <!-- end center infos-->
+      <!-- pb-right-column-->
+      <div class="pb-right-column col-xs-12 col-sm-4 col-md-3">
+        {if ($product->show_price && !isset($restricted_country_mode)) || isset($groups) || $product->reference || (isset($HOOK_PRODUCT_ACTIONS) && $HOOK_PRODUCT_ACTIONS)}
+          <!-- add to cart form-->
+          <form id="buy_block"{if $PS_CATALOG_MODE && !isset($groups) && $product->quantity > 0} class="hidden"{/if} action="{$link->getPageLink('cart')|escape:'html':'UTF-8'}" method="post">
+            <!-- hidden datas -->
+            <p class="hidden">
+              <input type="hidden" name="token" value="{$static_token}" />
+              <input type="hidden" name="id_product" value="{$product->id|intval}" id="product_page_product_id" />
+              <input type="hidden" name="add" value="1" />
+              <input type="hidden" name="id_product_attribute" id="idCombination" value="" />
+            </p>
+            <div class="box-info-product">
+              <div class="content_prices clearfix">
+                {if $product->show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
+                  <!-- prices -->
+                  <div>
+                    <p class="our_price_display" itemprop="offers" itemscope itemtype="https://schema.org/Offer">{strip}
+                        {if $product->quantity > 0}<link itemprop="availability" href="https://schema.org/InStock"/>{/if}
+                        {if $priceDisplay >= 0 && $priceDisplay <= 2}
+                          <span id="our_price_display" class="price" itemprop="price" content="{$productPrice}">{convertPrice price=$productPrice|floatval}</span>
+                          {if $tax_enabled  && ((isset($display_tax_label) && $display_tax_label == 1) || !isset($display_tax_label))}
+                            {if $priceDisplay == 1} {l s='tax excl.'}{else} {l s='tax incl.'}{/if}
+                          {/if}
+                          <meta itemprop="priceCurrency" content="{$currency->iso_code}" />
+                          {hook h="displayProductPriceBlock" product=$product type="price"}
+                        {/if}
+                      {/strip}</p>
+                    <p id="reduction_percent" {if $productPriceWithoutReduction <= 0 || !$product->specificPrice || $product->specificPrice.reduction_type != 'percentage'} style="display:none;"{/if}>{strip}
+                        <span id="reduction_percent_display">
                                         {if $product->specificPrice && $product->specificPrice.reduction_type == 'percentage'}-{$product->specificPrice.reduction*100}%{/if}
                                     </span>
-                                {/strip}</p>
-                                <p id="reduction_amount" {if $productPriceWithoutReduction <= 0 || !$product->specificPrice || $product->specificPrice.reduction_type != 'amount' || $product->specificPrice.reduction|floatval ==0} style="display:none"{/if}>{strip}
-                                    <span id="reduction_amount_display">
+                      {/strip}</p>
+                    <p id="reduction_amount" {if $productPriceWithoutReduction <= 0 || !$product->specificPrice || $product->specificPrice.reduction_type != 'amount' || $product->specificPrice.reduction|floatval ==0} style="display:none"{/if}>{strip}
+                        <span id="reduction_amount_display">
                                     {if $product->specificPrice && $product->specificPrice.reduction_type == 'amount' && $product->specificPrice.reduction|floatval !=0}
-                                        -{convertPrice price=$productPriceWithoutReduction|floatval-$productPrice|floatval}
+                                      -{convertPrice price=$productPriceWithoutReduction|floatval-$productPrice|floatval}
                                     {/if}
                                     </span>
-                                {/strip}</p>
-                                <p id="old_price"{if (!$product->specificPrice || !$product->specificPrice.reduction)} class="hidden"{/if}>{strip}
-                                    {if $priceDisplay >= 0 && $priceDisplay <= 2}
-                                        {hook h="displayProductPriceBlock" product=$product type="old_price"}
-                                        <span id="old_price_display"><span class="price">{if $productPriceWithoutReduction > $productPrice}{convertPrice price=$productPriceWithoutReduction|floatval}{/if}</span>{if $productPriceWithoutReduction > $productPrice && $tax_enabled && $display_tax_label == 1} {if $priceDisplay == 1}{l s='tax excl.'}{else}{l s='tax incl.'}{/if}{/if}</span>
-                                    {/if}
-                                {/strip}</p>
-                                {if $priceDisplay == 2}
-                                    <br />
-                                    <span id="pretaxe_price">{strip}
+                      {/strip}</p>
+                    <p id="old_price"{if (!$product->specificPrice || !$product->specificPrice.reduction)} class="hidden"{/if}>{strip}
+                        {if $priceDisplay >= 0 && $priceDisplay <= 2}
+                          {hook h="displayProductPriceBlock" product=$product type="old_price"}
+                          <span id="old_price_display"><span class="price">{if $productPriceWithoutReduction > $productPrice}{convertPrice price=$productPriceWithoutReduction|floatval}{/if}</span>{if $productPriceWithoutReduction > $productPrice && $tax_enabled && $display_tax_label == 1} {if $priceDisplay == 1}{l s='tax excl.'}{else}{l s='tax incl.'}{/if}{/if}</span>
+                        {/if}
+                      {/strip}</p>
+                    {if $priceDisplay == 2}
+                      <br />
+                      <span id="pretaxe_price">{strip}
                                         <span id="pretaxe_price_display">{convertPrice price=$product->getPrice(false, $smarty.const.NULL)}</span> {l s='tax excl.'}
                                     {/strip}</span>
-                                {/if}
-                            </div> <!-- end prices -->
-                            {if $packItems|@count && $productPrice < $product->getNoPackPrice()}
-                                <p class="pack_price">{l s='Instead of'} <span style="text-decoration: line-through;">{convertPrice price=$product->getNoPackPrice()}</span></p>
-                            {/if}
-                            {if $product->ecotax != 0}
-                                <p class="price-ecotax">{l s='Including'} <span id="ecotax_price_display">{if $priceDisplay == 2}{$ecotax_tax_exc|convertAndFormatPrice}{else}{$ecotax_tax_inc|convertAndFormatPrice}{/if}</span> {l s='for ecotax'}
-                                    {if $product->specificPrice && $product->specificPrice.reduction}
-                                    <br />{l s='(not impacted by the discount)'}
-                                    {/if}
-                                </p>
-                            {/if}
-                            {if !empty($product->unity) && $product->unit_price_ratio > 0.000000}
-                                {math equation="pprice / punit_price" pprice=$productPrice  punit_price=$product->unit_price_ratio assign=unit_price}
-                                <p class="unit-price"><span id="unit_price_display">{convertPrice price=$unit_price}</span> {l s='per'} {$product->unity|escape:'html':'UTF-8'}</p>
-                                {hook h="displayProductPriceBlock" product=$product type="unit_price"}
-                            {/if}
-                        {/if} {*close if for show price*}
-                        {hook h="displayProductPriceBlock" product=$product type="weight" hook_origin='product_sheet'}
-                        {hook h="displayProductPriceBlock" product=$product type="after_price"}
-                        <div class="clear"></div>
-                    </div> <!-- end content_prices -->
-                    <div class="product_attributes clearfix">
-                        <!-- quantity wanted -->
-                        {if !$PS_CATALOG_MODE}
-                        <p id="quantity_wanted_p"{if (!$allow_oosp && $product->quantity <= 0) || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
-                            <label for="quantity_wanted">{l s='Quantity'}</label>
-                            <input type="number" min="1" name="qty" id="quantity_wanted" class="text" value="{if isset($quantityBackup)}{$quantityBackup|intval}{else}{if $product->minimal_quantity > 1}{$product->minimal_quantity}{else}1{/if}{/if}" />
-                            <a href="#" data-field-qty="qty" class="btn btn-default button-minus product_quantity_down">
-                                <span><i class="icon-minus"></i></span>
-                            </a>
-                            <a href="#" data-field-qty="qty" class="btn btn-default button-plus product_quantity_up">
-                                <span><i class="icon-plus"></i></span>
-                            </a>
-                            <span class="clearfix"></span>
-                        </p>
-                        {/if}
-                        <!-- minimal quantity wanted -->
-                        <p id="minimal_quantity_wanted_p"{if $product->minimal_quantity <= 1 || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
-                            {l s='The minimum purchase order quantity for the product is'} <b id="minimal_quantity_label">{$product->minimal_quantity}</b>
-                        </p>
-                        {if isset($groups)}
-                            <!-- attributes -->
-                            <div id="attributes">
-                                <div class="clearfix"></div>
-                                {foreach from=$groups key=id_attribute_group item=group}
-                                    {if $group.attributes|@count}
-                                        <fieldset class="attribute_fieldset">
-                                            <label class="attribute_label" {if $group.group_type != 'color' && $group.group_type != 'radio'}for="group_{$id_attribute_group|intval}"{/if}>{$group.name|escape:'html':'UTF-8'}&nbsp;</label>
-                                            {assign var="groupName" value="group_$id_attribute_group"}
-                                            <div class="attribute_list">
-                                                {if ($group.group_type == 'select')}
-                                                    <select name="{$groupName}" id="group_{$id_attribute_group|intval}" class="form-control attribute_select no-print">
-                                                        {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                                                            <option value="{$id_attribute|intval}"{if (isset($smarty.get.$groupName) && $smarty.get.$groupName|intval == $id_attribute) || $group.default == $id_attribute} selected="selected"{/if} title="{$group_attribute|escape:'html':'UTF-8'}">{$group_attribute|escape:'html':'UTF-8'}</option>
-                                                        {/foreach}
-                                                    </select>
-                                                {elseif ($group.group_type == 'color')}
-                                                    <ul id="color_to_pick_list" class="clearfix">
-                                                        {assign var="default_colorpicker" value=""}
-                                                        {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                                                            {assign var='img_color_exists' value=file_exists($col_img_dir|cat:$id_attribute|cat:'.jpg')}
-                                                            <li{if $group.default == $id_attribute} class="selected"{/if}>
-                                                                <a href="{$link->getProductLink($product)|escape:'html':'UTF-8'}" id="color_{$id_attribute|intval}" name="{$colors.$id_attribute.name|escape:'html':'UTF-8'}" class="color_pick{if ($group.default == $id_attribute)} selected{/if}"{if !$img_color_exists && isset($colors.$id_attribute.value) && $colors.$id_attribute.value} style="background:{$colors.$id_attribute.value|escape:'html':'UTF-8'};"{/if} title="{$colors.$id_attribute.name|escape:'html':'UTF-8'}">
-                                                                    {if $img_color_exists}
-                                                                        <img src="{$img_col_dir}{$id_attribute|intval}.jpg" alt="{$colors.$id_attribute.name|escape:'html':'UTF-8'}" title="{$colors.$id_attribute.name|escape:'html':'UTF-8'}" width="20" height="20" />
-                                                                    {/if}
-                                                                </a>
-                                                            </li>
-                                                            {if ($group.default == $id_attribute)}
-                                                                {$default_colorpicker = $id_attribute}
-                                                            {/if}
-                                                        {/foreach}
-                                                    </ul>
-                                                    <input type="hidden" class="color_pick_hidden" name="{$groupName|escape:'html':'UTF-8'}" value="{$default_colorpicker|intval}" />
-                                                {elseif ($group.group_type == 'radio')}
-                                                    <ul>
-                                                        {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                                                            <li>
-                                                                <input type="radio" class="attribute_radio" name="{$groupName|escape:'html':'UTF-8'}" value="{$id_attribute}" {if ($group.default == $id_attribute)} checked="checked"{/if} />
-                                                                <span>{$group_attribute|escape:'html':'UTF-8'}</span>
-                                                            </li>
-                                                        {/foreach}
-                                                    </ul>
-                                                {/if}
-                                            </div> <!-- end attribute_list -->
-                                        </fieldset>
-                                    {/if}
+                    {/if}
+                  </div> <!-- end prices -->
+                  {if $packItems|@count && $productPrice < $product->getNoPackPrice()}
+                    <p class="pack_price">{l s='Instead of'} <span style="text-decoration: line-through;">{convertPrice price=$product->getNoPackPrice()}</span></p>
+                  {/if}
+                  {if $product->ecotax != 0}
+                    <p class="price-ecotax">{l s='Including'} <span id="ecotax_price_display">{if $priceDisplay == 2}{$ecotax_tax_exc|convertAndFormatPrice}{else}{$ecotax_tax_inc|convertAndFormatPrice}{/if}</span> {l s='for ecotax'}
+                      {if $product->specificPrice && $product->specificPrice.reduction}
+                        <br />{l s='(not impacted by the discount)'}
+                      {/if}
+                    </p>
+                  {/if}
+                  {if !empty($product->unity) && $product->unit_price_ratio > 0.000000}
+                    {math equation="pprice / punit_price" pprice=$productPrice  punit_price=$product->unit_price_ratio assign=unit_price}
+                    <p class="unit-price"><span id="unit_price_display">{convertPrice price=$unit_price}</span> {l s='per'} {$product->unity|escape:'html':'UTF-8'}</p>
+                    {hook h="displayProductPriceBlock" product=$product type="unit_price"}
+                  {/if}
+                {/if} {*close if for show price*}
+                {hook h="displayProductPriceBlock" product=$product type="weight" hook_origin='product_sheet'}
+                {hook h="displayProductPriceBlock" product=$product type="after_price"}
+                <div class="clear"></div>
+              </div> <!-- end content_prices -->
+              <div class="product_attributes clearfix">
+                <!-- quantity wanted -->
+                {if !$PS_CATALOG_MODE}
+                  <p id="quantity_wanted_p"{if (!$allow_oosp && $product->quantity <= 0) || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
+                    <label for="quantity_wanted">{l s='Quantity'}</label>
+                    <input type="number" min="1" name="qty" id="quantity_wanted" class="text" value="{if isset($quantityBackup)}{$quantityBackup|intval}{else}{if $product->minimal_quantity > 1}{$product->minimal_quantity}{else}1{/if}{/if}" />
+                    <a href="#" data-field-qty="qty" class="btn btn-default button-minus product_quantity_down">
+                      <span><i class="icon-minus"></i></span>
+                    </a>
+                    <a href="#" data-field-qty="qty" class="btn btn-default button-plus product_quantity_up">
+                      <span><i class="icon-plus"></i></span>
+                    </a>
+                    <span class="clearfix"></span>
+                  </p>
+                {/if}
+                <!-- minimal quantity wanted -->
+                <p id="minimal_quantity_wanted_p"{if $product->minimal_quantity <= 1 || !$product->available_for_order || $PS_CATALOG_MODE} style="display: none;"{/if}>
+                  {l s='The minimum purchase order quantity for the product is'} <b id="minimal_quantity_label">{$product->minimal_quantity}</b>
+                </p>
+                {if isset($groups)}
+                  <!-- attributes -->
+                  <div id="attributes">
+                    <div class="clearfix"></div>
+                    {foreach from=$groups key=id_attribute_group item=group}
+                      {if $group.attributes|@count}
+                        <fieldset class="attribute_fieldset">
+                          <label class="attribute_label" {if $group.group_type != 'color' && $group.group_type != 'radio'}for="group_{$id_attribute_group|intval}"{/if}>{$group.name|escape:'html':'UTF-8'}&nbsp;</label>
+                          {assign var="groupName" value="group_$id_attribute_group"}
+                          <div class="attribute_list">
+                            {if ($group.group_type == 'select')}
+                              <select name="{$groupName}" id="group_{$id_attribute_group|intval}" class="form-control attribute_select no-print">
+                                {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                                  <option value="{$id_attribute|intval}"{if (isset($smarty.get.$groupName) && $smarty.get.$groupName|intval == $id_attribute) || $group.default == $id_attribute} selected="selected"{/if} title="{$group_attribute|escape:'html':'UTF-8'}">{$group_attribute|escape:'html':'UTF-8'}</option>
                                 {/foreach}
-                            </div> <!-- end attributes -->
-                        {/if}
-                    </div> <!-- end product_attributes -->
-                    <div class="box-cart-bottom">
-                        <div{if (!$allow_oosp && $product->quantity <= 0) || !$product->available_for_order || (isset($restricted_country_mode) && $restricted_country_mode) || $PS_CATALOG_MODE} class="unvisible"{/if}>
-                            <p id="add_to_cart" class="buttons_bottom_block no-print">
-                                <button type="submit" name="Submit" class="exclusive">
-                                    <span>{if $content_only && (isset($product->customization_required) && $product->customization_required)}{l s='Customize'}{else}{l s='Add to cart'}{/if}</span>
-                                </button>
-                            </p>
-                        </div>
-                        {if isset($HOOK_PRODUCT_ACTIONS) && $HOOK_PRODUCT_ACTIONS}{$HOOK_PRODUCT_ACTIONS}{/if}
-                    </div> <!-- end box-cart-bottom -->
-                </div> <!-- end box-info-product -->
-            </form>
-            {/if}
-        </div> <!-- end pb-right-column-->
+                              </select>
+                            {elseif ($group.group_type == 'color')}
+                              <ul id="color_to_pick_list" class="clearfix">
+                                {assign var="default_colorpicker" value=""}
+                                {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                                  {assign var='img_color_exists' value=file_exists($col_img_dir|cat:$id_attribute|cat:'.jpg')}
+                                  <li{if $group.default == $id_attribute} class="selected"{/if}>
+                                    <a href="{$link->getProductLink($product)|escape:'html':'UTF-8'}" id="color_{$id_attribute|intval}" name="{$colors.$id_attribute.name|escape:'html':'UTF-8'}" class="color_pick{if ($group.default == $id_attribute)} selected{/if}"{if !$img_color_exists && isset($colors.$id_attribute.value) && $colors.$id_attribute.value} style="background:{$colors.$id_attribute.value|escape:'html':'UTF-8'};"{/if} title="{$colors.$id_attribute.name|escape:'html':'UTF-8'}">
+                                      {if $img_color_exists}
+                                        <img src="{$img_col_dir}{$id_attribute|intval}.jpg" alt="{$colors.$id_attribute.name|escape:'html':'UTF-8'}" title="{$colors.$id_attribute.name|escape:'html':'UTF-8'}" width="20" height="20" />
+                                      {/if}
+                                    </a>
+                                  </li>
+                                  {if ($group.default == $id_attribute)}
+                                    {$default_colorpicker = $id_attribute}
+                                  {/if}
+                                {/foreach}
+                              </ul>
+                              <input type="hidden" class="color_pick_hidden" name="{$groupName|escape:'html':'UTF-8'}" value="{$default_colorpicker|intval}" />
+                            {elseif ($group.group_type == 'radio')}
+                              <ul>
+                                {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                                  <li>
+                                    <input type="radio" class="attribute_radio" name="{$groupName|escape:'html':'UTF-8'}" value="{$id_attribute}" {if ($group.default == $id_attribute)} checked="checked"{/if} />
+                                    <span>{$group_attribute|escape:'html':'UTF-8'}</span>
+                                  </li>
+                                {/foreach}
+                              </ul>
+                            {/if}
+                          </div> <!-- end attribute_list -->
+                        </fieldset>
+                      {/if}
+                    {/foreach}
+                  </div> <!-- end attributes -->
+                {/if}
+              </div> <!-- end product_attributes -->
+              <div class="box-cart-bottom">
+                <div{if (!$allow_oosp && $product->quantity <= 0) || !$product->available_for_order || (isset($restricted_country_mode) && $restricted_country_mode) || $PS_CATALOG_MODE} class="unvisible"{/if}>
+                  <p id="add_to_cart" class="buttons_bottom_block no-print">
+                    <button type="submit" name="Submit" class="exclusive">
+                      <span>{if $content_only && (isset($product->customization_required) && $product->customization_required)}{l s='Customize'}{else}{l s='Add to cart'}{/if}</span>
+                    </button>
+                  </p>
+                </div>
+                {if isset($HOOK_PRODUCT_ACTIONS) && $HOOK_PRODUCT_ACTIONS}{$HOOK_PRODUCT_ACTIONS}{/if}
+              </div> <!-- end box-cart-bottom -->
+            </div> <!-- end box-info-product -->
+          </form>
+        {/if}
+      </div> <!-- end pb-right-column-->
     </div> <!-- end primary_block -->
     {if !$content_only}
-{if (isset($quantity_discounts) && count($quantity_discounts) > 0)}
-            <!-- quantity discount -->
-            <section class="page-product-box">
-                <h3 class="page-product-heading">{l s='Volume discounts'}</h3>
-                <div id="quantityDiscount">
-                    <table class="std table-product-discounts">
-                        <thead>
-                            <tr>
-                                <th>{l s='Quantity'}</th>
-                                <th>{if $display_discount_price}{l s='Price'}{else}{l s='Discount'}{/if}</th>
-                                <th>{l s='You Save'}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {foreach from=$quantity_discounts item='quantity_discount' name='quantity_discounts'}
-                            {if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
-                                {$realDiscountPrice=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
-                            {else}
-                                {$realDiscountPrice=$productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
-                            {/if}
-                            <tr id="quantityDiscount_{$quantity_discount.id_product_attribute}" class="quantityDiscount_{$quantity_discount.id_product_attribute}" data-real-discount-value="{convertPrice price = $realDiscountPrice}" data-discount-type="{$quantity_discount.reduction_type}" data-discount="{$quantity_discount.real_value|floatval}" data-discount-quantity="{$quantity_discount.quantity|intval}">
-                                <td>
-                                    {$quantity_discount.quantity|intval}
-                                </td>
-                                <td>
-                                    {if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
-                                        {if $display_discount_price}
-                                            {if $quantity_discount.reduction_tax == 0 && !$quantity_discount.price}
-                                                {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction_with_tax)|floatval}
-                                            {else}
-                                                {convertPrice price=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
-                                            {/if}
-                                        {else}
-                                            {convertPrice price=$quantity_discount.real_value|floatval}
-                                        {/if}
-                                    {else}
-                                        {if $display_discount_price}
-                                            {if $quantity_discount.reduction_tax == 0}
-                                                {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction_with_tax)|floatval}
-                                            {else}
-                                                {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
-                                            {/if}
-                                        {else}
-                                            {$quantity_discount.real_value|floatval}%
-                                        {/if}
-                                    {/if}
-                                </td>
-                                <td>
-                                    <span>{l s='Up to'}</span>
-                                    {if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
-                                        {$discountPrice=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
-                                    {else}
-                                        {$discountPrice=$productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
-                                    {/if}
-                                    {$discountPrice=$discountPrice * $quantity_discount.quantity}
-                                    {$qtyProductPrice=$productPriceWithoutReduction|floatval * $quantity_discount.quantity}
-                                    {convertPrice price=$qtyProductPrice - $discountPrice}
-                                </td>
-                            </tr>
-                        {/foreach}
-                        </tbody>
-                    </table>
-                </div>
-            </section>
-        {/if}
-        {if isset($features) && $features}
-            <!-- Data sheet -->
-            <section class="page-product-box">
-                <h3 class="page-product-heading">{l s='Data sheet'}</h3>
-                <table class="table-data-sheet">
-                    {foreach from=$features item=feature}
-                    <tr class="{cycle values="odd,even"}">
-                        {if isset($feature.value)}
-                        <td>{$feature.name|escape:'html':'UTF-8'}</td>
-                        <td>{$feature.value|escape:'html':'UTF-8'}</td>
-                        {/if}
-                    </tr>
-                    {/foreach}
-                </table>
-            </section>
-            <!--end Data sheet -->
-        {/if}
-        {if isset($product) && $product->description}
-            <!-- More info -->
-            <section class="page-product-box">
-                <h3 class="page-product-heading">{l s='More info'}</h3>
-                <!-- full description -->
-                <div  class="rte">{$product->description}</div>
-            </section>
-            <!--end  More info -->
-        {/if}
-        {if isset($packItems) && $packItems|@count > 0}
-        <section id="blockpack">
-            <h3 class="page-product-heading">{l s='Pack content'}</h3>
-            {include file="$tpl_dir./product-list.tpl" products=$packItems}
-        </section>
-        {/if}
-        <!--HOOK_PRODUCT_TAB -->
+      {if (isset($quantity_discounts) && count($quantity_discounts) > 0)}
+        <!-- quantity discount -->
         <section class="page-product-box">
-            {$HOOK_PRODUCT_TAB}
-            {if isset($HOOK_PRODUCT_TAB_CONTENT) && $HOOK_PRODUCT_TAB_CONTENT}{$HOOK_PRODUCT_TAB_CONTENT}{/if}
+          <h3 class="page-product-heading">{l s='Volume discounts'}</h3>
+          <div id="quantityDiscount">
+            <table class="std table-product-discounts">
+              <thead>
+              <tr>
+                <th>{l s='Quantity'}</th>
+                <th>{if $display_discount_price}{l s='Price'}{else}{l s='Discount'}{/if}</th>
+                <th>{l s='You Save'}</th>
+              </tr>
+              </thead>
+              <tbody>
+              {foreach from=$quantity_discounts item='quantity_discount' name='quantity_discounts'}
+                {if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
+                  {$realDiscountPrice=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
+                {else}
+                  {$realDiscountPrice=$productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
+                {/if}
+                <tr id="quantityDiscount_{$quantity_discount.id_product_attribute}" class="quantityDiscount_{$quantity_discount.id_product_attribute}" data-real-discount-value="{convertPrice price = $realDiscountPrice}" data-discount-type="{$quantity_discount.reduction_type}" data-discount="{$quantity_discount.real_value|floatval}" data-discount-quantity="{$quantity_discount.quantity|intval}">
+                  <td>
+                    {$quantity_discount.quantity|intval}
+                  </td>
+                  <td>
+                    {if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
+                      {if $display_discount_price}
+                        {if $quantity_discount.reduction_tax == 0 && !$quantity_discount.price}
+                          {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction_with_tax)|floatval}
+                        {else}
+                          {convertPrice price=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
+                        {/if}
+                      {else}
+                        {convertPrice price=$quantity_discount.real_value|floatval}
+                      {/if}
+                    {else}
+                      {if $display_discount_price}
+                        {if $quantity_discount.reduction_tax == 0}
+                          {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction_with_tax)|floatval}
+                        {else}
+                          {convertPrice price = $productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
+                        {/if}
+                      {else}
+                        {$quantity_discount.real_value|floatval}%
+                      {/if}
+                    {/if}
+                  </td>
+                  <td>
+                    <span>{l s='Up to'}</span>
+                    {if $quantity_discount.price >= 0 || $quantity_discount.reduction_type == 'amount'}
+                      {$discountPrice=$productPriceWithoutReduction|floatval-$quantity_discount.real_value|floatval}
+                    {else}
+                      {$discountPrice=$productPriceWithoutReduction|floatval-($productPriceWithoutReduction*$quantity_discount.reduction)|floatval}
+                    {/if}
+                    {$discountPrice=$discountPrice * $quantity_discount.quantity}
+                    {$qtyProductPrice=$productPriceWithoutReduction|floatval * $quantity_discount.quantity}
+                    {convertPrice price=$qtyProductPrice - $discountPrice}
+                  </td>
+                </tr>
+              {/foreach}
+              </tbody>
+            </table>
+          </div>
         </section>
-        <!--end HOOK_PRODUCT_TAB -->
-        {if isset($accessories) && $accessories}
-            <!--Accessories -->
-            <section class="page-product-box">
-                <h3 class="page-product-heading">{l s='Accessories'}</h3>
-                <div class="block products_block accessories-block clearfix">
-                    <div class="block_content">
-                        <ul id="bxslider" class="bxslider clearfix">
-                            {foreach from=$accessories item=accessory name=accessories_list}
-                                {if ($accessory.allow_oosp || $accessory.quantity_all_versions > 0 || $accessory.quantity > 0) && $accessory.available_for_order && !isset($restricted_country_mode)}
-                                    {assign var='accessoryLink' value=$link->getProductLink($accessory.id_product, $accessory.link_rewrite, $accessory.category)}
-                                    <li class="item product-box ajax_block_product{if $smarty.foreach.accessories_list.first} first_item{elseif $smarty.foreach.accessories_list.last} last_item{else} item{/if} product_accessories_description">
-                                        <div class="product_desc">
-                                            <a href="{$accessoryLink|escape:'html':'UTF-8'}" title="{$accessory.legend|escape:'html':'UTF-8'}" class="product-image product_image">
-                                                <img class="lazyOwl" src="{$link->getImageLink($accessory.link_rewrite, $accessory.id_image, 'home_default')|escape:'html':'UTF-8'}" alt="{$accessory.legend|escape:'html':'UTF-8'}" width="{$homeSize.width}" height="{$homeSize.height}"/>
-                                            </a>
-                                            <div class="block_description">
-                                                <a href="{$accessoryLink|escape:'html':'UTF-8'}" title="{l s='More'}" class="product_description">
-                                                    {$accessory.description_short|strip_tags|truncate:25:'...'}
-                                                </a>
-                                            </div>
-                                        </div>
-                                        <div class="s_title_block">
-                                            <h5 itemprop="name" class="product-name">
-                                                <a href="{$accessoryLink|escape:'html':'UTF-8'}">
-                                                    {$accessory.name|truncate:20:'...':true|escape:'html':'UTF-8'}
-                                                </a>
-                                            </h5>
-                                            {if $accessory.show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
-                                            <span class="price">
-                                                {if $priceDisplay != 1}
-                                                    {displayWtPrice p=$accessory.price}
-                                                {else}
-                                                    {displayWtPrice p=$accessory.price_tax_exc}
-                                                {/if}
-                                                {hook h="displayProductPriceBlock" product=$accessory type="price"}
-                                            </span>
-                                            {/if}
-                                            {hook h="displayProductPriceBlock" product=$accessory type="after_price"}
-                                        </div>
-                                        <div class="clearfix" style="margin-top:5px">
-                                            {if !$PS_CATALOG_MODE && ($accessory.allow_oosp || $accessory.quantity > 0) && isset($add_prod_display) && $add_prod_display == 1}
-                                                <div class="no-print">
-                                                    <a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$accessory.id_product|intval}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" data-id-product="{$accessory.id_product|intval}" title="{l s='Add to cart'}">
-                                                        <span>{l s='Add to cart'}</span>
-                                                    </a>
-                                                </div>
-                                            {/if}
-                                        </div>
-                                    </li>
-                                {/if}
-                            {/foreach}
-                        </ul>
-                    </div>
-                </div>
-            </section>
-            <!--end Accessories -->
-        {/if}
-        {if isset($HOOK_PRODUCT_FOOTER) && $HOOK_PRODUCT_FOOTER}{$HOOK_PRODUCT_FOOTER}{/if}
-        <!-- description & features -->
-        {if (isset($product) && $product->description) || (isset($features) && $features) || (isset($accessories) && $accessories) || (isset($HOOK_PRODUCT_TAB) && $HOOK_PRODUCT_TAB) || (isset($attachments) && $attachments) || isset($product) && $product->customizable}
-            {if isset($attachments) && $attachments}
-            <!--Download -->
-            <section class="page-product-box">
-                <h3 class="page-product-heading">{l s='Download'}</h3>
-                {foreach from=$attachments item=attachment name=attachements}
-                    {if $smarty.foreach.attachements.iteration %3 == 1}<div class="row">{/if}
-                        <div class="col-lg-4">
-                            <h4><a href="{$link->getPageLink('attachment', true, NULL, "id_attachment={$attachment.id_attachment}")|escape:'html':'UTF-8'}">{$attachment.name|escape:'html':'UTF-8'}</a></h4>
-                            <p class="text-muted">{$attachment.description|escape:'html':'UTF-8'}</p>
-                            <a class="btn btn-default btn-block" href="{$link->getPageLink('attachment', true, NULL, "id_attachment={$attachment.id_attachment}")|escape:'html':'UTF-8'}">
-                                <i class="icon-download"></i>
-                                {l s="Download"} ({Tools::formatBytes($attachment.file_size, 2)})
+      {/if}
+      {if isset($features) && $features}
+        <!-- Data sheet -->
+        <section class="page-product-box">
+          <h3 class="page-product-heading">{l s='Data sheet'}</h3>
+          <table class="table-data-sheet">
+            {foreach from=$features item=feature}
+              <tr class="{cycle values="odd,even"}">
+                {if isset($feature.value)}
+                  <td>{$feature.name|escape:'html':'UTF-8'}</td>
+                  <td>{$feature.value|escape:'html':'UTF-8'}</td>
+                {/if}
+              </tr>
+            {/foreach}
+          </table>
+        </section>
+        <!--end Data sheet -->
+      {/if}
+      {if isset($product) && $product->description}
+        <!-- More info -->
+        <section class="page-product-box">
+          <h3 class="page-product-heading">{l s='More info'}</h3>
+          <!-- full description -->
+          <div  class="rte">{$product->description}</div>
+        </section>
+        <!--end  More info -->
+      {/if}
+      {if isset($packItems) && $packItems|@count > 0}
+        <section id="blockpack">
+          <h3 class="page-product-heading">{l s='Pack content'}</h3>
+          {include file="$tpl_dir./product-list.tpl" products=$packItems}
+        </section>
+      {/if}
+      <!--HOOK_PRODUCT_TAB -->
+      <section class="page-product-box">
+        {$HOOK_PRODUCT_TAB}
+        {if isset($HOOK_PRODUCT_TAB_CONTENT) && $HOOK_PRODUCT_TAB_CONTENT}{$HOOK_PRODUCT_TAB_CONTENT}{/if}
+      </section>
+      <!--end HOOK_PRODUCT_TAB -->
+      {if isset($accessories) && $accessories}
+        <!--Accessories -->
+        <section class="page-product-box">
+          <h3 class="page-product-heading">{l s='Accessories'}</h3>
+          <div class="block products_block accessories-block clearfix">
+            <div class="block_content">
+              <ul id="bxslider" class="bxslider clearfix">
+                {foreach from=$accessories item=accessory name=accessories_list}
+                  {if ($accessory.allow_oosp || $accessory.quantity_all_versions > 0 || $accessory.quantity > 0) && $accessory.available_for_order && !isset($restricted_country_mode)}
+                    {assign var='accessoryLink' value=$link->getProductLink($accessory.id_product, $accessory.link_rewrite, $accessory.category)}
+                    <li class="item product-box ajax_block_product{if $smarty.foreach.accessories_list.first} first_item{elseif $smarty.foreach.accessories_list.last} last_item{else} item{/if} product_accessories_description">
+                      <div class="product_desc">
+                        <a href="{$accessoryLink|escape:'html':'UTF-8'}" title="{$accessory.legend|escape:'html':'UTF-8'}" class="product-image product_image">
+                          <img class="lazyOwl" src="{$link->getImageLink($accessory.link_rewrite, $accessory.id_image, 'home_default')|escape:'html':'UTF-8'}" alt="{$accessory.legend|escape:'html':'UTF-8'}" width="{$homeSize.width}" height="{$homeSize.height}"/>
+                        </a>
+                        <div class="block_description">
+                          <a href="{$accessoryLink|escape:'html':'UTF-8'}" title="{l s='More'}" class="product_description">
+                            {$accessory.description_short|strip_tags|truncate:25:'...'}
+                          </a>
+                        </div>
+                      </div>
+                      <div class="s_title_block">
+                        <h5 itemprop="name" class="product-name">
+                          <a href="{$accessoryLink|escape:'html':'UTF-8'}">
+                            {$accessory.name|truncate:20:'...':true|escape:'html':'UTF-8'}
+                          </a>
+                        </h5>
+                        {if $accessory.show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
+                          <span class="price">
+                            {if $priceDisplay != 1}
+                              {displayWtPrice p=$accessory.price}
+                            {else}
+                              {displayWtPrice p=$accessory.price_tax_exc}
+                            {/if}
+                            {hook h="displayProductPriceBlock" product=$accessory type="price"}
+                          </span>
+                        {/if}
+                        {hook h="displayProductPriceBlock" product=$accessory type="after_price"}
+                      </div>
+                      <div class="clearfix" style="margin-top:5px">
+                        {if !$PS_CATALOG_MODE && ($accessory.allow_oosp || $accessory.quantity > 0) && isset($add_prod_display) && $add_prod_display == 1}
+                          <div class="no-print">
+                            <a class="exclusive button ajax_add_to_cart_button" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$accessory.id_product|intval}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" data-id-product="{$accessory.id_product|intval}" title="{l s='Add to cart'}">
+                              <span>{l s='Add to cart'}</span>
                             </a>
-                            <hr />
-                        </div>
-                    {if $smarty.foreach.attachements.iteration %3 == 0 || $smarty.foreach.attachements.last}</div>{/if}
+                          </div>
+                        {/if}
+                      </div>
+                    </li>
+                  {/if}
                 {/foreach}
-            </section>
-            <!--end Download -->
-            {/if}
-            {if isset($product) && $product->customizable}
-            <!--Customization -->
-            <section class="page-product-box">
-                <h3 class="page-product-heading">{l s='Product customization'}</h3>
-                <!-- Customizable products -->
-                <form method="post" action="{$customizationFormTarget}" enctype="multipart/form-data" id="customizationForm" class="clearfix">
-                    <p class="infoCustomizable">
-                        {l s='After saving your customized product, remember to add it to your cart.'}
-                        {if $product->uploadable_files}
-                        <br />
-                        {l s='Allowed file formats are: GIF, JPG, PNG'}{/if}
-                    </p>
-                    {if $product->uploadable_files|intval}
-                        <div class="customizableProductsFile">
-                            <h5 class="product-heading-h5">{l s='Pictures'}</h5>
-                            <ul id="uploadable_files" class="clearfix">
-                                {counter start=0 assign='customizationField'}
-                                {foreach from=$customizationFields item='field' name='customizationFields'}
-                                    {if $field.type == 0}
-                                        <li class="customizationUploadLine{if $field.required} required{/if}">{assign var='key' value='pictures_'|cat:$product->id|cat:'_'|cat:$field.id_customization_field}
-                                            {if isset($pictures.$key)}
-                                                <div class="customizationUploadBrowse">
-                                                    <img src="{$pic_dir}{$pictures.$key}_small" alt="" />
-                                                        <a href="{$link->getProductDeletePictureLink($product, $field.id_customization_field)|escape:'html':'UTF-8'}" title="{l s='Delete'}" >
-                                                            <img src="{$img_dir}icon/delete.gif" alt="{l s='Delete'}" class="customization_delete_icon" width="11" height="13" />
-                                                        </a>
-                                                </div>
-                                            {/if}
-                                            <div class="customizationUploadBrowse form-group">
-                                                <label class="customizationUploadBrowseDescription">
-                                                    {if !empty($field.name)}
-                                                        {$field.name}
-                                                    {else}
-                                                        {l s='Please select an image file from your computer'}
-                                                    {/if}
-                                                    {if $field.required}<sup>*</sup>{/if}
-                                                </label>
-                                                <input type="file" name="file{$field.id_customization_field}" id="img{$customizationField}" class="form-control customization_block_input {if isset($pictures.$key)}filled{/if}" />
-                                            </div>
-                                        </li>
-                                        {counter}
-                                    {/if}
-                                {/foreach}
-                            </ul>
-                        </div>
-                    {/if}
-                    {if $product->text_fields|intval}
-                        <div class="customizableProductsText">
-                            <h5 class="product-heading-h5">{l s='Text'}</h5>
-                            <ul id="text_fields">
-                            {counter start=0 assign='customizationField'}
-                            {foreach from=$customizationFields item='field' name='customizationFields'}
-                                {if $field.type == 1}
-                                    <li class="customizationUploadLine{if $field.required} required{/if}">
-                                        <label for ="textField{$customizationField}">
-                                            {assign var='key' value='textFields_'|cat:$product->id|cat:'_'|cat:$field.id_customization_field}
-                                            {if !empty($field.name)}
-                                                {$field.name}
-                                            {/if}
-                                            {if $field.required}<sup>*</sup>{/if}
-                                        </label>
-                                        <textarea name="textField{$field.id_customization_field}" class="form-control customization_block_input" id="textField{$customizationField}" rows="3" cols="20">{strip}
-                                            {if isset($textFields.$key)}
-                                                {$textFields.$key|stripslashes}
-                                            {/if}
-                                        {/strip}</textarea>
-                                    </li>
-                                    {counter}
-                                {/if}
-                            {/foreach}
-                            </ul>
-                        </div>
-                    {/if}
-                    <p id="customizedDatas">
-                        <input type="hidden" name="quantityBackup" id="quantityBackup" value="" />
-                        <input type="hidden" name="submitCustomizedDatas" value="1" />
-                        <button class="button btn btn-default button button-small" name="saveCustomization">
-                            <span>{l s='Save'}</span>
-                        </button>
-                        <span id="ajax-loader" class="unvisible">
-                            <img src="{$img_ps_dir}loader.gif" alt="loader" />
-                        </span>
-                    </p>
-                </form>
-                <p class="clear required"><sup>*</sup> {l s='required fields'}</p>
-            </section>
-            <!--end Customization -->
-            {/if}
+              </ul>
+            </div>
+          </div>
+        </section>
+        <!--end Accessories -->
+      {/if}
+      {if isset($HOOK_PRODUCT_FOOTER) && $HOOK_PRODUCT_FOOTER}{$HOOK_PRODUCT_FOOTER}{/if}
+      <!-- description & features -->
+      {if (isset($product) && $product->description) || (isset($features) && $features) || (isset($accessories) && $accessories) || (isset($HOOK_PRODUCT_TAB) && $HOOK_PRODUCT_TAB) || (isset($attachments) && $attachments) || isset($product) && $product->customizable}
+        {if isset($attachments) && $attachments}
+          <!--Download -->
+          <section class="page-product-box">
+            <h3 class="page-product-heading">{l s='Download'}</h3>
+            {foreach from=$attachments item=attachment name=attachements}
+              {if $smarty.foreach.attachements.iteration %3 == 1}<div class="row">{/if}
+              <div class="col-lg-4">
+                <h4><a href="{$link->getPageLink('attachment', true, NULL, "id_attachment={$attachment.id_attachment}")|escape:'html':'UTF-8'}">{$attachment.name|escape:'html':'UTF-8'}</a></h4>
+                <p class="text-muted">{$attachment.description|escape:'html':'UTF-8'}</p>
+                <a class="btn btn-default btn-block" href="{$link->getPageLink('attachment', true, NULL, "id_attachment={$attachment.id_attachment}")|escape:'html':'UTF-8'}">
+                  <i class="icon-download"></i>
+                  {l s="Download"} ({Tools::formatBytes($attachment.file_size, 2)})
+                </a>
+                <hr />
+              </div>
+              {if $smarty.foreach.attachements.iteration %3 == 0 || $smarty.foreach.attachements.last}</div>{/if}
+            {/foreach}
+          </section>
+          <!--end Download -->
         {/if}
+        {if isset($product) && $product->customizable}
+          <!--Customization -->
+          <section class="page-product-box">
+            <h3 class="page-product-heading">{l s='Product customization'}</h3>
+            <!-- Customizable products -->
+            <form method="post" action="{$customizationFormTarget}" enctype="multipart/form-data" id="customizationForm" class="clearfix">
+              <p class="infoCustomizable">
+                {l s='After saving your customized product, remember to add it to your cart.'}
+                {if $product->uploadable_files}
+                  <br />
+                  {l s='Allowed file formats are: GIF, JPG, PNG'}{/if}
+              </p>
+              {if $product->uploadable_files|intval}
+                <div class="customizableProductsFile">
+                  <h5 class="product-heading-h5">{l s='Pictures'}</h5>
+                  <ul id="uploadable_files" class="clearfix">
+                    {counter start=0 assign='customizationField'}
+                    {foreach from=$customizationFields item='field' name='customizationFields'}
+                      {if $field.type == 0}
+                        <li class="customizationUploadLine{if $field.required} required{/if}">{assign var='key' value='pictures_'|cat:$product->id|cat:'_'|cat:$field.id_customization_field}
+                          {if isset($pictures.$key)}
+                            <div class="customizationUploadBrowse">
+                              <img src="{$pic_dir}{$pictures.$key}_small" alt="" />
+                              <a href="{$link->getProductDeletePictureLink($product, $field.id_customization_field)|escape:'html':'UTF-8'}" title="{l s='Delete'}" >
+                                <img src="{$img_dir}icon/delete.gif" alt="{l s='Delete'}" class="customization_delete_icon" width="11" height="13" />
+                              </a>
+                            </div>
+                          {/if}
+                          <div class="customizationUploadBrowse form-group">
+                            <label class="customizationUploadBrowseDescription">
+                              {if !empty($field.name)}
+                                {$field.name}
+                              {else}
+                                {l s='Please select an image file from your computer'}
+                              {/if}
+                              {if $field.required}<sup>*</sup>{/if}
+                            </label>
+                            <input type="file" name="file{$field.id_customization_field}" id="img{$customizationField}" class="form-control customization_block_input {if isset($pictures.$key)}filled{/if}" />
+                          </div>
+                        </li>
+                        {counter}
+                      {/if}
+                    {/foreach}
+                  </ul>
+                </div>
+              {/if}
+              {if $product->text_fields|intval}
+                <div class="customizableProductsText">
+                  <h5 class="product-heading-h5">{l s='Text'}</h5>
+                  <ul id="text_fields">
+                    {counter start=0 assign='customizationField'}
+                    {foreach from=$customizationFields item='field' name='customizationFields'}
+                      {if $field.type == 1}
+                        <li class="customizationUploadLine{if $field.required} required{/if}">
+                          <label for ="textField{$customizationField}">
+                            {assign var='key' value='textFields_'|cat:$product->id|cat:'_'|cat:$field.id_customization_field}
+                            {if !empty($field.name)}
+                              {$field.name}
+                            {/if}
+                            {if $field.required}<sup>*</sup>{/if}
+                          </label>
+                          <textarea name="textField{$field.id_customization_field}" class="form-control customization_block_input" id="textField{$customizationField}" rows="3" cols="20">{strip}
+                              {if isset($textFields.$key)}
+                              {$textFields.$key|stripslashes}
+                            {/if}
+                          {/strip}</textarea>
+                        </li>
+                        {counter}
+                      {/if}
+                    {/foreach}
+                  </ul>
+                </div>
+              {/if}
+              <p id="customizedDatas">
+                <input type="hidden" name="quantityBackup" id="quantityBackup" value="" />
+                <input type="hidden" name="submitCustomizedDatas" value="1" />
+                <button class="button btn btn-default button button-small" name="saveCustomization">
+                  <span>{l s='Save'}</span>
+                </button>
+                <span id="ajax-loader" class="unvisible">
+                 <img src="{$img_ps_dir}loader.gif" alt="loader" />
+                </span>
+              </p>
+            </form>
+            <p class="clear required"><sup>*</sup> {l s='required fields'}</p>
+          </section>
+          <!--end Customization -->
+        {/if}
+      {/if}
     {/if}
-</div> <!-- itemscope product wrapper -->
-{strip}
-{if isset($smarty.get.ad) && $smarty.get.ad}
-    {addJsDefL name=ad}{$base_dir|cat:$smarty.get.ad|escape:'html':'UTF-8'}{/addJsDefL}
-{/if}
-{if isset($smarty.get.adtoken) && $smarty.get.adtoken}
-    {addJsDefL name=adtoken}{$smarty.get.adtoken|escape:'html':'UTF-8'}{/addJsDefL}
-{/if}
-{addJsDef allowBuyWhenOutOfStock=$allow_oosp|boolval}
-{addJsDef availableNowValue=$product->available_now|escape:'quotes':'UTF-8'}
-{addJsDef availableLaterValue=$product->available_later|escape:'quotes':'UTF-8'}
-{addJsDef attribute_anchor_separator=$attribute_anchor_separator|escape:'quotes':'UTF-8'}
-{addJsDef attributesCombinations=$attributesCombinations}
-{addJsDef currentDate=$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'}
-{if isset($combinations) && $combinations}
-    {addJsDef combinations=$combinations}
-    {addJsDef combinationsFromController=$combinations}
-    {addJsDef displayDiscountPrice=$display_discount_price}
-    {addJsDefL name='upToTxt'}{l s='Up to' js=1}{/addJsDefL}
-{/if}
-{if isset($combinationImages) && $combinationImages}
-    {addJsDef combinationImages=$combinationImages}
-{/if}
-{addJsDef customizationId=$id_customization}
-{addJsDef customizationFields=$customizationFields}
-{addJsDef default_eco_tax=$product->ecotax|floatval}
-{addJsDef displayPrice=$priceDisplay|intval}
-{addJsDef ecotaxTax_rate=$ecotaxTax_rate|floatval}
-{if isset($cover.id_image_only)}
-    {addJsDef idDefaultImage=$cover.id_image_only|intval}
-{else}
-    {addJsDef idDefaultImage=0}
-{/if}
-{addJsDef img_ps_dir=$img_ps_dir}
-{addJsDef img_prod_dir=$img_prod_dir}
-{addJsDef id_product=$product->id|intval}
-{addJsDef jqZoomEnabled=$jqZoomEnabled|boolval}
-{addJsDef maxQuantityToAllowDisplayOfLastQuantityMessage=$last_qties|intval}
-{addJsDef minimalQuantity=$product->minimal_quantity|intval}
-{addJsDef noTaxForThisProduct=$no_tax|boolval}
-{if isset($customer_group_without_tax)}
-    {addJsDef customerGroupWithoutTax=$customer_group_without_tax|boolval}
-{else}
-    {addJsDef customerGroupWithoutTax=false}
-{/if}
-{if isset($group_reduction)}
-    {addJsDef groupReduction=$group_reduction|floatval}
-{else}
-    {addJsDef groupReduction=false}
-{/if}
-{addJsDef oosHookJsCodeFunctions=Array()}
-{addJsDef productHasAttributes=isset($groups)|boolval}
-{addJsDef productPriceTaxExcluded=($product->getPriceWithoutReduct(true)|default:'null' - $product->ecotax)|floatval}
-{addJsDef productPriceTaxIncluded=($product->getPriceWithoutReduct(false)|default:'null' - $product->ecotax * (1 + $ecotaxTax_rate / 100))|floatval}
-{addJsDef productBasePriceTaxExcluded=($product->getPrice(false, null, 6, null, false, false) - $product->ecotax)|floatval}
-{addJsDef productBasePriceTaxExcl=($product->getPrice(false, null, 6, null, false, false)|floatval)}
-{addJsDef productBasePriceTaxIncl=($product->getPrice(true, null, 6, null, false, false)|floatval)}
-{addJsDef productReference=$product->reference|escape:'html':'UTF-8'}
-{addJsDef productAvailableForOrder=$product->available_for_order|boolval}
-{addJsDef productPriceWithoutReduction=$productPriceWithoutReduction|floatval}
-{addJsDef productPrice=$productPrice|floatval}
-{addJsDef productUnitPriceRatio=$product->unit_price_ratio|floatval}
-{addJsDef productShowPrice=(!$PS_CATALOG_MODE && $product->show_price)|boolval}
-{addJsDef PS_CATALOG_MODE=$PS_CATALOG_MODE}
-{if $product->specificPrice && $product->specificPrice|@count}
-    {addJsDef product_specific_price=$product->specificPrice}
-{else}
-    {addJsDef product_specific_price=array()}
-{/if}
-{if $display_qties == 1 && $product->quantity}
-    {addJsDef quantityAvailable=$product->quantity}
-{else}
-    {addJsDef quantityAvailable=0}
-{/if}
-{addJsDef quantitiesDisplayAllowed=$display_qties|boolval}
-{if $product->specificPrice && $product->specificPrice.reduction && $product->specificPrice.reduction_type == 'percentage'}
-    {addJsDef reduction_percent=$product->specificPrice.reduction*100|floatval}
-{else}
-    {addJsDef reduction_percent=0}
-{/if}
-{if $product->specificPrice && $product->specificPrice.reduction && $product->specificPrice.reduction_type == 'amount'}
-    {addJsDef reduction_price=$product->specificPrice.reduction|floatval}
-{else}
-    {addJsDef reduction_price=0}
-{/if}
-{if $product->specificPrice && $product->specificPrice.price}
-    {addJsDef specific_price=$product->specificPrice.price|floatval}
-{else}
-    {addJsDef specific_price=0}
-{/if}
-{addJsDef specific_currency=($product->specificPrice && $product->specificPrice.id_currency)|boolval} {* TODO: remove if always false *}
-{addJsDef stock_management=$PS_STOCK_MANAGEMENT|intval}
-{addJsDef taxRate=$tax_rate|floatval}
-{addJsDefL name=doesntExist}{l s='This combination does not exist for this product. Please select another combination.' js=1}{/addJsDefL}
-{addJsDefL name=doesntExistNoMore}{l s='This product is no longer in stock' js=1}{/addJsDefL}
-{addJsDefL name=doesntExistNoMoreBut}{l s='with those attributes but is available with others.' js=1}{/addJsDefL}
-{addJsDefL name=fieldRequired}{l s='Please fill in all the required fields before saving your customization.' js=1}{/addJsDefL}
-{addJsDefL name=uploading_in_progress}{l s='Uploading in progress, please be patient.' js=1}{/addJsDefL}
-{addJsDefL name='product_fileDefaultHtml'}{l s='No file selected' js=1}{/addJsDefL}
-{addJsDefL name='product_fileButtonHtml'}{l s='Choose File' js=1}{/addJsDefL}
-{/strip}
+  </div> <!-- itemscope product wrapper -->
+  {strip}
+    {if isset($smarty.get.ad) && $smarty.get.ad}
+      {addJsDefL name=ad}{$base_dir|cat:$smarty.get.ad|escape:'html':'UTF-8'}{/addJsDefL}
+    {/if}
+    {if isset($smarty.get.adtoken) && $smarty.get.adtoken}
+      {addJsDefL name=adtoken}{$smarty.get.adtoken|escape:'html':'UTF-8'}{/addJsDefL}
+    {/if}
+    {addJsDef allowBuyWhenOutOfStock=$allow_oosp|boolval}
+    {addJsDef availableNowValue=$product->available_now|escape:'quotes':'UTF-8'}
+    {addJsDef availableLaterValue=$product->available_later|escape:'quotes':'UTF-8'}
+    {addJsDef attribute_anchor_separator=$attribute_anchor_separator|escape:'quotes':'UTF-8'}
+    {addJsDef attributesCombinations=$attributesCombinations}
+    {addJsDef currentDate=$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'}
+    {if isset($combinations) && $combinations}
+      {addJsDef combinations=$combinations}
+      {addJsDef combinationsFromController=$combinations}
+      {addJsDef displayDiscountPrice=$display_discount_price}
+      {addJsDefL name='upToTxt'}{l s='Up to' js=1}{/addJsDefL}
+    {/if}
+    {if isset($combinationImages) && $combinationImages}
+      {addJsDef combinationImages=$combinationImages}
+    {/if}
+    {addJsDef customizationId=$id_customization}
+    {addJsDef customizationFields=$customizationFields}
+    {addJsDef default_eco_tax=$product->ecotax|floatval}
+    {addJsDef displayPrice=$priceDisplay|intval}
+    {addJsDef ecotaxTax_rate=$ecotaxTax_rate|floatval}
+    {if isset($cover.id_image_only)}
+      {addJsDef idDefaultImage=$cover.id_image_only|intval}
+    {else}
+      {addJsDef idDefaultImage=0}
+    {/if}
+    {addJsDef img_ps_dir=$img_ps_dir}
+    {addJsDef img_prod_dir=$img_prod_dir}
+    {addJsDef id_product=$product->id|intval}
+    {addJsDef jqZoomEnabled=$jqZoomEnabled|boolval}
+    {addJsDef maxQuantityToAllowDisplayOfLastQuantityMessage=$last_qties|intval}
+    {addJsDef minimalQuantity=$product->minimal_quantity|intval}
+    {addJsDef noTaxForThisProduct=$no_tax|boolval}
+    {if isset($customer_group_without_tax)}
+      {addJsDef customerGroupWithoutTax=$customer_group_without_tax|boolval}
+    {else}
+      {addJsDef customerGroupWithoutTax=false}
+    {/if}
+    {if isset($group_reduction)}
+      {addJsDef groupReduction=$group_reduction|floatval}
+    {else}
+      {addJsDef groupReduction=false}
+    {/if}
+    {addJsDef oosHookJsCodeFunctions=Array()}
+    {addJsDef productHasAttributes=isset($groups)|boolval}
+    {addJsDef productPriceTaxExcluded=($product->getPriceWithoutReduct(true)|default:'null' - $product->ecotax)|floatval}
+    {addJsDef productPriceTaxIncluded=($product->getPriceWithoutReduct(false)|default:'null' - $product->ecotax * (1 + $ecotaxTax_rate / 100))|floatval}
+    {addJsDef productBasePriceTaxExcluded=($product->getPrice(false, null, 6, null, false, false) - $product->ecotax)|floatval}
+    {addJsDef productBasePriceTaxExcl=($product->getPrice(false, null, 6, null, false, false)|floatval)}
+    {addJsDef productBasePriceTaxIncl=($product->getPrice(true, null, 6, null, false, false)|floatval)}
+    {addJsDef productReference=$product->reference|escape:'html':'UTF-8'}
+    {addJsDef productAvailableForOrder=$product->available_for_order|boolval}
+    {addJsDef productPriceWithoutReduction=$productPriceWithoutReduction|floatval}
+    {addJsDef productPrice=$productPrice|floatval}
+    {addJsDef productUnitPriceRatio=$product->unit_price_ratio|floatval}
+    {addJsDef productShowPrice=(!$PS_CATALOG_MODE && $product->show_price)|boolval}
+    {addJsDef PS_CATALOG_MODE=$PS_CATALOG_MODE}
+    {if $product->specificPrice && $product->specificPrice|@count}
+      {addJsDef product_specific_price=$product->specificPrice}
+    {else}
+      {addJsDef product_specific_price=array()}
+    {/if}
+    {if $display_qties == 1 && $product->quantity}
+      {addJsDef quantityAvailable=$product->quantity}
+    {else}
+      {addJsDef quantityAvailable=0}
+    {/if}
+    {addJsDef quantitiesDisplayAllowed=$display_qties|boolval}
+    {if $product->specificPrice && $product->specificPrice.reduction && $product->specificPrice.reduction_type == 'percentage'}
+      {addJsDef reduction_percent=$product->specificPrice.reduction*100|floatval}
+    {else}
+      {addJsDef reduction_percent=0}
+    {/if}
+    {if $product->specificPrice && $product->specificPrice.reduction && $product->specificPrice.reduction_type == 'amount'}
+      {addJsDef reduction_price=$product->specificPrice.reduction|floatval}
+    {else}
+      {addJsDef reduction_price=0}
+    {/if}
+    {if $product->specificPrice && $product->specificPrice.price}
+      {addJsDef specific_price=$product->specificPrice.price|floatval}
+    {else}
+      {addJsDef specific_price=0}
+    {/if}
+    {addJsDef specific_currency=($product->specificPrice && $product->specificPrice.id_currency)|boolval} {* TODO: remove if always false *}
+    {addJsDef stock_management=$PS_STOCK_MANAGEMENT|intval}
+    {addJsDef taxRate=$tax_rate|floatval}
+    {addJsDefL name=doesntExist}{l s='This combination does not exist for this product. Please select another combination.' js=1}{/addJsDefL}
+    {addJsDefL name=doesntExistNoMore}{l s='This product is no longer in stock' js=1}{/addJsDefL}
+    {addJsDefL name=doesntExistNoMoreBut}{l s='with those attributes but is available with others.' js=1}{/addJsDefL}
+    {addJsDefL name=fieldRequired}{l s='Please fill in all the required fields before saving your customization.' js=1}{/addJsDefL}
+    {addJsDefL name=uploading_in_progress}{l s='Uploading in progress, please be patient.' js=1}{/addJsDefL}
+    {addJsDefL name='product_fileDefaultHtml'}{l s='No file selected' js=1}{/addJsDefL}
+    {addJsDefL name='product_fileButtonHtml'}{l s='Choose File' js=1}{/addJsDefL}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/products-comparison.tpl
+++ b/themes/community-theme-16/products-comparison.tpl
@@ -25,171 +25,171 @@
 {capture name=path}{l s='Product Comparison'}{/capture}
 <h1 class="page-heading">{l s='Product Comparison'}</h1>
 {if $hasProduct}
-    <div class="products_block table-responsive">
-        <table id="product_comparison" class="table table-bordered">
-            <tr>
-                <td class="td_empty compare_extra_information">
-                    {$HOOK_COMPARE_EXTRA_INFORMATION}
-                    <span>{l s='Features:'}</span>
-                </td>
-                {assign var='taxes_behavior' value=false}
-                {if $use_taxes && (!$priceDisplay  || $priceDisplay == 2)}
-                    {assign var='taxes_behavior' value=true}
+  <div class="products_block table-responsive">
+    <table id="product_comparison" class="table table-bordered">
+      <tr>
+        <td class="td_empty compare_extra_information">
+          {$HOOK_COMPARE_EXTRA_INFORMATION}
+          <span>{l s='Features:'}</span>
+        </td>
+        {assign var='taxes_behavior' value=false}
+        {if $use_taxes && (!$priceDisplay  || $priceDisplay == 2)}
+          {assign var='taxes_behavior' value=true}
+        {/if}
+        {foreach from=$products item=product name=for_products}
+          {assign var='replace_id' value=$product->id|cat:'|'}
+          <td class="ajax_block_product comparison_infos product-block product-{$product->id}">
+            <div class="remove">
+              <a class="cmp_remove" href="{$link->getPageLink('products-comparison', true)|escape:'html':'UTF-8'}" title="{l s='Remove'}" data-id-product="{$product->id}">
+                <i class="icon-trash"></i>
+              </a>
+            </div>
+            <div class="product-image-block">
+              <a
+                class="product_image"
+                href="{$product->getLink()|escape:'html':'UTF-8'}"
+                title="{$product->name|escape:'html':'UTF-8'}">
+                <img
+                  class="img-responsive"
+                  src="{$link->getImageLink($product->link_rewrite, $product->id_image, 'home_default')|escape:'html':'UTF-8'}"
+                  alt="{$product->name|escape:'html':'UTF-8'}" />
+              </a>
+              {if isset($product->new) && $product->new == 1}
+                <a class="new-box" href="{$product->getLink()|escape:'html':'UTF-8'}">
+                  <span class="new-label">{l s='New'}</span>
+                </a>
+              {/if}
+              {if isset($product->show_price) && $product->show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
+                {if $product->on_sale}
+                  <a class="sale-box" href="{$product->getLink()|escape:'html':'UTF-8'}">
+                    <span class="sale-label">{l s='Sale!'}</span>
+                  </a>
                 {/if}
-                {foreach from=$products item=product name=for_products}
-                    {assign var='replace_id' value=$product->id|cat:'|'}
-                    <td class="ajax_block_product comparison_infos product-block product-{$product->id}">
-                        <div class="remove">
-                            <a class="cmp_remove" href="{$link->getPageLink('products-comparison', true)|escape:'html':'UTF-8'}" title="{l s='Remove'}" data-id-product="{$product->id}">
-                                <i class="icon-trash"></i>
-                            </a>
-                        </div>
-                        <div class="product-image-block">
-                            <a
-                            class="product_image"
-                            href="{$product->getLink()|escape:'html':'UTF-8'}"
-                            title="{$product->name|escape:'html':'UTF-8'}">
-                                <img
-                                class="img-responsive"
-                                src="{$link->getImageLink($product->link_rewrite, $product->id_image, 'home_default')|escape:'html':'UTF-8'}"
-                                alt="{$product->name|escape:'html':'UTF-8'}" />
-                            </a>
-                            {if isset($product->new) && $product->new == 1}
-                                <a class="new-box" href="{$product->getLink()|escape:'html':'UTF-8'}">
-                                    <span class="new-label">{l s='New'}</span>
-                                </a>
-                            {/if}
-                            {if isset($product->show_price) && $product->show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
-                                {if $product->on_sale}
-                                    <a class="sale-box" href="{$product->getLink()|escape:'html':'UTF-8'}">
-                                        <span class="sale-label">{l s='Sale!'}</span>
-                                    </a>
-                                {/if}
-                            {/if}
-                        </div> <!-- end product-image-block -->
-                        <h5>
-                            <a class="product-name" href="{$product->getLink()|escape:'html':'UTF-8'}" title="{$product->name|truncate:32:'...'|escape:'html':'UTF-8'}">
-                                {$product->name|truncate:45:'...'|escape:'html':'UTF-8'}
-                            </a>
-                        </h5>
-                        <div class="prices-container">
-                            {if isset($product->show_price) && $product->show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
-                                <span class="price product-price">{convertPrice price=$product->getPrice($taxes_behavior)}</span>
-                                {hook h="displayProductPriceBlock" id_product=$product->id type="price"}
-                                {if isset($product->specificPrice) && $product->specificPrice}
-                                    {if {$product->specificPrice.reduction_type == 'percentage'}}
-                                        <span class="old-price product-price">
-                                            {displayWtPrice p=($product->getPrice(true, null, 6, null, false, false))}
-                                        </span>
-                                        <span class="price-percent-reduction">
-                                            -{$product->specificPrice.reduction*100|floatval}%
-                                        </span>
-                                    {else}
-                                        <span class="old-price product-price">
-                                            {convertPrice price=($product->getPrice($taxes_behavior) + $product->specificPrice.reduction)}
-                                        </span>
-                                        <span class="price-percent-reduction">
-                                            -{convertPrice price=$product->specificPrice.reduction}
-                                        </span>
-                                    {/if}
-                                    {hook h="displayProductPriceBlock" product=$product type="old_price"}
-                                {/if}
-                                {hook h="displayProductPriceBlock" product=$product type="price"}
-                                {if $product->on_sale}
-                                    {elseif $product->specificPrice AND $product->specificPrice.reduction}
-                                        <div class="product_discount">
-                                            <span class="reduced-price">{l s='Reduced price!'}</span>
-                                        </div>
-                                    {/if}
-                                    {if !empty($product->unity) && $product->unit_price_ratio > 0.000000}
-                                        {math equation="pprice / punit_price"  pprice=$product->getPrice($taxes_behavior)  punit_price=$product->unit_price_ratio assign=unit_price}
-                                        <span class="comparison_unit_price">
-                                            &nbsp;{convertPrice price=$unit_price} {l s='per %s' sprintf=$product->unity|escape:'html':'UTF-8'}
-                                        </span>
-                                        {hook h="displayProductPriceBlock" product=$product type="unit_price"}
-                                    {else}
-                                {/if}
-                            {/if}
-                        </div> <!-- end prices-container -->
-                        <div class="product_desc">
-                            {$product->description_short|strip_tags|truncate:60:'...'}
-                        </div>
-                        <div class="comparison_product_infos">
-                            <p class="comparison_availability_statut">
-                                {if !(($product->quantity <= 0 && !$product->available_later) OR ($product->quantity != 0 && !$product->available_now) OR !$product->available_for_order OR $PS_CATALOG_MODE)}
-                                    <span class="availability_label">{l s='Availability:'}</span>
-                                    <span class="availability_value"{if $product->quantity <= 0} class="warning-inline"{/if}>
-                                        {if $product->quantity <= 0}
-                                            {if $product->allow_oosp}
-                                                {$product->available_later|escape:'html':'UTF-8'}
-                                            {else}
-                                                {l s='This product is no longer in stock.'}
-                                            {/if}
-                                        {else}
-                                            {$product->available_now|escape:'html':'UTF-8'}
-                                        {/if}
-                                    </span>
-                                {/if}
-                            </p>
-                            {if !$product->is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
-                            {hook h="displayProductPriceBlock" product=$product type="weight"}
-                            <div class="clearfix">
-                                <div class="button-container">
-                                    {if (!$product->hasAttributes() OR (isset($add_prod_display) AND ($add_prod_display == 1))) AND $product->minimal_quantity == 1 AND $product->customizable != 2 AND !$PS_CATALOG_MODE}
-                                        {if ($product->quantity > 0 OR $product->allow_oosp)}
-                                            <a class="button ajax_add_to_cart_button btn btn-default" data-id-product="{$product->id}" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$product->id}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" title="{l s='Add to cart'}">
-                                                <span>{l s='Add to cart'}</span>
-                                            </a>
-                                        {else}
-                                            <span class="ajax_add_to_cart_button button btn btn-default disabled">
-                                                <span>{l s='Add to cart'}</span>
-                                            </span>
-                                        {/if}
-                                    {/if}
-                                    <a class="button lnk_view btn btn-default" href="{$product->getLink()|escape:'html':'UTF-8'}" title="{l s='View'}">
-                                        <span>{l s='View'}</span>
-                                    </a>
-                                </div>
-                            </div>
-                        </div> <!-- end comparison_product_infos -->
-                    </td>
-                {/foreach}
-            </tr>
-            {if $ordered_features}
-                {foreach from=$ordered_features item=feature}
-                    <tr>
-                        {cycle values='comparison_feature_odd,comparison_feature_even' assign='classname'}
-                        <td class="{$classname} feature-name" >
-                            <strong>{$feature.name|escape:'html':'UTF-8'}</strong>
-                        </td>
-                        {foreach from=$products item=product name=for_products}
-                            {assign var='product_id' value=$product->id}
-                            {assign var='feature_id' value=$feature.id_feature}
-                            {if isset($product_features[$product_id])}
-                                {assign var='tab' value=$product_features[$product_id]}
-                                <td class="{$classname} comparison_infos product-{$product->id}">{if (isset($tab[$feature_id]))}{$tab[$feature_id]|escape:'html':'UTF-8'}{/if}</td>
-                            {else}
-                                <td class="{$classname} comparison_infos product-{$product->id}"></td>
-                            {/if}
-                        {/foreach}
-                    </tr>
-                {/foreach}
-            {else}
-                <tr>
-                    <td></td>
-                    <td colspan="{$products|@count}" class="text-center">{l s='No features to compare'}</td>
-                </tr>
-            {/if}
-            {$HOOK_EXTRA_PRODUCT_COMPARISON}
-        </table>
-    </div> <!-- end products_block -->
+              {/if}
+            </div> <!-- end product-image-block -->
+            <h5>
+              <a class="product-name" href="{$product->getLink()|escape:'html':'UTF-8'}" title="{$product->name|truncate:32:'...'|escape:'html':'UTF-8'}">
+                {$product->name|truncate:45:'...'|escape:'html':'UTF-8'}
+              </a>
+            </h5>
+            <div class="prices-container">
+              {if isset($product->show_price) && $product->show_price && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}
+                <span class="price product-price">{convertPrice price=$product->getPrice($taxes_behavior)}</span>
+                {hook h="displayProductPriceBlock" id_product=$product->id type="price"}
+                {if isset($product->specificPrice) && $product->specificPrice}
+                  {if {$product->specificPrice.reduction_type == 'percentage'}}
+                    <span class="old-price product-price">
+                      {displayWtPrice p=($product->getPrice(true, null, 6, null, false, false))}
+                    </span>
+                    <span class="price-percent-reduction">
+                      -{$product->specificPrice.reduction*100|floatval}%
+                    </span>
+                  {else}
+                    <span class="old-price product-price">
+                      {convertPrice price=($product->getPrice($taxes_behavior) + $product->specificPrice.reduction)}
+                    </span>
+                    <span class="price-percent-reduction">
+                      -{convertPrice price=$product->specificPrice.reduction}
+                    </span>
+                  {/if}
+                  {hook h="displayProductPriceBlock" product=$product type="old_price"}
+                {/if}
+                {hook h="displayProductPriceBlock" product=$product type="price"}
+                {if $product->on_sale}
+                {elseif $product->specificPrice AND $product->specificPrice.reduction}
+                  <div class="product_discount">
+                    <span class="reduced-price">{l s='Reduced price!'}</span>
+                  </div>
+                {/if}
+                {if !empty($product->unity) && $product->unit_price_ratio > 0.000000}
+                  {math equation="pprice / punit_price"  pprice=$product->getPrice($taxes_behavior)  punit_price=$product->unit_price_ratio assign=unit_price}
+                  <span class="comparison_unit_price">
+                    &nbsp;{convertPrice price=$unit_price} {l s='per %s' sprintf=$product->unity|escape:'html':'UTF-8'}
+                  </span>
+                  {hook h="displayProductPriceBlock" product=$product type="unit_price"}
+                {else}
+                {/if}
+              {/if}
+            </div> <!-- end prices-container -->
+            <div class="product_desc">
+              {$product->description_short|strip_tags|truncate:60:'...'}
+            </div>
+            <div class="comparison_product_infos">
+              <p class="comparison_availability_statut">
+                {if !(($product->quantity <= 0 && !$product->available_later) OR ($product->quantity != 0 && !$product->available_now) OR !$product->available_for_order OR $PS_CATALOG_MODE)}
+                  <span class="availability_label">{l s='Availability:'}</span>
+                  <span class="availability_value"{if $product->quantity <= 0} class="warning-inline"{/if}>
+                   {if $product->quantity <= 0}
+                     {if $product->allow_oosp}
+                       {$product->available_later|escape:'html':'UTF-8'}
+                     {else}
+                       {l s='This product is no longer in stock.'}
+                     {/if}
+                   {else}
+                     {$product->available_now|escape:'html':'UTF-8'}
+                   {/if}
+                  </span>
+                {/if}
+              </p>
+              {if !$product->is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}
+              {hook h="displayProductPriceBlock" product=$product type="weight"}
+              <div class="clearfix">
+                <div class="button-container">
+                  {if (!$product->hasAttributes() OR (isset($add_prod_display) AND ($add_prod_display == 1))) AND $product->minimal_quantity == 1 AND $product->customizable != 2 AND !$PS_CATALOG_MODE}
+                    {if ($product->quantity > 0 OR $product->allow_oosp)}
+                      <a class="button ajax_add_to_cart_button btn btn-default" data-id-product="{$product->id}" href="{$link->getPageLink('cart', true, NULL, "qty=1&amp;id_product={$product->id}&amp;token={$static_token}&amp;add")|escape:'html':'UTF-8'}" title="{l s='Add to cart'}">
+                        <span>{l s='Add to cart'}</span>
+                      </a>
+                    {else}
+                      <span class="ajax_add_to_cart_button button btn btn-default disabled">
+                        <span>{l s='Add to cart'}</span>
+                      </span>
+                    {/if}
+                  {/if}
+                  <a class="button lnk_view btn btn-default" href="{$product->getLink()|escape:'html':'UTF-8'}" title="{l s='View'}">
+                    <span>{l s='View'}</span>
+                  </a>
+                </div>
+              </div>
+            </div> <!-- end comparison_product_infos -->
+          </td>
+        {/foreach}
+      </tr>
+      {if $ordered_features}
+        {foreach from=$ordered_features item=feature}
+          <tr>
+            {cycle values='comparison_feature_odd,comparison_feature_even' assign='classname'}
+            <td class="{$classname} feature-name" >
+              <strong>{$feature.name|escape:'html':'UTF-8'}</strong>
+            </td>
+            {foreach from=$products item=product name=for_products}
+              {assign var='product_id' value=$product->id}
+              {assign var='feature_id' value=$feature.id_feature}
+              {if isset($product_features[$product_id])}
+                {assign var='tab' value=$product_features[$product_id]}
+                <td class="{$classname} comparison_infos product-{$product->id}">{if (isset($tab[$feature_id]))}{$tab[$feature_id]|escape:'html':'UTF-8'}{/if}</td>
+              {else}
+                <td class="{$classname} comparison_infos product-{$product->id}"></td>
+              {/if}
+            {/foreach}
+          </tr>
+        {/foreach}
+      {else}
+        <tr>
+          <td></td>
+          <td colspan="{$products|@count}" class="text-center">{l s='No features to compare'}</td>
+        </tr>
+      {/if}
+      {$HOOK_EXTRA_PRODUCT_COMPARISON}
+    </table>
+  </div> <!-- end products_block -->
 {else}
-    <p class="alert alert-warning">{l s='There are no products selected for comparison.'}</p>
+  <p class="alert alert-warning">{l s='There are no products selected for comparison.'}</p>
 {/if}
 <ul class="footer_link">
-    <li>
-        <a class="button lnk_view btn btn-default" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
-            <span><i class="icon-chevron-left left"></i>{l s='Continue Shopping'}</span>
-        </a>
-    </li>
+  <li>
+    <a class="button lnk_view btn btn-default" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}">
+      <span><i class="icon-chevron-left left"></i>{l s='Continue Shopping'}</span>
+    </a>
+  </li>
 </ul>

--- a/themes/community-theme-16/restricted-country.tpl
+++ b/themes/community-theme-16/restricted-country.tpl
@@ -24,106 +24,106 @@
 *}
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <title>{$meta_title|escape:'html':'UTF-8'}</title>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-{if isset($meta_description)}
-        <meta name="description" content="{$meta_description|escape:'html':'UTF-8'}" />
-{/if}
-{if isset($meta_keywords)}
-        <meta name="keywords" content="{$meta_keywords|escape:'html':'UTF-8'}" />
-{/if}
-        <meta name="robots" content="{if isset($nobots)}no{/if}index,follow" />
-        <link rel="shortcut icon" href="{$favicon_url}" />
-        <style>
-            ::-moz-selection {
-                background: #b3d4fc;
-                text-shadow: none;
-            }
+<head>
+  <title>{$meta_title|escape:'html':'UTF-8'}</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  {if isset($meta_description)}
+    <meta name="description" content="{$meta_description|escape:'html':'UTF-8'}" />
+  {/if}
+  {if isset($meta_keywords)}
+    <meta name="keywords" content="{$meta_keywords|escape:'html':'UTF-8'}" />
+  {/if}
+  <meta name="robots" content="{if isset($nobots)}no{/if}index,follow" />
+  <link rel="shortcut icon" href="{$favicon_url}" />
+  <style>
+    ::-moz-selection {
+      background: #b3d4fc;
+      text-shadow: none;
+    }
 
-            ::selection {
-                background: #b3d4fc;
-                text-shadow: none;
-            }
+    ::selection {
+      background: #b3d4fc;
+      text-shadow: none;
+    }
 
-            html {
-                padding: 30px 10px;
-                font-size: 16px;
-                line-height: 1.4;
-                color: #737373;
-                background: #f0f0f0;
-                -webkit-text-size-adjust: 100%;
-                -ms-text-size-adjust: 100%;
-            }
+    html {
+      padding: 30px 10px;
+      font-size: 16px;
+      line-height: 1.4;
+      color: #737373;
+      background: #f0f0f0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
 
-            html,
-            input {
-                font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-            }
+    html,
+    input {
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    }
 
-            body {
-                max-width:600px;
-                _width: 600px;
-                padding: 30px 20px 50px;
-                border: 1px solid #b3b3b3;
-                border-radius: 4px;
-                margin: 0 auto;
-                box-shadow: 0 1px 10px #a7a7a7, inset 0 1px 0 #fff;
-                background: #fcfcfc;
-            }
+    body {
+      max-width:600px;
+      _width: 600px;
+      padding: 30px 20px 50px;
+      border: 1px solid #b3b3b3;
+      border-radius: 4px;
+      margin: 0 auto;
+      box-shadow: 0 1px 10px #a7a7a7, inset 0 1px 0 #fff;
+      background: #fcfcfc;
+    }
 
-            h1 {
-                margin: 0 10px;
-                font-size: 50px;
-                text-align: center;
-            }
+    h1 {
+      margin: 0 10px;
+      font-size: 50px;
+      text-align: center;
+    }
 
-            h1 span {
-                color: #bbb;
-            }
-            h2 {
-                color: #D35780;
-                margin: 0 10px;
-                font-size: 40px;
-                text-align: center;
-            }
+    h1 span {
+      color: #bbb;
+    }
+    h2 {
+      color: #D35780;
+      margin: 0 10px;
+      font-size: 40px;
+      text-align: center;
+    }
 
-            h2 span {
-                color: #bbb;
-                font-size: 60px;
-            }
+    h2 span {
+      color: #bbb;
+      font-size: 60px;
+    }
 
-            h3 {
-                margin: 1.5em 0 0.5em;
-            }
+    h3 {
+      margin: 1.5em 0 0.5em;
+    }
 
-            p {
-                margin: 1em 0;
-            }
+    p {
+      margin: 1em 0;
+    }
 
-            ul {
-                padding: 0 0 0 40px;
-                margin: 1em 0;
-            }
+    ul {
+      padding: 0 0 0 40px;
+      margin: 1em 0;
+    }
 
-            .container {
-                max-width: 380px;
-                _width: 380px;
-                margin: 0 auto;
-            }
+    .container {
+      max-width: 380px;
+      _width: 380px;
+      margin: 0 auto;
+    }
 
-            input::-moz-focus-inner {
-                padding: 0;
-                border: 0;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <h1>{$shop_name}</h1>
-            <h2><span>503</span> Overloaded</h2>
-            <p style="text-align:center;"><img src="{$logo_url}" alt="logo" /></p>
-            <p>{l s='You cannot access this store from your country. We apologize for the inconvenience.'}</p>
-        </div>
-    </body>
+    input::-moz-focus-inner {
+      padding: 0;
+      border: 0;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>{$shop_name}</h1>
+  <h2><span>503</span> Overloaded</h2>
+  <p style="text-align:center;"><img src="{$logo_url}" alt="logo" /></p>
+  <p>{l s='You cannot access this store from your country. We apologize for the inconvenience.'}</p>
+</div>
+</body>
 </html>

--- a/themes/community-theme-16/scenes.tpl
+++ b/themes/community-theme-16/scenes.tpl
@@ -23,65 +23,65 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 {if $scenes}
-<div id="scenes">
+  <div id="scenes">
     <div>
-        {foreach $scenes as $scene_key=>$scene}
+      {foreach $scenes as $scene_key=>$scene}
         <div class="screen_scene" id="screen_scene_{$scene->id}" style="background:transparent url({$base_dir}img/scenes/{$scene->id}-scene_default.jpg); height:{$largeSceneImageType.height}px; width:{$largeSceneImageType.width}px;{if !$scene@first} display:none;{/if}">
-            {foreach $scene->products as $product_key=>$product}
+          {foreach $scene->products as $product_key=>$product}
             {if isset($product.id_image)}
-                {assign var=imageIds value="`$product.id_product`-`$product.id_image`"}
+              {assign var=imageIds value="`$product.id_product`-`$product.id_image`"}
             {/if}
-                <a href="{$product.link|escape:'html':'UTF-8'}" class="popover-button" style="width:{$product.zone_width}px; height:{$product.zone_height}px; margin-left:{$product.x_axis}px ;margin-top:{$product.y_axis}px;" data-id_product_scene="{$scene_key|intval}_{$product_key|intval}_{$product.id_product|intval}">
-                    <span style="margin-top:{math equation='a/2 -10' a=$product.zone_height}px; margin-left:{math equation='a/2 -10' a=$product.zone_width}px;"></span>
-                </a>
-                <div id="scene_products_cluetip_{$scene_key}_{$product_key}_{$product.id_product}" style="display:none;">
-                    <div class="product-image-container">
-                        {if isset($imageIds)}
-                            <img class="img-responsive replace-2x" src="{$link->getImageLink($product.id_product, $imageIds, 'home_default')|escape:'html':'UTF-8'}" alt="" />
-                        {/if}
-                    </div>
-                    <p class="product-name"><span class="product_name">{$product.details->name}</span></p>
-                    <div class="description">{$product.details->description_short|strip_tags|truncate:170:'...'}</div>
-                    {if !$PS_CATALOG_MODE AND $product.details->show_price}
-                    <div class="prices">
-                        {if isset($product.details->new) AND $product.details->new}<span class="new-box"><span class="new-label">{l s='New'}</span></span>{/if}
-                        <p class="price product-price">{if $priceDisplay}{convertPrice price=$product.details->getPrice(false, $product.details->getDefaultAttribute($product.id_product))}{else}{convertPrice price=$product.details->getPrice(true, $product.details->getDefaultAttribute($product.id_product))}{/if}</p>
-                            {if $product.details->on_sale}
-                            <span class="sale-box"><span class="sale-label">{l s='Sale'}</span></span>
-                        {elseif isset($product.reduction) && $product.reduction}
-                            <span class="discount">{l s='Reduced price!'}</span>
-                        {/if}
-                    </div>
-                    {/if}
+            <a href="{$product.link|escape:'html':'UTF-8'}" class="popover-button" style="width:{$product.zone_width}px; height:{$product.zone_height}px; margin-left:{$product.x_axis}px ;margin-top:{$product.y_axis}px;" data-id_product_scene="{$scene_key|intval}_{$product_key|intval}_{$product.id_product|intval}">
+              <span style="margin-top:{math equation='a/2 -10' a=$product.zone_height}px; margin-left:{math equation='a/2 -10' a=$product.zone_width}px;"></span>
+            </a>
+            <div id="scene_products_cluetip_{$scene_key}_{$product_key}_{$product.id_product}" style="display:none;">
+              <div class="product-image-container">
+                {if isset($imageIds)}
+                  <img class="img-responsive replace-2x" src="{$link->getImageLink($product.id_product, $imageIds, 'home_default')|escape:'html':'UTF-8'}" alt="" />
+                {/if}
+              </div>
+              <p class="product-name"><span class="product_name">{$product.details->name}</span></p>
+              <div class="description">{$product.details->description_short|strip_tags|truncate:170:'...'}</div>
+              {if !$PS_CATALOG_MODE AND $product.details->show_price}
+                <div class="prices">
+                  {if isset($product.details->new) AND $product.details->new}<span class="new-box"><span class="new-label">{l s='New'}</span></span>{/if}
+                  <p class="price product-price">{if $priceDisplay}{convertPrice price=$product.details->getPrice(false, $product.details->getDefaultAttribute($product.id_product))}{else}{convertPrice price=$product.details->getPrice(true, $product.details->getDefaultAttribute($product.id_product))}{/if}</p>
+                  {if $product.details->on_sale}
+                    <span class="sale-box"><span class="sale-label">{l s='Sale'}</span></span>
+                  {elseif isset($product.reduction) && $product.reduction}
+                    <span class="discount">{l s='Reduced price!'}</span>
+                  {/if}
                 </div>
-            {/foreach}
+              {/if}
+            </div>
+          {/foreach}
         </div>
-        {/foreach}
+      {/foreach}
     </div>
     {if isset($scenes.1)}
-    <div class="thumbs_banner" style="height:{$thumbSceneImageType.height}px;">
+      <div class="thumbs_banner" style="height:{$thumbSceneImageType.height}px;">
         <span class="space-keeper">
             <a class="prev" href="#" style="height:{math equation='a+2' a=$thumbSceneImageType.height}px;">&nbsp;</a>
         </span>
         <div id="scenes_list">
-            <ul style="width:{math equation='(a*b + (a-1)*10)' a=$scenes|@count b=$thumbSceneImageType.width}px; height:{$thumbSceneImageType.height}px;">
+          <ul style="width:{math equation='(a*b + (a-1)*10)' a=$scenes|@count b=$thumbSceneImageType.width}px; height:{$thumbSceneImageType.height}px;">
             {foreach $scenes as $scene}
-                <li id="scene_thumb_{$scene->id}" style="{if !$scene@last} padding-right:10px;{/if}">
-                    <a style="width:{$thumbSceneImageType.width}px; height:{$thumbSceneImageType.height}px" title="{$scene->name|escape:'html':'UTF-8'}" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" data-id_scene="{$scene->id|intval}" class="scene_thumb">
-                        <img alt="{$scene->name|escape:'html':'UTF-8'}" src="{$content_dir}img/scenes/thumbs/{$scene->id}-m_scene_default.jpg" width="{$thumbSceneSize.width}" height="{$thumbSceneSize.height}" />
-                    </a>
-                </li>
+              <li id="scene_thumb_{$scene->id}" style="{if !$scene@last} padding-right:10px;{/if}">
+                <a style="width:{$thumbSceneImageType.width}px; height:{$thumbSceneImageType.height}px" title="{$scene->name|escape:'html':'UTF-8'}" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" data-id_scene="{$scene->id|intval}" class="scene_thumb">
+                  <img alt="{$scene->name|escape:'html':'UTF-8'}" src="{$content_dir}img/scenes/thumbs/{$scene->id}-m_scene_default.jpg" width="{$thumbSceneSize.width}" height="{$thumbSceneSize.height}" />
+                </a>
+              </li>
             {/foreach}
-            </ul>
+          </ul>
         </div>
         <span class="space-keeper">
             <a class="next" href="{if isset($force_ssl) && $force_ssl}{$base_dir_ssl}{else}{$base_dir}{/if}" style="height:{math equation='a+2' a=$thumbSceneImageType.height}px;">&nbsp;</a>
         </span>
-    </div>
+      </div>
     {/if}
-</div>
-{strip}
-{addJsDefL name=i18n_scene_close}{l s='Close' js=1}{/addJsDefL}
-{addJsDef li_width=($thumbSceneImageType.width|intval+10)}
-{/strip}
+  </div>
+  {strip}
+    {addJsDefL name=i18n_scene_close}{l s='Close' js=1}{/addJsDefL}
+    {addJsDef li_width=($thumbSceneImageType.width|intval+10)}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/search.tpl
+++ b/themes/community-theme-16/search.tpl
@@ -26,63 +26,63 @@
 {capture name=path}{l s='Search'}{/capture}
 
 <h1
-{if isset($instant_search) && $instant_search}id="instant_search_results"{/if}
-class="page-heading {if !isset($instant_search) || (isset($instant_search) && !$instant_search)} product-listing{/if}">
-    {l s='Search'}&nbsp;
-    {if $nbProducts > 0}
-        <span class="lighter">
-            "{if isset($search_query) && $search_query}{$search_query|escape:'html':'UTF-8'}{elseif $search_tag}{$search_tag|escape:'html':'UTF-8'}{elseif $ref}{$ref|escape:'html':'UTF-8'}{/if}"
-        </span>
-    {/if}
-    {if isset($instant_search) && $instant_search}
-        <a href="#" class="close">
-            {l s='Return to the previous page'}
-        </a>
-    {else}
-        <span class="heading-counter">
-            {if $nbProducts == 1}{l s='%d result has been found.' sprintf=$nbProducts|intval}{else}{l s='%d results have been found.' sprintf=$nbProducts|intval}{/if}
-        </span>
-    {/if}
+  {if isset($instant_search) && $instant_search}id="instant_search_results"{/if}
+  class="page-heading {if !isset($instant_search) || (isset($instant_search) && !$instant_search)} product-listing{/if}">
+  {l s='Search'}&nbsp;
+  {if $nbProducts > 0}
+    <span class="lighter">
+      "{if isset($search_query) && $search_query}{$search_query|escape:'html':'UTF-8'}{elseif $search_tag}{$search_tag|escape:'html':'UTF-8'}{elseif $ref}{$ref|escape:'html':'UTF-8'}{/if}"
+    </span>
+  {/if}
+  {if isset($instant_search) && $instant_search}
+    <a href="#" class="close">
+      {l s='Return to the previous page'}
+    </a>
+  {else}
+    <span class="heading-counter">
+      {if $nbProducts == 1}{l s='%d result has been found.' sprintf=$nbProducts|intval}{else}{l s='%d results have been found.' sprintf=$nbProducts|intval}{/if}
+    </span>
+  {/if}
 </h1>
 
 {include file="$tpl_dir./errors.tpl"}
 {if !$nbProducts}
-    <p class="alert alert-warning">
-        {if isset($search_query) && $search_query}
-            {l s='No results were found for your search'}&nbsp;"{if isset($search_query)}{$search_query|escape:'html':'UTF-8'}{/if}"
-        {elseif isset($search_tag) && $search_tag}
-            {l s='No results were found for your search'}&nbsp;"{$search_tag|escape:'html':'UTF-8'}"
-        {else}
-            {l s='Please enter a search keyword'}
-        {/if}
-    </p>
-{else}
-    {if isset($instant_search) && $instant_search}
-        <p class="alert alert-info">
-            {if $nbProducts == 1}{l s='%d result has been found.' sprintf=$nbProducts|intval}{else}{l s='%d results have been found.' sprintf=$nbProducts|intval}{/if}
-        </p>
+  <p class="alert alert-warning">
+    {if isset($search_query) && $search_query}
+      {l s='No results were found for your search'}&nbsp;"{if isset($search_query)}{$search_query|escape:'html':'UTF-8'}{/if}"
+    {elseif isset($search_tag) && $search_tag}
+      {l s='No results were found for your search'}&nbsp;"{$search_tag|escape:'html':'UTF-8'}"
+    {else}
+      {l s='Please enter a search keyword'}
     {/if}
-    <div class="content_sortPagiBar">
-        <div class="sortPagiBar clearfix {if isset($instant_search) && $instant_search} instant_search{/if}">
-            {include file="$tpl_dir./product-sort.tpl"}
-            {if !isset($instant_search) || (isset($instant_search) && !$instant_search)}
-                {include file="./nbr-product-page.tpl"}
-            {/if}
-        </div>
-        <div class="top-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {if !isset($instant_search) || (isset($instant_search) && !$instant_search)}
-                {include file="$tpl_dir./pagination.tpl" no_follow=1}
-            {/if}
-        </div>
+  </p>
+{else}
+  {if isset($instant_search) && $instant_search}
+    <p class="alert alert-info">
+      {if $nbProducts == 1}{l s='%d result has been found.' sprintf=$nbProducts|intval}{else}{l s='%d results have been found.' sprintf=$nbProducts|intval}{/if}
+    </p>
+  {/if}
+  <div class="content_sortPagiBar">
+    <div class="sortPagiBar clearfix {if isset($instant_search) && $instant_search} instant_search{/if}">
+      {include file="$tpl_dir./product-sort.tpl"}
+      {if !isset($instant_search) || (isset($instant_search) && !$instant_search)}
+        {include file="./nbr-product-page.tpl"}
+      {/if}
     </div>
-    {include file="$tpl_dir./product-list.tpl" products=$search_products}
-    <div class="content_sortPagiBar">
-        <div class="bottom-pagination-content clearfix">
-            {include file="./product-compare.tpl"}
-            {if !isset($instant_search) || (isset($instant_search) && !$instant_search)}
-                {include file="$tpl_dir./pagination.tpl" paginationId='bottom' no_follow=1}
-            {/if}
-        </div>
+    <div class="top-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {if !isset($instant_search) || (isset($instant_search) && !$instant_search)}
+        {include file="$tpl_dir./pagination.tpl" no_follow=1}
+      {/if}
     </div>
+  </div>
+  {include file="$tpl_dir./product-list.tpl" products=$search_products}
+  <div class="content_sortPagiBar">
+    <div class="bottom-pagination-content clearfix">
+      {include file="./product-compare.tpl"}
+      {if !isset($instant_search) || (isset($instant_search) && !$instant_search)}
+        {include file="$tpl_dir./pagination.tpl" paginationId='bottom' no_follow=1}
+      {/if}
+    </div>
+  </div>
 {/if}

--- a/themes/community-theme-16/shopping-cart-advanced.tpl
+++ b/themes/community-theme-16/shopping-cart-advanced.tpl
@@ -29,345 +29,345 @@
 {* eu-legal *}
 {hook h="displayBeforeShoppingCartBlock"}
 <div id="order-detail-content" class="table_block table-responsive">
-    <table id="cart_summary" class="table table-bordered {if $PS_STOCK_MANAGEMENT}stock-management-on{else}stock-management-off{/if}">
-        <thead>
-        <tr>
-            <th class="cart_product first_item">{l s='Product'}</th>
-            <th class="cart_description item">{l s='Description'}</th>
-            {if $PS_STOCK_MANAGEMENT}
-                {assign var='col_span_subtotal' value='3'}
-                {assign var='col_span_total' value='7'}
-                <th class="cart_avail item text-center">{l s='Availability'}</th>
-            {else}
-                {assign var='col_span_subtotal' value='2'}
-                {assign var='col_span_total' value='6'}
-            {/if}
-            <th class="cart_unit item text-right">{l s='Unit price'}</th>
-            <th class="cart_quantity item text-center">{l s='Qty'}</th>
-            <th colspan="{$col_span_subtotal}" class="cart_total item text-right">{l s='Total'}</th>
-        </tr>
-        </thead>
-        <tfoot>
-        {assign var='rowspan_total' value=2+$total_discounts_num+$total_wrapping_taxes_num}
+  <table id="cart_summary" class="table table-bordered {if $PS_STOCK_MANAGEMENT}stock-management-on{else}stock-management-off{/if}">
+    <thead>
+    <tr>
+      <th class="cart_product first_item">{l s='Product'}</th>
+      <th class="cart_description item">{l s='Description'}</th>
+      {if $PS_STOCK_MANAGEMENT}
+        {assign var='col_span_subtotal' value='3'}
+        {assign var='col_span_total' value='7'}
+        <th class="cart_avail item text-center">{l s='Availability'}</th>
+      {else}
+        {assign var='col_span_subtotal' value='2'}
+        {assign var='col_span_total' value='6'}
+      {/if}
+      <th class="cart_unit item text-right">{l s='Unit price'}</th>
+      <th class="cart_quantity item text-center">{l s='Qty'}</th>
+      <th colspan="{$col_span_subtotal}" class="cart_total item text-right">{l s='Total'}</th>
+    </tr>
+    </thead>
+    <tfoot>
+    {assign var='rowspan_total' value=2+$total_discounts_num+$total_wrapping_taxes_num}
 
-        {if $use_taxes && $show_taxes && $total_tax != 0}
-            {assign var='rowspan_total' value=$rowspan_total+1}
-        {/if}
+    {if $use_taxes && $show_taxes && $total_tax != 0}
+      {assign var='rowspan_total' value=$rowspan_total+1}
+    {/if}
 
-        {if $priceDisplay != 0}
-            {assign var='rowspan_total' value=$rowspan_total+1}
-        {/if}
+    {if $priceDisplay != 0}
+      {assign var='rowspan_total' value=$rowspan_total+1}
+    {/if}
 
-        {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
-            {assign var='rowspan_total' value=$rowspan_total+1}
-        {else}
-            {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
-                {if $priceDisplay && $total_shipping_tax_exc > 0}
-                    {assign var='rowspan_total' value=$rowspan_total+1}
-                {elseif $total_shipping > 0}
-                    {assign var='rowspan_total' value=$rowspan_total+1}
-                {/if}
-            {elseif $total_shipping_tax_exc > 0}
-                {assign var='rowspan_total' value=$rowspan_total+1}
-            {/if}
+    {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
+      {assign var='rowspan_total' value=$rowspan_total+1}
+    {else}
+      {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+        {if $priceDisplay && $total_shipping_tax_exc > 0}
+          {assign var='rowspan_total' value=$rowspan_total+1}
+        {elseif $total_shipping > 0}
+          {assign var='rowspan_total' value=$rowspan_total+1}
         {/if}
+      {elseif $total_shipping_tax_exc > 0}
+        {assign var='rowspan_total' value=$rowspan_total+1}
+      {/if}
+    {/if}
 
-        {if $use_taxes}
-            {if $priceDisplay}
-                <tr class="cart_total_price">
-                    <td rowspan="{$rowspan_total}" colspan="3" id="cart_voucher" class="cart_voucher">
-                        {if $voucherAllowed}
-                            <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                                <fieldset>
-                                    <h4>{l s='Vouchers'}</h4>
-                                    <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                    <input type="hidden" name="submitDiscount" />
-                                    <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
-                                </fieldset>
-                            </form>
-                            {if $displayVouchers}
-                                <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
-                                <div id="display_cart_vouchers">
-                                    {foreach $displayVouchers as $voucher}
-                                        {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
-                                    {/foreach}
-                                </div>
-                            {/if}
-                        {/if}
-                    </td>
-                    <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
-                    <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
-                </tr>
-            {else}
-                <tr class="cart_total_price">
-                    <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
-                        {if $voucherAllowed}
-                            <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                                <fieldset>
-                                    <h4>{l s='Vouchers'}</h4>
-                                    <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                    <input type="hidden" name="submitDiscount" />
-                                    <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
-                                </fieldset>
-                            </form>
-                            {if $displayVouchers}
-                                <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
-                                <div id="display_cart_vouchers">
-                                    {foreach $displayVouchers as $voucher}
-                                        {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
-                                    {/foreach}
-                                </div>
-                            {/if}
-                        {/if}
-                    </td>
-                    <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
-                    <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
-                </tr>
-            {/if}
-        {else}
-            <tr class="cart_total_price">
-                <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
-                    {if $voucherAllowed}
-                        <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                            <fieldset>
-                                <h4>{l s='Vouchers'}</h4>
-                                <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                <input type="hidden" name="submitDiscount" />
-                                <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small">
-                                    <span>{l s='OK'}</span>
-                                </button>
-                            </fieldset>
-                        </form>
-                        {if $displayVouchers}
-                            <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
-                            <div id="display_cart_vouchers">
-                                {foreach $displayVouchers as $voucher}
-                                    {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
-                                {/foreach}
-                            </div>
-                        {/if}
-                    {/if}
-                </td>
-                <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total products'}</td>
-                <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
-            </tr>
-        {/if}
-        <tr{if $total_wrapping == 0} style="display: none;"{/if}>
-            <td colspan="3" class="text-right">
-                {if $use_taxes}
-                    {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift-wrapping cost'}{/if}
-                {else}
-                    {l s='Total gift-wrapping cost'}
-                {/if}
-            </td>
-            <td colspan="2" class="price-discount price" id="total_wrapping">
-                {if $use_taxes}
-                    {if $priceDisplay}
-                        {displayPrice price=$total_wrapping_tax_exc}
-                    {else}
-                        {displayPrice price=$total_wrapping}
-                    {/if}
-                {else}
-                    {displayPrice price=$total_wrapping_tax_exc}
-                {/if}
-            </td>
-        </tr>
-        {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart)}
-            <tr class="cart_total_delivery{if !$opc && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
-                <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
-                <td colspan="2" class="price" id="total_shipping">{l s='Free shipping!'}</td>
-            </tr>
-        {else}
-            {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
-                {if $priceDisplay}
-                    <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
-                        <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
-                        <td colspan="2" class="price" id="total_shipping">{displayPrice price=$total_shipping_tax_exc}</td>
-                    </tr>
-                {else}
-                    <tr class="cart_total_delivery{if $total_shipping <= 0} unvisible{/if}">
-                        <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
-                        <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping}</td>
-                    </tr>
-                {/if}
-            {else}
-                <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
-                    <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
-                    <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping_tax_exc}</td>
-                </tr>
-            {/if}
-        {/if}
-        <tr class="cart_total_voucher{if $total_discounts == 0} unvisible{/if}">
-            <td colspan="{$col_span_subtotal}" class="text-right">
-                {if $display_tax_label}
-                    {if $use_taxes && $priceDisplay == 0}
-                        {l s='Total vouchers (tax incl.)'}
-                    {else}
-                        {l s='Total vouchers (tax excl.)'}
-                    {/if}
-                {else}
-                    {l s='Total vouchers'}
-                {/if}
-            </td>
-            <td colspan="2" class="price-discount price" id="total_discount">
-                {if $use_taxes && $priceDisplay == 0}
-                    {assign var='total_discounts_negative' value=$total_discounts * -1}
-                {else}
-                    {assign var='total_discounts_negative' value=$total_discounts_tax_exc * -1}
-                {/if}
-                {displayPrice price=$total_discounts_negative}
-            </td>
-        </tr>
-        {if $use_taxes && $show_taxes && $total_tax != 0 }
-            {if $priceDisplay != 0}
-                <tr class="cart_total_price">
-                    <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
-                    <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
-                </tr>
-            {/if}
-            <tr class="cart_total_tax">
-                <td colspan="{$col_span_subtotal}" class="text-right">{l s='Tax'}</td>
-                <td colspan="2" class="price" id="total_tax">{displayPrice price=$total_tax}</td>
-            </tr>
-        {/if}
+    {if $use_taxes}
+      {if $priceDisplay}
         <tr class="cart_total_price">
-            <td colspan="{$col_span_subtotal}" class="total_price_container text-right">
-                <span>{l s='Total'}</span>
-                <div class="hookDisplayProductPriceBlock-price">
-                    {hook h="displayCartTotalPriceLabel"}
+          <td rowspan="{$rowspan_total}" colspan="3" id="cart_voucher" class="cart_voucher">
+            {if $voucherAllowed}
+              <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                <fieldset>
+                  <h4>{l s='Vouchers'}</h4>
+                  <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                  <input type="hidden" name="submitDiscount" />
+                  <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
+                </fieldset>
+              </form>
+              {if $displayVouchers}
+                <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                <div id="display_cart_vouchers">
+                  {foreach $displayVouchers as $voucher}
+                    {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                  {/foreach}
                 </div>
-            </td>
-            {if $use_taxes}
-                <td colspan="2" class="price" id="total_price_container">
-                    <span id="total_price">{displayPrice price=$total_price}</span>
-                </td>
-            {else}
-                <td colspan="2" class="price" id="total_price_container">
-                    <span id="total_price">{displayPrice price=$total_price_without_tax}</span>
-                </td>
+              {/if}
             {/if}
+          </td>
+          <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
+          <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
         </tr>
-        {hook h="displayAfterShoppingCartBlock" colspan_total=$col_span_total}
-        </tfoot>
-        <tbody>
-        {assign var='odd' value=0}
-        {assign var='have_non_virtual_products' value=false}
-        {foreach $products as $product}
-            {if $product.is_virtual == 0}
-                {assign var='have_non_virtual_products' value=true}
+      {else}
+        <tr class="cart_total_price">
+          <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
+            {if $voucherAllowed}
+              <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                <fieldset>
+                  <h4>{l s='Vouchers'}</h4>
+                  <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                  <input type="hidden" name="submitDiscount" />
+                  <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
+                </fieldset>
+              </form>
+              {if $displayVouchers}
+                <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                <div id="display_cart_vouchers">
+                  {foreach $displayVouchers as $voucher}
+                    {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                  {/foreach}
+                </div>
+              {/if}
             {/if}
-            {assign var='productId' value=$product.id_product}
-            {assign var='productAttributeId' value=$product.id_product_attribute}
-            {assign var='quantityDisplayed' value=0}
-            {assign var='odd' value=($odd+1)%2}
-            {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId) || count($gift_products)}
-            {* Display the product line *}
-            {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=1 cannotModify=1}
-            {* Then the customized datas ones*}
-            {if isset($customizedDatas.$productId.$productAttributeId)}
-                {foreach $customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] as $id_customization=>$customization}
-                    <tr
-                            id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
-                            class="product_customization_for_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}{if $odd} odd{else} even{/if} customization alternate_item {if $product@last && $customization@last && !count($gift_products)}last_item{/if}">
-                        <td></td>
-                        <td colspan="3">
-                            {foreach $customization.datas as $type => $custom_data}
-                                {if $type == $CUSTOMIZE_FILE}
-                                    <div class="customizationUploaded">
-                                        <ul class="customizationUploaded">
-                                            {foreach $custom_data as $picture}
-                                                <li><img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" /></li>
-                                            {/foreach}
-                                        </ul>
-                                    </div>
-                                {elseif $type == $CUSTOMIZE_TEXTFIELD}
-                                    <ul class="typedText">
-                                        {foreach $custom_data as $textField}
-                                            <li>
-                                                {if $textField.name}
-                                                    {$textField.name}
-                                                {else}
-                                                    {l s='Text #'}{$textField@index+1}
-                                                {/if}
-                                                : {$textField.value}
-                                            </li>
-                                        {/foreach}
-                                    </ul>
-                                {/if}
-                            {/foreach}
-                        </td>
-                        <td class="cart_quantity" colspan="1">
-                            <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
-                        </td>
-
-                        <td>
-                        </td>
-                    </tr>
-                    {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
+          </td>
+          <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
+          <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
+        </tr>
+      {/if}
+    {else}
+      <tr class="cart_total_price">
+        <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
+          {if $voucherAllowed}
+            <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+              <fieldset>
+                <h4>{l s='Vouchers'}</h4>
+                <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                <input type="hidden" name="submitDiscount" />
+                <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small">
+                  <span>{l s='OK'}</span>
+                </button>
+              </fieldset>
+            </form>
+            {if $displayVouchers}
+              <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+              <div id="display_cart_vouchers">
+                {foreach $displayVouchers as $voucher}
+                  {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
                 {/foreach}
-
-                {* If it exists also some uncustomized products *}
-                {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=1 cannotModify=1}{/if}
+              </div>
             {/if}
-        {/foreach}
-        {assign var='last_was_odd' value=$product@iteration%2}
-        {foreach $gift_products as $product}
-            {assign var='productId' value=$product.id_product}
-            {assign var='productAttributeId' value=$product.id_product_attribute}
-            {assign var='quantityDisplayed' value=0}
-            {assign var='odd' value=($product@iteration+$last_was_odd)%2}
-            {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
-            {assign var='cannotModify' value=1}
-            {* Display the gift product line *}
-            {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=1 cannotModify=1}
-        {/foreach}
-        </tbody>
-        {if sizeof($discounts)}
-            <tbody>
-            {foreach $discounts as $discount}
-                {if (float)$discount.value_real == 0}
-                    {continue}
-                {/if}
-                <tr class="cart_discount {if $discount@last}last_item{elseif $discount@first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
-                    <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
-                    <td class="cart_discount_price">
-                                <span class="price-discount">
-                                {if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}
-                                </span>
-                    </td>
-                    <td class="cart_discount_delete">1</td>
-                    <td class="price_discount_del text-center">
-                        {if strlen($discount.code)}
-                            <a
-                                    href="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}?deleteDiscount={$discount.id_discount}"
-                                    class="price_discount_delete"
-                                    title="{l s='Delete'}">
-                                <i class="icon-trash"></i>
-                            </a>
-                        {/if}
-                    </td>
-                    <td class="cart_discount_price">
-                        <span class="price-discount price">{if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}</span>
-                    </td>
-                </tr>
-            {/foreach}
-            </tbody>
+          {/if}
+        </td>
+        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total products'}</td>
+        <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+      </tr>
+    {/if}
+    <tr{if $total_wrapping == 0} style="display: none;"{/if}>
+      <td colspan="3" class="text-right">
+        {if $use_taxes}
+          {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift-wrapping cost'}{/if}
+        {else}
+          {l s='Total gift-wrapping cost'}
         {/if}
-    </table>
+      </td>
+      <td colspan="2" class="price-discount price" id="total_wrapping">
+        {if $use_taxes}
+          {if $priceDisplay}
+            {displayPrice price=$total_wrapping_tax_exc}
+          {else}
+            {displayPrice price=$total_wrapping}
+          {/if}
+        {else}
+          {displayPrice price=$total_wrapping_tax_exc}
+        {/if}
+      </td>
+    </tr>
+    {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart)}
+      <tr class="cart_total_delivery{if !$opc && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
+        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
+        <td colspan="2" class="price" id="total_shipping">{l s='Free shipping!'}</td>
+      </tr>
+    {else}
+      {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+        {if $priceDisplay}
+          <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
+            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
+            <td colspan="2" class="price" id="total_shipping">{displayPrice price=$total_shipping_tax_exc}</td>
+          </tr>
+        {else}
+          <tr class="cart_total_delivery{if $total_shipping <= 0} unvisible{/if}">
+            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
+            <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping}</td>
+          </tr>
+        {/if}
+      {else}
+        <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
+          <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
+          <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping_tax_exc}</td>
+        </tr>
+      {/if}
+    {/if}
+    <tr class="cart_total_voucher{if $total_discounts == 0} unvisible{/if}">
+      <td colspan="{$col_span_subtotal}" class="text-right">
+        {if $display_tax_label}
+          {if $use_taxes && $priceDisplay == 0}
+            {l s='Total vouchers (tax incl.)'}
+          {else}
+            {l s='Total vouchers (tax excl.)'}
+          {/if}
+        {else}
+          {l s='Total vouchers'}
+        {/if}
+      </td>
+      <td colspan="2" class="price-discount price" id="total_discount">
+        {if $use_taxes && $priceDisplay == 0}
+          {assign var='total_discounts_negative' value=$total_discounts * -1}
+        {else}
+          {assign var='total_discounts_negative' value=$total_discounts_tax_exc * -1}
+        {/if}
+        {displayPrice price=$total_discounts_negative}
+      </td>
+    </tr>
+    {if $use_taxes && $show_taxes && $total_tax != 0 }
+      {if $priceDisplay != 0}
+        <tr class="cart_total_price">
+          <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
+          <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
+        </tr>
+      {/if}
+      <tr class="cart_total_tax">
+        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Tax'}</td>
+        <td colspan="2" class="price" id="total_tax">{displayPrice price=$total_tax}</td>
+      </tr>
+    {/if}
+    <tr class="cart_total_price">
+      <td colspan="{$col_span_subtotal}" class="total_price_container text-right">
+        <span>{l s='Total'}</span>
+        <div class="hookDisplayProductPriceBlock-price">
+          {hook h="displayCartTotalPriceLabel"}
+        </div>
+      </td>
+      {if $use_taxes}
+        <td colspan="2" class="price" id="total_price_container">
+          <span id="total_price">{displayPrice price=$total_price}</span>
+        </td>
+      {else}
+        <td colspan="2" class="price" id="total_price_container">
+          <span id="total_price">{displayPrice price=$total_price_without_tax}</span>
+        </td>
+      {/if}
+    </tr>
+    {hook h="displayAfterShoppingCartBlock" colspan_total=$col_span_total}
+    </tfoot>
+    <tbody>
+    {assign var='odd' value=0}
+    {assign var='have_non_virtual_products' value=false}
+    {foreach $products as $product}
+      {if $product.is_virtual == 0}
+        {assign var='have_non_virtual_products' value=true}
+      {/if}
+      {assign var='productId' value=$product.id_product}
+      {assign var='productAttributeId' value=$product.id_product_attribute}
+      {assign var='quantityDisplayed' value=0}
+      {assign var='odd' value=($odd+1)%2}
+      {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId) || count($gift_products)}
+      {* Display the product line *}
+      {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=1 cannotModify=1}
+      {* Then the customized datas ones*}
+      {if isset($customizedDatas.$productId.$productAttributeId)}
+        {foreach $customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] as $id_customization=>$customization}
+          <tr
+            id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
+            class="product_customization_for_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}{if $odd} odd{else} even{/if} customization alternate_item {if $product@last && $customization@last && !count($gift_products)}last_item{/if}">
+            <td></td>
+            <td colspan="3">
+              {foreach $customization.datas as $type => $custom_data}
+                {if $type == $CUSTOMIZE_FILE}
+                  <div class="customizationUploaded">
+                    <ul class="customizationUploaded">
+                      {foreach $custom_data as $picture}
+                        <li><img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" /></li>
+                      {/foreach}
+                    </ul>
+                  </div>
+                {elseif $type == $CUSTOMIZE_TEXTFIELD}
+                  <ul class="typedText">
+                    {foreach $custom_data as $textField}
+                      <li>
+                        {if $textField.name}
+                          {$textField.name}
+                        {else}
+                          {l s='Text #'}{$textField@index+1}
+                        {/if}
+                        : {$textField.value}
+                      </li>
+                    {/foreach}
+                  </ul>
+                {/if}
+              {/foreach}
+            </td>
+            <td class="cart_quantity" colspan="1">
+              <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
+            </td>
+
+            <td>
+            </td>
+          </tr>
+          {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
+        {/foreach}
+
+        {* If it exists also some uncustomized products *}
+        {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=1 cannotModify=1}{/if}
+      {/if}
+    {/foreach}
+    {assign var='last_was_odd' value=$product@iteration%2}
+    {foreach $gift_products as $product}
+      {assign var='productId' value=$product.id_product}
+      {assign var='productAttributeId' value=$product.id_product_attribute}
+      {assign var='quantityDisplayed' value=0}
+      {assign var='odd' value=($product@iteration+$last_was_odd)%2}
+      {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
+      {assign var='cannotModify' value=1}
+      {* Display the gift product line *}
+      {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first noDeleteButton=1 cannotModify=1}
+    {/foreach}
+    </tbody>
+    {if sizeof($discounts)}
+      <tbody>
+      {foreach $discounts as $discount}
+        {if (float)$discount.value_real == 0}
+          {continue}
+        {/if}
+        <tr class="cart_discount {if $discount@last}last_item{elseif $discount@first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
+          <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
+          <td class="cart_discount_price">
+            <span class="price-discount">
+              {if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}
+            </span>
+          </td>
+          <td class="cart_discount_delete">1</td>
+          <td class="price_discount_del text-center">
+            {if strlen($discount.code)}
+              <a
+                href="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}?deleteDiscount={$discount.id_discount}"
+                class="price_discount_delete"
+                title="{l s='Delete'}">
+                <i class="icon-trash"></i>
+              </a>
+            {/if}
+          </td>
+          <td class="cart_discount_price">
+            <span class="price-discount price">{if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}</span>
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    {/if}
+  </table>
 </div> <!-- end order-detail-content -->
 
 
 
 <p class="cart_navigation clearfix">
 
-    {if $opc}
-        {assign var='back_link' value=$link->getPageLink('index')}
-    {else}
-        {assign var='back_link' value=$link->getPageLink('order', true, NULL, "step=2")}
-    {/if}
-    <a href="{$back_link|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
-        <i class="icon-chevron-left"></i>
-        {l s='Continue shopping'}
-    </a>
-    <button data-show-if-js="" style="" id="confirmOrder" type="button" class="button btn btn-default standard-checkout button-medium"><span>{l s='Order With Obligation To Pay'}</span></button>
+  {if $opc}
+    {assign var='back_link' value=$link->getPageLink('index')}
+  {else}
+    {assign var='back_link' value=$link->getPageLink('order', true, NULL, "step=2")}
+  {/if}
+  <a href="{$back_link|escape:'html':'UTF-8'}" title="{l s='Previous'}" class="button-exclusive btn btn-default">
+    <i class="icon-chevron-left"></i>
+    {l s='Continue shopping'}
+  </a>
+  <button data-show-if-js="" style="" id="confirmOrder" type="button" class="button btn btn-default standard-checkout button-medium"><span>{l s='Order With Obligation To Pay'}</span></button>
 </p>

--- a/themes/community-theme-16/shopping-cart-product-line.tpl
+++ b/themes/community-theme-16/shopping-cart-product-line.tpl
@@ -23,116 +23,116 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 <tr id="product_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}" class="cart_item{if isset($productLast) && $productLast && (!isset($ignoreProductLast) || !$ignoreProductLast)} last_item{/if}{if isset($productFirst) && $productFirst} first_item{/if}{if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0} alternate_item{/if} address_{$product.id_address_delivery|intval} {if $odd}odd{else}even{/if}">
-    <td class="cart_product">
-        <a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}" {if isset($smallSize)}width="{$smallSize.width}" height="{$smallSize.height}" {/if} /></a>
-    </td>
-    <td class="cart_description">
-        {capture name=sep} : {/capture}
-        {capture}{l s=' : '}{/capture}
-        <p class="product-name"><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}">{$product.name|escape:'html':'UTF-8'}</a></p>
-            {if $product.reference}<small class="cart_ref">{l s='SKU'}{$smarty.capture.default}{$product.reference|escape:'html':'UTF-8'}</small>{/if}
-        {if isset($product.attributes) && $product.attributes}<small><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}">{$product.attributes|@replace: $smarty.capture.sep:$smarty.capture.default|escape:'html':'UTF-8'}</a></small>{/if}
-    </td>
-    {if $PS_STOCK_MANAGEMENT}
-        <td class="cart_avail"><span class="label{if $product.quantity_available <= 0 && isset($product.allow_oosp) && !$product.allow_oosp} label-danger{elseif $product.quantity_available <= 0} label-warning{else} label-success{/if}">{if $product.quantity_available <= 0}{if isset($product.allow_oosp) && $product.allow_oosp}{if isset($product.available_later) && $product.available_later}{$product.available_later}{else}{l s='In Stock'}{/if}{else}{l s='Out of stock'}{/if}{else}{if isset($product.available_now) && $product.available_now}{$product.available_now}{else}{l s='In Stock'}{/if}{/if}</span>{if !$product.is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}</td>
-    {/if}
-    <td class="cart_unit" data-title="{l s='Unit price'}">
-        <ul class="price text-right" id="product_price_{$product.id_product}_{$product.id_product_attribute}{if $quantityDisplayed > 0}_nocustom{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}">
-            {if !empty($product.gift)}
-                <li class="gift-icon">{l s='Gift!'}</li>
-            {else}
-                {if !$priceDisplay}
-                    <li class="price{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies} special-price{/if}">{convertPrice price=$product.price_wt}</li>
-                {else}
-                    <li class="price{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies} special-price{/if}">{convertPrice price=$product.price}</li>
-                {/if}
-                {if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies}
-                    <li class="price-percent-reduction small">
-                        {if !$priceDisplay}
-                            {if isset($product.reduction_type) && $product.reduction_type == 'amount'}
-                                {assign var='priceReduction' value=($product.price_wt - $product.price_without_specific_price)}
-                                {assign var='symbol' value=$currency->sign}
-                            {else}
-                                {assign var='priceReduction' value=(($product.price_without_specific_price - $product.price_wt)/$product.price_without_specific_price) * 100 * -1}
-                                {assign var='symbol' value='%'}
-                            {/if}
-                        {else}
-                            {if isset($product.reduction_type) && $product.reduction_type == 'amount'}
-                                {assign var='priceReduction' value=($product.price - $product.price_without_specific_price)}
-                                {assign var='symbol' value=$currency->sign}
-                            {else}
-                                {assign var='priceReduction' value=(($product.price_without_specific_price - $product.price)/$product.price_without_specific_price) * -100}
-                                {assign var='symbol' value='%'}
-                            {/if}
-                        {/if}
-                        {if $symbol == '%'}
-                            &nbsp;{$priceReduction|string_format:"%.2f"|regex_replace:"/[^\d]0+$/":""}{$symbol}&nbsp;
-                        {else}
-                            &nbsp;{convertPrice price=$priceReduction}&nbsp;
-                        {/if}
-                    </li>
-                    <li class="old-price">{convertPrice price=$product.price_without_specific_price}</li>
-                {/if}
-            {/if}
-        </ul>
-    </td>
-
-    <td class="cart_quantity text-center" data-title="{l s='Quantity'}">
-        {if (isset($cannotModify) && $cannotModify == 1)}
-            <span>
-                {if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}
-                    {$product.customizationQuantityTotal}
-                {else}
-                    {$product.cart_quantity-$quantityDisplayed}
-                {/if}
-            </span>
+  <td class="cart_product">
+    <a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}"><img src="{$link->getImageLink($product.link_rewrite, $product.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$product.name|escape:'html':'UTF-8'}" {if isset($smallSize)}width="{$smallSize.width}" height="{$smallSize.height}" {/if} /></a>
+  </td>
+  <td class="cart_description">
+    {capture name=sep} : {/capture}
+    {capture}{l s=' : '}{/capture}
+    <p class="product-name"><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}">{$product.name|escape:'html':'UTF-8'}</a></p>
+    {if $product.reference}<small class="cart_ref">{l s='SKU'}{$smarty.capture.default}{$product.reference|escape:'html':'UTF-8'}</small>{/if}
+    {if isset($product.attributes) && $product.attributes}<small><a href="{$link->getProductLink($product.id_product, $product.link_rewrite, $product.category, null, null, $product.id_shop, $product.id_product_attribute, false, false, true)|escape:'html':'UTF-8'}">{$product.attributes|@replace: $smarty.capture.sep:$smarty.capture.default|escape:'html':'UTF-8'}</a></small>{/if}
+  </td>
+  {if $PS_STOCK_MANAGEMENT}
+    <td class="cart_avail"><span class="label{if $product.quantity_available <= 0 && isset($product.allow_oosp) && !$product.allow_oosp} label-danger{elseif $product.quantity_available <= 0} label-warning{else} label-success{/if}">{if $product.quantity_available <= 0}{if isset($product.allow_oosp) && $product.allow_oosp}{if isset($product.available_later) && $product.available_later}{$product.available_later}{else}{l s='In Stock'}{/if}{else}{l s='Out of stock'}{/if}{else}{if isset($product.available_now) && $product.available_now}{$product.available_now}{else}{l s='In Stock'}{/if}{/if}</span>{if !$product.is_virtual}{hook h="displayProductDeliveryTime" product=$product}{/if}</td>
+  {/if}
+  <td class="cart_unit" data-title="{l s='Unit price'}">
+    <ul class="price text-right" id="product_price_{$product.id_product}_{$product.id_product_attribute}{if $quantityDisplayed > 0}_nocustom{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}">
+      {if !empty($product.gift)}
+        <li class="gift-icon">{l s='Gift!'}</li>
+      {else}
+        {if !$priceDisplay}
+          <li class="price{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies} special-price{/if}">{convertPrice price=$product.price_wt}</li>
         {else}
-            {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0}
-                <span id="cart_quantity_custom_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}" >{$product.customizationQuantityTotal}</span>
-            {/if}
-            {if !isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0}
-
-                <input type="hidden" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}_hidden" />
-                <input size="2" type="text" autocomplete="off" class="cart_quantity_input form-control grey" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}"  name="quantity_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" />
-                <div class="cart_quantity_button clearfix">
-                {if $product.minimal_quantity < ($product.cart_quantity-$quantityDisplayed) OR $product.minimal_quantity <= 1}
-                    <a rel="nofollow" class="cart_quantity_down btn btn-default button-minus" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}">
-                <span><i class="icon-minus"></i></span>
-                </a>
-                {else}
-                    <a class="cart_quantity_down btn btn-default button-minus disabled" href="#" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" title="{l s='You must purchase a minimum of %d of this product.' sprintf=$product.minimal_quantity}">
-                    <span><i class="icon-minus"></i></span>
-                </a>
-                {/if}
-                    <a rel="nofollow" class="cart_quantity_up btn btn-default button-plus" id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
-                </div>
-            {/if}
+          <li class="price{if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies} special-price{/if}">{convertPrice price=$product.price}</li>
         {/if}
-    </td>
-
-    {if !isset($noDeleteButton) || !$noDeleteButton}
-        <td class="cart_delete text-center" data-title="{l s='Delete'}">
-        {if (!isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0) && empty($product.gift)}
-            <div>
-                <a rel="nofollow" title="{l s='Delete'}" class="cart_quantity_delete" id="{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"><i class="icon-trash"></i></a>
-            </div>
-        {else}
-
-        {/if}
-        </td>
-    {/if}
-    <td class="cart_total" data-title="{l s='Total'}">
-        <span class="price" id="total_product_price_{$product.id_product}_{$product.id_product_attribute}{if $quantityDisplayed > 0}_nocustom{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}">
-            {if !empty($product.gift)}
-                <span class="gift-icon">{l s='Gift!'}</span>
+        {if isset($product.is_discounted) && $product.is_discounted && isset($product.reduction_applies) && $product.reduction_applies}
+          <li class="price-percent-reduction small">
+            {if !$priceDisplay}
+              {if isset($product.reduction_type) && $product.reduction_type == 'amount'}
+                {assign var='priceReduction' value=($product.price_wt - $product.price_without_specific_price)}
+                {assign var='symbol' value=$currency->sign}
+              {else}
+                {assign var='priceReduction' value=(($product.price_without_specific_price - $product.price_wt)/$product.price_without_specific_price) * 100 * -1}
+                {assign var='symbol' value='%'}
+              {/if}
             {else}
-                {if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}
-                    {if !$priceDisplay}{displayPrice price=$product.total_customization_wt}{else}{displayPrice price=$product.total_customization}{/if}
-                {else}
-                    {if !$priceDisplay}{displayPrice price=$product.total_wt}{else}{displayPrice price=$product.total}{/if}
-                {/if}
+              {if isset($product.reduction_type) && $product.reduction_type == 'amount'}
+                {assign var='priceReduction' value=($product.price - $product.price_without_specific_price)}
+                {assign var='symbol' value=$currency->sign}
+              {else}
+                {assign var='priceReduction' value=(($product.price_without_specific_price - $product.price)/$product.price_without_specific_price) * -100}
+                {assign var='symbol' value='%'}
+              {/if}
             {/if}
-        </span>
+            {if $symbol == '%'}
+              &nbsp;{$priceReduction|string_format:"%.2f"|regex_replace:"/[^\d]0+$/":""}{$symbol}&nbsp;
+            {else}
+              &nbsp;{convertPrice price=$priceReduction}&nbsp;
+            {/if}
+          </li>
+          <li class="old-price">{convertPrice price=$product.price_without_specific_price}</li>
+        {/if}
+      {/if}
+    </ul>
+  </td>
+
+  <td class="cart_quantity text-center" data-title="{l s='Quantity'}">
+    {if (isset($cannotModify) && $cannotModify == 1)}
+      <span>
+        {if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}
+          {$product.customizationQuantityTotal}
+        {else}
+          {$product.cart_quantity-$quantityDisplayed}
+        {/if}
+      </span>
+    {else}
+      {if isset($customizedDatas.$productId.$productAttributeId) AND $quantityDisplayed == 0}
+        <span id="cart_quantity_custom_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}" >{$product.customizationQuantityTotal}</span>
+      {/if}
+      {if !isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0}
+
+        <input type="hidden" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}_hidden" />
+        <input size="2" type="text" autocomplete="off" class="cart_quantity_input form-control grey" value="{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}"  name="quantity_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" />
+        <div class="cart_quantity_button clearfix">
+          {if $product.minimal_quantity < ($product.cart_quantity-$quantityDisplayed) OR $product.minimal_quantity <= 1}
+            <a rel="nofollow" class="cart_quantity_down btn btn-default button-minus" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Subtract'}">
+              <span><i class="icon-minus"></i></span>
+            </a>
+          {else}
+            <a class="cart_quantity_down btn btn-default button-minus disabled" href="#" id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" title="{l s='You must purchase a minimum of %d of this product.' sprintf=$product.minimal_quantity}">
+              <span><i class="icon-minus"></i></span>
+            </a>
+          {/if}
+          <a rel="nofollow" class="cart_quantity_up btn btn-default button-plus" id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}" title="{l s='Add'}"><span><i class="icon-plus"></i></span></a>
+        </div>
+      {/if}
+    {/if}
+  </td>
+
+  {if !isset($noDeleteButton) || !$noDeleteButton}
+    <td class="cart_delete text-center" data-title="{l s='Delete'}">
+      {if (!isset($customizedDatas.$productId.$productAttributeId) OR $quantityDisplayed > 0) && empty($product.gift)}
+        <div>
+          <a rel="nofollow" title="{l s='Delete'}" class="cart_quantity_delete" id="{$product.id_product}_{$product.id_product_attribute}_{if $quantityDisplayed > 0}nocustom{else}0{/if}_{$product.id_address_delivery|intval}" href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery|intval}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"><i class="icon-trash"></i></a>
+        </div>
+      {else}
+
+      {/if}
     </td>
+  {/if}
+  <td class="cart_total" data-title="{l s='Total'}">
+    <span class="price" id="total_product_price_{$product.id_product}_{$product.id_product_attribute}{if $quantityDisplayed > 0}_nocustom{/if}_{$product.id_address_delivery|intval}{if !empty($product.gift)}_gift{/if}">
+      {if !empty($product.gift)}
+        <span class="gift-icon">{l s='Gift!'}</span>
+      {else}
+        {if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}
+          {if !$priceDisplay}{displayPrice price=$product.total_customization_wt}{else}{displayPrice price=$product.total_customization}{/if}
+        {else}
+          {if !$priceDisplay}{displayPrice price=$product.total_wt}{else}{displayPrice price=$product.total}{/if}
+        {/if}
+      {/if}
+    </span>
+  </td>
 
 </tr>

--- a/themes/community-theme-16/shopping-cart.tpl
+++ b/themes/community-theme-16/shopping-cart.tpl
@@ -26,17 +26,17 @@
 {capture name=path}{l s='Your shopping cart'}{/capture}
 
 <h1 id="cart_title" class="page-heading">{l s='Shopping-cart summary'}
-    {if !isset($empty) && !$PS_CATALOG_MODE}
-        <span class="heading-counter">{l s='Your shopping cart contains:'}
-            <span id="summary_products_quantity">{$productNumber} {if $productNumber == 1}{l s='product'}{else}{l s='products'}{/if}</span>
-        </span>
-    {/if}
+  {if !isset($empty) && !$PS_CATALOG_MODE}
+    <span class="heading-counter">{l s='Your shopping cart contains:'}
+      <span id="summary_products_quantity">{$productNumber} {if $productNumber == 1}{l s='product'}{else}{l s='products'}{/if}</span>
+    </span>
+  {/if}
 </h1>
 
 {if isset($account_created)}
-    <p class="alert alert-success">
-        {l s='Your account has been created.'}
-    </p>
+  <p class="alert alert-success">
+    {l s='Your account has been created.'}
+  </p>
 {/if}
 
 {assign var='current_step' value='summary'}
@@ -44,522 +44,522 @@
 {include file="$tpl_dir./errors.tpl"}
 
 {if isset($empty)}
-    <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
+  <p class="alert alert-warning">{l s='Your shopping cart is empty.'}</p>
 {elseif $PS_CATALOG_MODE}
-    <p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
+  <p class="alert alert-warning">{l s='This store has not accepted your new order.'}</p>
 {else}
-    <p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
-    {if isset($lastProductAdded) AND $lastProductAdded}
-        <div class="cart_last_product">
-            <div class="cart_last_product_header">
-                <div class="left">{l s='Last product added'}</div>
-            </div>
-            <a class="cart_last_product_img" href="{$link->getProductLink($lastProductAdded.id_product, $lastProductAdded.link_rewrite, $lastProductAdded.category, null, null, $lastProductAdded.id_shop)|escape:'html':'UTF-8'}">
-                <img src="{$link->getImageLink($lastProductAdded.link_rewrite, $lastProductAdded.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$lastProductAdded.name|escape:'html':'UTF-8'}"/>
+  <p id="emptyCartWarning" class="alert alert-warning unvisible">{l s='Your shopping cart is empty.'}</p>
+  {if isset($lastProductAdded) AND $lastProductAdded}
+    <div class="cart_last_product">
+      <div class="cart_last_product_header">
+        <div class="left">{l s='Last product added'}</div>
+      </div>
+      <a class="cart_last_product_img" href="{$link->getProductLink($lastProductAdded.id_product, $lastProductAdded.link_rewrite, $lastProductAdded.category, null, null, $lastProductAdded.id_shop)|escape:'html':'UTF-8'}">
+        <img src="{$link->getImageLink($lastProductAdded.link_rewrite, $lastProductAdded.id_image, 'small_default')|escape:'html':'UTF-8'}" alt="{$lastProductAdded.name|escape:'html':'UTF-8'}"/>
+      </a>
+      <div class="cart_last_product_content">
+        <p class="product-name">
+          <a href="{$link->getProductLink($lastProductAdded.id_product, $lastProductAdded.link_rewrite, $lastProductAdded.category, null, null, null, $lastProductAdded.id_product_attribute)|escape:'html':'UTF-8'}">
+            {$lastProductAdded.name|escape:'html':'UTF-8'}
+          </a>
+        </p>
+        {if isset($lastProductAdded.attributes) && $lastProductAdded.attributes}
+          <small>
+            <a href="{$link->getProductLink($lastProductAdded.id_product, $lastProductAdded.link_rewrite, $lastProductAdded.category, null, null, null, $lastProductAdded.id_product_attribute)|escape:'html':'UTF-8'}">
+              {$lastProductAdded.attributes|escape:'html':'UTF-8'}
             </a>
-            <div class="cart_last_product_content">
-                <p class="product-name">
-                    <a href="{$link->getProductLink($lastProductAdded.id_product, $lastProductAdded.link_rewrite, $lastProductAdded.category, null, null, null, $lastProductAdded.id_product_attribute)|escape:'html':'UTF-8'}">
-                        {$lastProductAdded.name|escape:'html':'UTF-8'}
-                    </a>
-                </p>
-                {if isset($lastProductAdded.attributes) && $lastProductAdded.attributes}
-                    <small>
-                        <a href="{$link->getProductLink($lastProductAdded.id_product, $lastProductAdded.link_rewrite, $lastProductAdded.category, null, null, null, $lastProductAdded.id_product_attribute)|escape:'html':'UTF-8'}">
-                            {$lastProductAdded.attributes|escape:'html':'UTF-8'}
-                        </a>
-                    </small>
-                {/if}
-            </div>
-        </div>
-    {/if}
-    {assign var='total_discounts_num' value="{if $total_discounts != 0}1{else}0{/if}"}
-    {assign var='use_show_taxes' value="{if $use_taxes && $show_taxes}2{else}0{/if}"}
-    {assign var='total_wrapping_taxes_num' value="{if $total_wrapping != 0}1{else}0{/if}"}
-    {* eu-legal *}
-    {hook h="displayBeforeShoppingCartBlock"}
-    <div id="order-detail-content" class="table_block table-responsive">
-        <table id="cart_summary" class="table table-bordered {if $PS_STOCK_MANAGEMENT}stock-management-on{else}stock-management-off{/if}">
-            <thead>
-                <tr>
-                    <th class="cart_product first_item">{l s='Product'}</th>
-                    <th class="cart_description item">{l s='Description'}</th>
-                    {if $PS_STOCK_MANAGEMENT}
-                        {assign var='col_span_subtotal' value='3'}
-                        <th class="cart_avail item text-center">{l s='Availability'}</th>
-                    {else}
-                        {assign var='col_span_subtotal' value='2'}
-                    {/if}
-                    <th class="cart_unit item text-right">{l s='Unit price'}</th>
-                    <th class="cart_quantity item text-center">{l s='Qty'}</th>
-                    <th class="cart_delete last_item">&nbsp;</th>
-                    <th class="cart_total item text-right">{l s='Total'}</th>
-                </tr>
-            </thead>
-            <tfoot>
-                {assign var='rowspan_total' value=2+$total_discounts_num+$total_wrapping_taxes_num}
-
-                {if $use_taxes && $show_taxes && $total_tax != 0}
-                    {assign var='rowspan_total' value=$rowspan_total+1}
-                {/if}
-
-                {if $priceDisplay != 0}
-                    {assign var='rowspan_total' value=$rowspan_total+1}
-                {/if}
-
-                {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
-                    {assign var='rowspan_total' value=$rowspan_total+1}
-                {else}
-                    {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
-                        {if $priceDisplay && $total_shipping_tax_exc > 0}
-                            {assign var='rowspan_total' value=$rowspan_total+1}
-                        {elseif $total_shipping > 0}
-                            {assign var='rowspan_total' value=$rowspan_total+1}
-                        {/if}
-                    {elseif $total_shipping_tax_exc > 0}
-                        {assign var='rowspan_total' value=$rowspan_total+1}
-                    {/if}
-                {/if}
-
-                {if $use_taxes}
-                    {if $priceDisplay}
-                        <tr class="cart_total_price">
-                            <td rowspan="{$rowspan_total}" colspan="3" id="cart_voucher" class="cart_voucher">
-                                {if $voucherAllowed}
-                                    <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                                        <fieldset>
-                                            <h4>{l s='Vouchers'}</h4>
-                                            <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                            <input type="hidden" name="submitDiscount" />
-                                            <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
-                                        </fieldset>
-                                    </form>
-                                    {if $displayVouchers}
-                                        <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
-                                        <div id="display_cart_vouchers">
-                                            {foreach $displayVouchers as $voucher}
-                                                {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
-                                            {/foreach}
-                                        </div>
-                                    {/if}
-                                {/if}
-                            </td>
-                            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
-                            <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
-                        </tr>
-                    {else}
-                        <tr class="cart_total_price">
-                            <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
-                                {if $voucherAllowed}
-                                    <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                                        <fieldset>
-                                            <h4>{l s='Vouchers'}</h4>
-                                            <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                            <input type="hidden" name="submitDiscount" />
-                                            <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
-                                        </fieldset>
-                                    </form>
-                                    {if $displayVouchers}
-                                        <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
-                                        <div id="display_cart_vouchers">
-                                            {foreach $displayVouchers as $voucher}
-                                                {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
-                                            {/foreach}
-                                        </div>
-                                    {/if}
-                                {/if}
-                            </td>
-                            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
-                            <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
-                        </tr>
-                    {/if}
-                {else}
-                    <tr class="cart_total_price">
-                        <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
-                            {if $voucherAllowed}
-                                <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
-                                    <fieldset>
-                                        <h4>{l s='Vouchers'}</h4>
-                                        <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
-                                        <input type="hidden" name="submitDiscount" />
-                                        <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small">
-                                            <span>{l s='OK'}</span>
-                                        </button>
-                                    </fieldset>
-                                </form>
-                                {if $displayVouchers}
-                                    <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
-                                    <div id="display_cart_vouchers">
-                                        {foreach $displayVouchers as $voucher}
-                                            {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
-                                        {/foreach}
-                                    </div>
-                                {/if}
-                            {/if}
-                        </td>
-                        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total products'}</td>
-                        <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
-                    </tr>
-                {/if}
-                <tr{if $total_wrapping == 0} style="display: none;"{/if}>
-                    <td colspan="3" class="text-right">
-                        {if $use_taxes}
-                            {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift-wrapping cost'}{/if}
-                        {else}
-                            {l s='Total gift-wrapping cost'}
-                        {/if}
-                    </td>
-                    <td colspan="2" class="price-discount price" id="total_wrapping">
-                        {if $use_taxes}
-                            {if $priceDisplay}
-                                {displayPrice price=$total_wrapping_tax_exc}
-                            {else}
-                                {displayPrice price=$total_wrapping}
-                            {/if}
-                        {else}
-                            {displayPrice price=$total_wrapping_tax_exc}
-                        {/if}
-                    </td>
-                </tr>
-                {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
-                    <tr class="cart_total_delivery{if !$opc && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
-                        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
-                        <td colspan="2" class="price" id="total_shipping">{l s='Free shipping!'}</td>
-                    </tr>
-                {else}
-                    {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
-                        {if $priceDisplay}
-                            <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
-                                <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
-                                <td colspan="2" class="price" id="total_shipping">{displayPrice price=$total_shipping_tax_exc}</td>
-                            </tr>
-                        {else}
-                            <tr class="cart_total_delivery{if $total_shipping <= 0} unvisible{/if}">
-                                <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
-                                <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping}</td>
-                            </tr>
-                        {/if}
-                    {else}
-                        <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
-                            <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
-                            <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping_tax_exc}</td>
-                        </tr>
-                    {/if}
-                {/if}
-                <tr class="cart_total_voucher{if $total_discounts == 0} unvisible{/if}">
-                    <td colspan="{$col_span_subtotal}" class="text-right">
-                        {if $display_tax_label}
-                            {if $use_taxes && $priceDisplay == 0}
-                                {l s='Total vouchers (tax incl.)'}
-                            {else}
-                                {l s='Total vouchers (tax excl.)'}
-                            {/if}
-                        {else}
-                            {l s='Total vouchers'}
-                        {/if}
-                    </td>
-                    <td colspan="2" class="price-discount price" id="total_discount">
-                        {if $use_taxes && $priceDisplay == 0}
-                            {assign var='total_discounts_negative' value=$total_discounts * -1}
-                        {else}
-                            {assign var='total_discounts_negative' value=$total_discounts_tax_exc * -1}
-                        {/if}
-                        {displayPrice price=$total_discounts_negative}
-                    </td>
-                </tr>
-                {if $use_taxes && $show_taxes && $total_tax != 0 }
-                    {if $priceDisplay != 0}
-                    <tr class="cart_total_price">
-                        <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
-                        <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
-                    </tr>
-                    {/if}
-                    <tr class="cart_total_tax">
-                        <td colspan="{$col_span_subtotal}" class="text-right">{l s='Tax'}</td>
-                        <td colspan="2" class="price" id="total_tax">{displayPrice price=$total_tax}</td>
-                    </tr>
-                {/if}
-                <tr class="cart_total_price">
-                    <td colspan="{$col_span_subtotal}" class="total_price_container text-right">
-                        <span>{l s='Total'}</span>
-                        <div class="hookDisplayProductPriceBlock-price">
-                            {hook h="displayCartTotalPriceLabel"}
-                        </div>
-                    </td>
-                    {if $use_taxes}
-                        <td colspan="2" class="price" id="total_price_container">
-                            <span id="total_price">{displayPrice price=$total_price}</span>
-                        </td>
-                    {else}
-                        <td colspan="2" class="price" id="total_price_container">
-                            <span id="total_price">{displayPrice price=$total_price_without_tax}</span>
-                        </td>
-                    {/if}
-                </tr>
-            </tfoot>
-            <tbody>
-                {assign var='odd' value=0}
-                {assign var='have_non_virtual_products' value=false}
-                {foreach $products as $product}
-                    {if $product.is_virtual == 0}
-                        {assign var='have_non_virtual_products' value=true}
-                    {/if}
-                    {assign var='productId' value=$product.id_product}
-                    {assign var='productAttributeId' value=$product.id_product_attribute}
-                    {assign var='quantityDisplayed' value=0}
-                    {assign var='odd' value=($odd+1)%2}
-                    {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId) || count($gift_products)}
-                    {* Display the product line *}
-                    {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
-                    {* Then the customized datas ones*}
-                    {if isset($customizedDatas.$productId.$productAttributeId[$product.id_address_delivery])}
-                        {foreach $customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] as $id_customization=>$customization}
-                            <tr
-                                id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
-                                class="product_customization_for_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}{if $odd} odd{else} even{/if} customization alternate_item {if $product@last && $customization@last && !count($gift_products)}last_item{/if}">
-                                <td></td>
-                                <td colspan="3">
-                                    {foreach $customization.datas as $type => $custom_data}
-                                        {if $type == $CUSTOMIZE_FILE}
-                                            <div class="customizationUploaded">
-                                                <ul class="customizationUploaded">
-                                                    {foreach $custom_data as $picture}
-                                                        <li><img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" /></li>
-                                                    {/foreach}
-                                                </ul>
-                                            </div>
-                                        {elseif $type == $CUSTOMIZE_TEXTFIELD}
-                                            <ul class="typedText">
-                                                {foreach $custom_data as $textField}
-                                                    <li>
-                                                        {if $textField.name}
-                                                            {$textField.name}
-                                                        {else}
-                                                            {l s='Text #'}{$textField@index+1}
-                                                        {/if}
-                                                        : {$textField.value}
-                                                    </li>
-                                                {/foreach}
-                                            </ul>
-                                        {/if}
-                                    {/foreach}
-                                </td>
-                                <td class="cart_quantity" colspan="1">
-                                    {if isset($cannotModify) AND $cannotModify == 1}
-                                        <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
-                                    {else}
-                                        <input type="hidden" value="{$customization.quantity}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}_hidden"/>
-                                        <input type="text" value="{$customization.quantity}" class="cart_quantity_input form-control grey" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"/>
-                                        <div class="cart_quantity_button clearfix">
-                                            {if $product.minimal_quantity < ($customization.quantity -$quantityDisplayed) OR $product.minimal_quantity <= 1}
-                                                <a
-                                                    id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
-                                                    class="cart_quantity_down btn btn-default button-minus"
-                                                    href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery}&amp;id_customization={$id_customization}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}"
-                                                    rel="nofollow"
-                                                    title="{l s='Subtract'}">
-                                                    <span><i class="icon-minus"></i></span>
-                                                </a>
-                                            {else}
-                                                <a
-                                                    id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}"
-                                                    class="cart_quantity_down btn btn-default button-minus disabled"
-                                                    href="#"
-                                                    title="{l s='Subtract'}">
-                                                    <span><i class="icon-minus"></i></span>
-                                                </a>
-                                            {/if}
-                                            <a
-                                                id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
-                                                class="cart_quantity_up btn btn-default button-plus"
-                                                href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery}&amp;id_customization={$id_customization}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"
-                                                rel="nofollow"
-                                                title="{l s='Add'}">
-                                                <span><i class="icon-plus"></i></span>
-                                            </a>
-                                        </div>
-                                    {/if}
-                                </td>
-                                <td class="cart_delete text-center">
-                                    {if isset($cannotModify) AND $cannotModify == 1}
-                                    {else}
-                                        <a
-                                            id="{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
-                                            class="cart_quantity_delete"
-                                            href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_customization={$id_customization}&amp;id_address_delivery={$product.id_address_delivery}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"
-                                            rel="nofollow"
-                                            title="{l s='Delete'}">
-                                            <i class="icon-trash"></i>
-                                        </a>
-                                    {/if}
-                                </td>
-                                <td>
-                                </td>
-                            </tr>
-                            {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
-                        {/foreach}
-
-                        {* If it exists also some uncustomized products *}
-                        {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}{/if}
-                    {/if}
-                {/foreach}
-                {assign var='last_was_odd' value=$product@iteration%2}
-                {foreach $gift_products as $product}
-                    {assign var='productId' value=$product.id_product}
-                    {assign var='productAttributeId' value=$product.id_product_attribute}
-                    {assign var='quantityDisplayed' value=0}
-                    {assign var='odd' value=($product@iteration+$last_was_odd)%2}
-                    {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
-                    {assign var='cannotModify' value=1}
-                    {* Display the gift product line *}
-                    {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
-                {/foreach}
-            </tbody>
-
-            {if sizeof($discounts)}
-                <tbody>
-                    {foreach $discounts as $discount}
-                    {if ((float)$discount.value_real == 0 && $discount.free_shipping != 1) || ((float)$discount.value_real == 0 && $discount.code == '')}
-                        {continue}
-                    {/if}
-                        <tr class="cart_discount {if $discount@last}last_item{elseif $discount@first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
-                            <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
-                            <td class="cart_discount_price">
-                                <span class="price-discount">
-                                {if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}
-                                </span>
-                            </td>
-                            <td class="cart_discount_delete">1</td>
-                            <td class="price_discount_del text-center">
-                                {if strlen($discount.code)}
-                                    <a
-                                        href="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}?deleteDiscount={$discount.id_discount}"
-                                        class="price_discount_delete"
-                                        title="{l s='Delete'}">
-                                        <i class="icon-trash"></i>
-                                    </a>
-                                {/if}
-                            </td>
-                            <td class="cart_discount_price">
-                                <span class="price-discount price">{if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}</span>
-                            </td>
-                        </tr>
-                    {/foreach}
-                </tbody>
-            {/if}
-        </table>
-    </div> <!-- end order-detail-content -->
-
-    {if $show_option_allow_separate_package}
-    <p>
-        <label for="allow_seperated_package" class="checkbox inline">
-            <input type="checkbox" name="allow_seperated_package" id="allow_seperated_package" {if $cart->allow_seperated_package}checked="checked"{/if} autocomplete="off"/>
-            {l s='Send available products first'}
-        </label>
-    </p>
-    {/if}
-
-    {* Define the style if it doesn't exist in the PrestaShop version*}
-    {* Will be deleted for 1.5 version and more *}
-    {if !isset($addresses_style)}
-        {$addresses_style.company = 'address_company'}
-        {$addresses_style.vat_number = 'address_company'}
-        {$addresses_style.firstname = 'address_name'}
-        {$addresses_style.lastname = 'address_name'}
-        {$addresses_style.address1 = 'address_address1'}
-        {$addresses_style.address2 = 'address_address2'}
-        {$addresses_style.city = 'address_city'}
-        {$addresses_style.country = 'address_country'}
-        {$addresses_style.phone = 'address_phone'}
-        {$addresses_style.phone_mobile = 'address_phone_mobile'}
-        {$addresses_style.alias = 'address_title'}
-    {/if}
-    {if !$advanced_payment_api && ((!empty($delivery_option) && (!isset($isVirtualCart) || !$isVirtualCart)) OR $delivery->id || $invoice->id) && !$opc}
-        <div class="order_delivery clearfix row">
-            {if !isset($formattedAddresses) || (count($formattedAddresses.invoice) == 0 && count($formattedAddresses.delivery) == 0) || (count($formattedAddresses.invoice.formated) == 0 && count($formattedAddresses.delivery.formated) == 0)}
-                {if $delivery->id}
-                    <div class="col-xs-12 col-sm-6"{if !$have_non_virtual_products} style="display: none;"{/if}>
-                        <ul id="delivery_address" class="address item box">
-                            <li><h3 class="page-subheading">{l s='Delivery address'}&nbsp;<span class="address_alias">({$delivery->alias})</span></h3></li>
-                            {if $delivery->company}<li class="address_company">{$delivery->company|escape:'html':'UTF-8'}</li>{/if}
-                            <li class="address_name">{$delivery->firstname|escape:'html':'UTF-8'} {$delivery->lastname|escape:'html':'UTF-8'}</li>
-                            <li class="address_address1">{$delivery->address1|escape:'html':'UTF-8'}</li>
-                            {if $delivery->address2}<li class="address_address2">{$delivery->address2|escape:'html':'UTF-8'}</li>{/if}
-                            <li class="address_city">{$delivery->postcode|escape:'html':'UTF-8'} {$delivery->city|escape:'html':'UTF-8'}</li>
-                            <li class="address_country">{$delivery->country|escape:'html':'UTF-8'} {if $delivery_state}({$delivery_state|escape:'html':'UTF-8'}){/if}</li>
-                        </ul>
-                    </div>
-                {/if}
-                {if $invoice->id}
-                    <div class="col-xs-12 col-sm-6">
-                        <ul id="invoice_address" class="address alternate_item box">
-                            <li><h3 class="page-subheading">{l s='Invoice address'}&nbsp;<span class="address_alias">({$invoice->alias})</span></h3></li>
-                            {if $invoice->company}<li class="address_company">{$invoice->company|escape:'html':'UTF-8'}</li>{/if}
-                            <li class="address_name">{$invoice->firstname|escape:'html':'UTF-8'} {$invoice->lastname|escape:'html':'UTF-8'}</li>
-                            <li class="address_address1">{$invoice->address1|escape:'html':'UTF-8'}</li>
-                            {if $invoice->address2}<li class="address_address2">{$invoice->address2|escape:'html':'UTF-8'}</li>{/if}
-                            <li class="address_city">{$invoice->postcode|escape:'html':'UTF-8'} {$invoice->city|escape:'html':'UTF-8'}</li>
-                            <li class="address_country">{$invoice->country|escape:'html':'UTF-8'} {if $invoice_state}({$invoice_state|escape:'html':'UTF-8'}){/if}</li>
-                        </ul>
-                    </div>
-                {/if}
-            {else}
-                {foreach from=$formattedAddresses key=k item=address}
-                    <div class="col-xs-12 col-sm-6"{if $k == 'delivery' && !$have_non_virtual_products} style="display: none;"{/if}>
-                        <ul class="address {if $address@last}last_item{elseif $address@first}first_item{/if} {if $address@index % 2}alternate_item{else}item{/if} box">
-                            <li>
-                                <h3 class="page-subheading">
-                                    {if $k eq 'invoice'}
-                                        {l s='Invoice address'}
-                                    {elseif $k eq 'delivery' && $delivery->id}
-                                        {l s='Delivery address'}
-                                    {/if}
-                                    {if isset($address.object.alias)}
-                                        <span class="address_alias">({$address.object.alias})</span>
-                                    {/if}
-                                </h3>
-                            </li>
-                            {foreach $address.ordered as $pattern}
-                                {assign var=addressKey value=" "|explode:$pattern}
-                                {assign var=addedli value=false}
-                                {foreach from=$addressKey item=key name=foo}
-                                {$key_str = $key|regex_replace:AddressFormat::_CLEANING_REGEX_:""}
-                                    {if isset($address.formated[$key_str]) && !empty($address.formated[$key_str])}
-                                        {if (!$addedli)}
-                                            {$addedli = true}
-                                            <li><span class="{if isset($addresses_style[$key_str])}{$addresses_style[$key_str]}{/if}">
-                                        {/if}
-                                        {$address.formated[$key_str]|escape:'html':'UTF-8'}
-                                    {/if}
-                                    {if ($smarty.foreach.foo.last && $addedli)}
-                                        </span></li>
-                                    {/if}
-                                {/foreach}
-                            {/foreach}
-                        </ul>
-                    </div>
-                {/foreach}
-            {/if}
-        </div>
-    {/if}
-    <div id="HOOK_SHOPPING_CART">{$HOOK_SHOPPING_CART}</div>
-    <p class="cart_navigation clearfix">
-        {if !$opc}
-            <a  href="{if $back}{$link->getPageLink('order', true, NULL, 'step=1&amp;back={$back}')|escape:'html':'UTF-8'}{else}{$link->getPageLink('order', true, NULL, 'step=1')|escape:'html':'UTF-8'}{/if}" class="button btn btn-default standard-checkout button-medium" title="{l s='Proceed to checkout'}">
-                <span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
-            </a>
+          </small>
         {/if}
-        <a href="{if (isset($smarty.server.HTTP_REFERER) && ($smarty.server.HTTP_REFERER == $link->getPageLink('order', true) || $smarty.server.HTTP_REFERER == $link->getPageLink('order-opc', true) || strstr($smarty.server.HTTP_REFERER, 'step='))) || !isset($smarty.server.HTTP_REFERER)}{$link->getPageLink('index')}{else}{$smarty.server.HTTP_REFERER|escape:'html':'UTF-8'|secureReferrer}{/if}" class="button-exclusive btn btn-default" title="{l s='Continue shopping'}">
-            <i class="icon-chevron-left"></i>{l s='Continue shopping'}
-        </a>
-    </p>
-    <div class="clear"></div>
-    <div class="cart_navigation_extra">
-        <div id="HOOK_SHOPPING_CART_EXTRA">{if isset($HOOK_SHOPPING_CART_EXTRA)}{$HOOK_SHOPPING_CART_EXTRA}{/if}</div>
+      </div>
     </div>
-{strip}
-{addJsDef deliveryAddress=$cart->id_address_delivery|intval}
-{addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
-{addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
-{/strip}
+  {/if}
+  {assign var='total_discounts_num' value="{if $total_discounts != 0}1{else}0{/if}"}
+  {assign var='use_show_taxes' value="{if $use_taxes && $show_taxes}2{else}0{/if}"}
+  {assign var='total_wrapping_taxes_num' value="{if $total_wrapping != 0}1{else}0{/if}"}
+  {* eu-legal *}
+  {hook h="displayBeforeShoppingCartBlock"}
+  <div id="order-detail-content" class="table_block table-responsive">
+    <table id="cart_summary" class="table table-bordered {if $PS_STOCK_MANAGEMENT}stock-management-on{else}stock-management-off{/if}">
+      <thead>
+      <tr>
+        <th class="cart_product first_item">{l s='Product'}</th>
+        <th class="cart_description item">{l s='Description'}</th>
+        {if $PS_STOCK_MANAGEMENT}
+          {assign var='col_span_subtotal' value='3'}
+          <th class="cart_avail item text-center">{l s='Availability'}</th>
+        {else}
+          {assign var='col_span_subtotal' value='2'}
+        {/if}
+        <th class="cart_unit item text-right">{l s='Unit price'}</th>
+        <th class="cart_quantity item text-center">{l s='Qty'}</th>
+        <th class="cart_delete last_item">&nbsp;</th>
+        <th class="cart_total item text-right">{l s='Total'}</th>
+      </tr>
+      </thead>
+      <tfoot>
+      {assign var='rowspan_total' value=2+$total_discounts_num+$total_wrapping_taxes_num}
+
+      {if $use_taxes && $show_taxes && $total_tax != 0}
+        {assign var='rowspan_total' value=$rowspan_total+1}
+      {/if}
+
+      {if $priceDisplay != 0}
+        {assign var='rowspan_total' value=$rowspan_total+1}
+      {/if}
+
+      {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
+        {assign var='rowspan_total' value=$rowspan_total+1}
+      {else}
+        {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+          {if $priceDisplay && $total_shipping_tax_exc > 0}
+            {assign var='rowspan_total' value=$rowspan_total+1}
+          {elseif $total_shipping > 0}
+            {assign var='rowspan_total' value=$rowspan_total+1}
+          {/if}
+        {elseif $total_shipping_tax_exc > 0}
+          {assign var='rowspan_total' value=$rowspan_total+1}
+        {/if}
+      {/if}
+
+      {if $use_taxes}
+        {if $priceDisplay}
+          <tr class="cart_total_price">
+            <td rowspan="{$rowspan_total}" colspan="3" id="cart_voucher" class="cart_voucher">
+              {if $voucherAllowed}
+                <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                  <fieldset>
+                    <h4>{l s='Vouchers'}</h4>
+                    <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                    <input type="hidden" name="submitDiscount" />
+                    <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
+                  </fieldset>
+                </form>
+                {if $displayVouchers}
+                  <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                  <div id="display_cart_vouchers">
+                    {foreach $displayVouchers as $voucher}
+                      {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                    {/foreach}
+                  </div>
+                {/if}
+              {/if}
+            </td>
+            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax excl.)'}{else}{l s='Total products'}{/if}</td>
+            <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+          </tr>
+        {else}
+          <tr class="cart_total_price">
+            <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
+              {if $voucherAllowed}
+                <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                  <fieldset>
+                    <h4>{l s='Vouchers'}</h4>
+                    <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                    <input type="hidden" name="submitDiscount" />
+                    <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small"><span>{l s='OK'}</span></button>
+                  </fieldset>
+                </form>
+                {if $displayVouchers}
+                  <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                  <div id="display_cart_vouchers">
+                    {foreach $displayVouchers as $voucher}
+                      {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                    {/foreach}
+                  </div>
+                {/if}
+              {/if}
+            </td>
+            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total products (tax incl.)'}{else}{l s='Total products'}{/if}</td>
+            <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products_wt}</td>
+          </tr>
+        {/if}
+      {else}
+        <tr class="cart_total_price">
+          <td rowspan="{$rowspan_total}" colspan="2" id="cart_voucher" class="cart_voucher">
+            {if $voucherAllowed}
+              <form action="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}" method="post" id="voucher">
+                <fieldset>
+                  <h4>{l s='Vouchers'}</h4>
+                  <input type="text" class="discount_name form-control" id="discount_name" name="discount_name" value="{if isset($discount_name) && $discount_name}{$discount_name}{/if}" />
+                  <input type="hidden" name="submitDiscount" />
+                  <button type="submit" name="submitAddDiscount" class="button btn btn-default button-small">
+                    <span>{l s='OK'}</span>
+                  </button>
+                </fieldset>
+              </form>
+              {if $displayVouchers}
+                <p id="title" class="title-offers">{l s='Take advantage of our exclusive offers:'}</p>
+                <div id="display_cart_vouchers">
+                  {foreach $displayVouchers as $voucher}
+                    {if $voucher.code != ''}<span class="voucher_name" data-code="{$voucher.code|escape:'html':'UTF-8'}">{$voucher.code|escape:'html':'UTF-8'}</span> - {/if}{$voucher.name}<br />
+                  {/foreach}
+                </div>
+              {/if}
+            {/if}
+          </td>
+          <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total products'}</td>
+          <td colspan="2" class="price" id="total_product">{displayPrice price=$total_products}</td>
+        </tr>
+      {/if}
+      <tr{if $total_wrapping == 0} style="display: none;"{/if}>
+        <td colspan="3" class="text-right">
+          {if $use_taxes}
+            {if $display_tax_label}{l s='Total gift wrapping (tax incl.)'}{else}{l s='Total gift-wrapping cost'}{/if}
+          {else}
+            {l s='Total gift-wrapping cost'}
+          {/if}
+        </td>
+        <td colspan="2" class="price-discount price" id="total_wrapping">
+          {if $use_taxes}
+            {if $priceDisplay}
+              {displayPrice price=$total_wrapping_tax_exc}
+            {else}
+              {displayPrice price=$total_wrapping}
+            {/if}
+          {else}
+            {displayPrice price=$total_wrapping_tax_exc}
+          {/if}
+        </td>
+      </tr>
+      {if $total_shipping_tax_exc <= 0 && (!isset($isVirtualCart) || !$isVirtualCart) && $free_ship}
+        <tr class="cart_total_delivery{if !$opc && (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
+          <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
+          <td colspan="2" class="price" id="total_shipping">{l s='Free shipping!'}</td>
+        </tr>
+      {else}
+        {if $use_taxes && $total_shipping_tax_exc != $total_shipping}
+          {if $priceDisplay}
+            <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
+              <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax excl.)'}{else}{l s='Total shipping'}{/if}</td>
+              <td colspan="2" class="price" id="total_shipping">{displayPrice price=$total_shipping_tax_exc}</td>
+            </tr>
+          {else}
+            <tr class="cart_total_delivery{if $total_shipping <= 0} unvisible{/if}">
+              <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total shipping (tax incl.)'}{else}{l s='Total shipping'}{/if}</td>
+              <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping}</td>
+            </tr>
+          {/if}
+        {else}
+          <tr class="cart_total_delivery{if $total_shipping_tax_exc <= 0} unvisible{/if}">
+            <td colspan="{$col_span_subtotal}" class="text-right">{l s='Total shipping'}</td>
+            <td colspan="2" class="price" id="total_shipping" >{displayPrice price=$total_shipping_tax_exc}</td>
+          </tr>
+        {/if}
+      {/if}
+      <tr class="cart_total_voucher{if $total_discounts == 0} unvisible{/if}">
+        <td colspan="{$col_span_subtotal}" class="text-right">
+          {if $display_tax_label}
+            {if $use_taxes && $priceDisplay == 0}
+              {l s='Total vouchers (tax incl.)'}
+            {else}
+              {l s='Total vouchers (tax excl.)'}
+            {/if}
+          {else}
+            {l s='Total vouchers'}
+          {/if}
+        </td>
+        <td colspan="2" class="price-discount price" id="total_discount">
+          {if $use_taxes && $priceDisplay == 0}
+            {assign var='total_discounts_negative' value=$total_discounts * -1}
+          {else}
+            {assign var='total_discounts_negative' value=$total_discounts_tax_exc * -1}
+          {/if}
+          {displayPrice price=$total_discounts_negative}
+        </td>
+      </tr>
+      {if $use_taxes && $show_taxes && $total_tax != 0 }
+        {if $priceDisplay != 0}
+          <tr class="cart_total_price">
+            <td colspan="{$col_span_subtotal}" class="text-right">{if $display_tax_label}{l s='Total (tax excl.)'}{else}{l s='Total'}{/if}</td>
+            <td colspan="2" class="price" id="total_price_without_tax">{displayPrice price=$total_price_without_tax}</td>
+          </tr>
+        {/if}
+        <tr class="cart_total_tax">
+          <td colspan="{$col_span_subtotal}" class="text-right">{l s='Tax'}</td>
+          <td colspan="2" class="price" id="total_tax">{displayPrice price=$total_tax}</td>
+        </tr>
+      {/if}
+      <tr class="cart_total_price">
+        <td colspan="{$col_span_subtotal}" class="total_price_container text-right">
+          <span>{l s='Total'}</span>
+          <div class="hookDisplayProductPriceBlock-price">
+            {hook h="displayCartTotalPriceLabel"}
+          </div>
+        </td>
+        {if $use_taxes}
+          <td colspan="2" class="price" id="total_price_container">
+            <span id="total_price">{displayPrice price=$total_price}</span>
+          </td>
+        {else}
+          <td colspan="2" class="price" id="total_price_container">
+            <span id="total_price">{displayPrice price=$total_price_without_tax}</span>
+          </td>
+        {/if}
+      </tr>
+      </tfoot>
+      <tbody>
+      {assign var='odd' value=0}
+      {assign var='have_non_virtual_products' value=false}
+      {foreach $products as $product}
+        {if $product.is_virtual == 0}
+          {assign var='have_non_virtual_products' value=true}
+        {/if}
+        {assign var='productId' value=$product.id_product}
+        {assign var='productAttributeId' value=$product.id_product_attribute}
+        {assign var='quantityDisplayed' value=0}
+        {assign var='odd' value=($odd+1)%2}
+        {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId) || count($gift_products)}
+        {* Display the product line *}
+        {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
+        {* Then the customized datas ones*}
+        {if isset($customizedDatas.$productId.$productAttributeId[$product.id_address_delivery])}
+          {foreach $customizedDatas.$productId.$productAttributeId[$product.id_address_delivery] as $id_customization=>$customization}
+            <tr
+              id="product_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
+              class="product_customization_for_{$product.id_product}_{$product.id_product_attribute}_{$product.id_address_delivery|intval}{if $odd} odd{else} even{/if} customization alternate_item {if $product@last && $customization@last && !count($gift_products)}last_item{/if}">
+              <td></td>
+              <td colspan="3">
+                {foreach $customization.datas as $type => $custom_data}
+                  {if $type == $CUSTOMIZE_FILE}
+                    <div class="customizationUploaded">
+                      <ul class="customizationUploaded">
+                        {foreach $custom_data as $picture}
+                          <li><img src="{$pic_dir}{$picture.value}_small" alt="" class="customizationUploaded" /></li>
+                        {/foreach}
+                      </ul>
+                    </div>
+                  {elseif $type == $CUSTOMIZE_TEXTFIELD}
+                    <ul class="typedText">
+                      {foreach $custom_data as $textField}
+                        <li>
+                          {if $textField.name}
+                            {$textField.name}
+                          {else}
+                            {l s='Text #'}{$textField@index+1}
+                          {/if}
+                          : {$textField.value}
+                        </li>
+                      {/foreach}
+                    </ul>
+                  {/if}
+                {/foreach}
+              </td>
+              <td class="cart_quantity" colspan="1">
+                {if isset($cannotModify) AND $cannotModify == 1}
+                  <span>{if $quantityDisplayed == 0 AND isset($customizedDatas.$productId.$productAttributeId)}{$customizedDatas.$productId.$productAttributeId|@count}{else}{$product.cart_quantity-$quantityDisplayed}{/if}</span>
+                {else}
+                  <input type="hidden" value="{$customization.quantity}" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}_hidden"/>
+                  <input type="text" value="{$customization.quantity}" class="cart_quantity_input form-control grey" name="quantity_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"/>
+                  <div class="cart_quantity_button clearfix">
+                    {if $product.minimal_quantity < ($customization.quantity -$quantityDisplayed) OR $product.minimal_quantity <= 1}
+                      <a
+                        id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
+                        class="cart_quantity_down btn btn-default button-minus"
+                        href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery}&amp;id_customization={$id_customization}&amp;op=down&amp;token={$token_cart}")|escape:'html':'UTF-8'}"
+                        rel="nofollow"
+                        title="{l s='Subtract'}">
+                        <span><i class="icon-minus"></i></span>
+                      </a>
+                    {else}
+                      <a
+                        id="cart_quantity_down_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}"
+                        class="cart_quantity_down btn btn-default button-minus disabled"
+                        href="#"
+                        title="{l s='Subtract'}">
+                        <span><i class="icon-minus"></i></span>
+                      </a>
+                    {/if}
+                    <a
+                      id="cart_quantity_up_{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
+                      class="cart_quantity_up btn btn-default button-plus"
+                      href="{$link->getPageLink('cart', true, NULL, "add=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_address_delivery={$product.id_address_delivery}&amp;id_customization={$id_customization}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"
+                      rel="nofollow"
+                      title="{l s='Add'}">
+                      <span><i class="icon-plus"></i></span>
+                    </a>
+                  </div>
+                {/if}
+              </td>
+              <td class="cart_delete text-center">
+                {if isset($cannotModify) AND $cannotModify == 1}
+                {else}
+                  <a
+                    id="{$product.id_product}_{$product.id_product_attribute}_{$id_customization}_{$product.id_address_delivery|intval}"
+                    class="cart_quantity_delete"
+                    href="{$link->getPageLink('cart', true, NULL, "delete=1&amp;id_product={$product.id_product|intval}&amp;ipa={$product.id_product_attribute|intval}&amp;id_customization={$id_customization}&amp;id_address_delivery={$product.id_address_delivery}&amp;token={$token_cart}")|escape:'html':'UTF-8'}"
+                    rel="nofollow"
+                    title="{l s='Delete'}">
+                    <i class="icon-trash"></i>
+                  </a>
+                {/if}
+              </td>
+              <td>
+              </td>
+            </tr>
+            {assign var='quantityDisplayed' value=$quantityDisplayed+$customization.quantity}
+          {/foreach}
+
+          {* If it exists also some uncustomized products *}
+          {if $product.quantity-$quantityDisplayed > 0}{include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}{/if}
+        {/if}
+      {/foreach}
+      {assign var='last_was_odd' value=$product@iteration%2}
+      {foreach $gift_products as $product}
+        {assign var='productId' value=$product.id_product}
+        {assign var='productAttributeId' value=$product.id_product_attribute}
+        {assign var='quantityDisplayed' value=0}
+        {assign var='odd' value=($product@iteration+$last_was_odd)%2}
+        {assign var='ignoreProductLast' value=isset($customizedDatas.$productId.$productAttributeId)}
+        {assign var='cannotModify' value=1}
+        {* Display the gift product line *}
+        {include file="$tpl_dir./shopping-cart-product-line.tpl" productLast=$product@last productFirst=$product@first}
+      {/foreach}
+      </tbody>
+
+      {if sizeof($discounts)}
+        <tbody>
+        {foreach $discounts as $discount}
+          {if ((float)$discount.value_real == 0 && $discount.free_shipping != 1) || ((float)$discount.value_real == 0 && $discount.code == '')}
+            {continue}
+          {/if}
+          <tr class="cart_discount {if $discount@last}last_item{elseif $discount@first}first_item{else}item{/if}" id="cart_discount_{$discount.id_discount}">
+            <td class="cart_discount_name" colspan="{if $PS_STOCK_MANAGEMENT}3{else}2{/if}">{$discount.name}</td>
+            <td class="cart_discount_price">
+              <span class="price-discount">
+                {if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}
+              </span>
+            </td>
+            <td class="cart_discount_delete">1</td>
+            <td class="price_discount_del text-center">
+              {if strlen($discount.code)}
+                <a
+                  href="{if $opc}{$link->getPageLink('order-opc', true)}{else}{$link->getPageLink('order', true)}{/if}?deleteDiscount={$discount.id_discount}"
+                  class="price_discount_delete"
+                  title="{l s='Delete'}">
+                  <i class="icon-trash"></i>
+                </a>
+              {/if}
+            </td>
+            <td class="cart_discount_price">
+              <span class="price-discount price">{if !$priceDisplay}{displayPrice price=$discount.value_real*-1}{else}{displayPrice price=$discount.value_tax_exc*-1}{/if}</span>
+            </td>
+          </tr>
+        {/foreach}
+        </tbody>
+      {/if}
+    </table>
+  </div> <!-- end order-detail-content -->
+
+  {if $show_option_allow_separate_package}
+    <p>
+      <label for="allow_seperated_package" class="checkbox inline">
+        <input type="checkbox" name="allow_seperated_package" id="allow_seperated_package" {if $cart->allow_seperated_package}checked="checked"{/if} autocomplete="off"/>
+        {l s='Send available products first'}
+      </label>
+    </p>
+  {/if}
+
+  {* Define the style if it doesn't exist in the PrestaShop version*}
+  {* Will be deleted for 1.5 version and more *}
+  {if !isset($addresses_style)}
+    {$addresses_style.company = 'address_company'}
+    {$addresses_style.vat_number = 'address_company'}
+    {$addresses_style.firstname = 'address_name'}
+    {$addresses_style.lastname = 'address_name'}
+    {$addresses_style.address1 = 'address_address1'}
+    {$addresses_style.address2 = 'address_address2'}
+    {$addresses_style.city = 'address_city'}
+    {$addresses_style.country = 'address_country'}
+    {$addresses_style.phone = 'address_phone'}
+    {$addresses_style.phone_mobile = 'address_phone_mobile'}
+    {$addresses_style.alias = 'address_title'}
+  {/if}
+  {if !$advanced_payment_api && ((!empty($delivery_option) && (!isset($isVirtualCart) || !$isVirtualCart)) OR $delivery->id || $invoice->id) && !$opc}
+    <div class="order_delivery clearfix row">
+      {if !isset($formattedAddresses) || (count($formattedAddresses.invoice) == 0 && count($formattedAddresses.delivery) == 0) || (count($formattedAddresses.invoice.formated) == 0 && count($formattedAddresses.delivery.formated) == 0)}
+        {if $delivery->id}
+          <div class="col-xs-12 col-sm-6"{if !$have_non_virtual_products} style="display: none;"{/if}>
+            <ul id="delivery_address" class="address item box">
+              <li><h3 class="page-subheading">{l s='Delivery address'}&nbsp;<span class="address_alias">({$delivery->alias})</span></h3></li>
+              {if $delivery->company}<li class="address_company">{$delivery->company|escape:'html':'UTF-8'}</li>{/if}
+              <li class="address_name">{$delivery->firstname|escape:'html':'UTF-8'} {$delivery->lastname|escape:'html':'UTF-8'}</li>
+              <li class="address_address1">{$delivery->address1|escape:'html':'UTF-8'}</li>
+              {if $delivery->address2}<li class="address_address2">{$delivery->address2|escape:'html':'UTF-8'}</li>{/if}
+              <li class="address_city">{$delivery->postcode|escape:'html':'UTF-8'} {$delivery->city|escape:'html':'UTF-8'}</li>
+              <li class="address_country">{$delivery->country|escape:'html':'UTF-8'} {if $delivery_state}({$delivery_state|escape:'html':'UTF-8'}){/if}</li>
+            </ul>
+          </div>
+        {/if}
+        {if $invoice->id}
+          <div class="col-xs-12 col-sm-6">
+            <ul id="invoice_address" class="address alternate_item box">
+              <li><h3 class="page-subheading">{l s='Invoice address'}&nbsp;<span class="address_alias">({$invoice->alias})</span></h3></li>
+              {if $invoice->company}<li class="address_company">{$invoice->company|escape:'html':'UTF-8'}</li>{/if}
+              <li class="address_name">{$invoice->firstname|escape:'html':'UTF-8'} {$invoice->lastname|escape:'html':'UTF-8'}</li>
+              <li class="address_address1">{$invoice->address1|escape:'html':'UTF-8'}</li>
+              {if $invoice->address2}<li class="address_address2">{$invoice->address2|escape:'html':'UTF-8'}</li>{/if}
+              <li class="address_city">{$invoice->postcode|escape:'html':'UTF-8'} {$invoice->city|escape:'html':'UTF-8'}</li>
+              <li class="address_country">{$invoice->country|escape:'html':'UTF-8'} {if $invoice_state}({$invoice_state|escape:'html':'UTF-8'}){/if}</li>
+            </ul>
+          </div>
+        {/if}
+      {else}
+        {foreach from=$formattedAddresses key=k item=address}
+          <div class="col-xs-12 col-sm-6"{if $k == 'delivery' && !$have_non_virtual_products} style="display: none;"{/if}>
+            <ul class="address {if $address@last}last_item{elseif $address@first}first_item{/if} {if $address@index % 2}alternate_item{else}item{/if} box">
+              <li>
+                <h3 class="page-subheading">
+                  {if $k eq 'invoice'}
+                    {l s='Invoice address'}
+                  {elseif $k eq 'delivery' && $delivery->id}
+                    {l s='Delivery address'}
+                  {/if}
+                  {if isset($address.object.alias)}
+                    <span class="address_alias">({$address.object.alias})</span>
+                  {/if}
+                </h3>
+              </li>
+              {foreach $address.ordered as $pattern}
+                {assign var=addressKey value=" "|explode:$pattern}
+                {assign var=addedli value=false}
+                {foreach from=$addressKey item=key name=foo}
+                  {$key_str = $key|regex_replace:AddressFormat::_CLEANING_REGEX_:""}
+                  {if isset($address.formated[$key_str]) && !empty($address.formated[$key_str])}
+                    {if (!$addedli)}
+                      {$addedli = true}
+                      <li><span class="{if isset($addresses_style[$key_str])}{$addresses_style[$key_str]}{/if}">
+                    {/if}
+                    {$address.formated[$key_str]|escape:'html':'UTF-8'}
+                  {/if}
+                  {if ($smarty.foreach.foo.last && $addedli)}
+                    </span></li>
+                  {/if}
+                {/foreach}
+              {/foreach}
+            </ul>
+          </div>
+        {/foreach}
+      {/if}
+    </div>
+  {/if}
+  <div id="HOOK_SHOPPING_CART">{$HOOK_SHOPPING_CART}</div>
+  <p class="cart_navigation clearfix">
+    {if !$opc}
+      <a  href="{if $back}{$link->getPageLink('order', true, NULL, 'step=1&amp;back={$back}')|escape:'html':'UTF-8'}{else}{$link->getPageLink('order', true, NULL, 'step=1')|escape:'html':'UTF-8'}{/if}" class="button btn btn-default standard-checkout button-medium" title="{l s='Proceed to checkout'}">
+        <span>{l s='Proceed to checkout'}<i class="icon-chevron-right right"></i></span>
+      </a>
+    {/if}
+    <a href="{if (isset($smarty.server.HTTP_REFERER) && ($smarty.server.HTTP_REFERER == $link->getPageLink('order', true) || $smarty.server.HTTP_REFERER == $link->getPageLink('order-opc', true) || strstr($smarty.server.HTTP_REFERER, 'step='))) || !isset($smarty.server.HTTP_REFERER)}{$link->getPageLink('index')}{else}{$smarty.server.HTTP_REFERER|escape:'html':'UTF-8'|secureReferrer}{/if}" class="button-exclusive btn btn-default" title="{l s='Continue shopping'}">
+      <i class="icon-chevron-left"></i>{l s='Continue shopping'}
+    </a>
+  </p>
+  <div class="clear"></div>
+  <div class="cart_navigation_extra">
+    <div id="HOOK_SHOPPING_CART_EXTRA">{if isset($HOOK_SHOPPING_CART_EXTRA)}{$HOOK_SHOPPING_CART_EXTRA}{/if}</div>
+  </div>
+  {strip}
+    {addJsDef deliveryAddress=$cart->id_address_delivery|intval}
+    {addJsDefL name=txtProduct}{l s='product' js=1}{/addJsDefL}
+    {addJsDefL name=txtProducts}{l s='products' js=1}{/addJsDefL}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/sitemap.tpl
+++ b/themes/community-theme-16/sitemap.tpl
@@ -26,196 +26,196 @@
 {capture name=path}{l s='Sitemap'}{/capture}
 
 <h1 class="page-heading">
-    {l s='Sitemap'}
+  {l s='Sitemap'}
 </h1>
 <div id="sitemap_content" class="row">
-    <div class="col-xs-12 col-sm-6">
-        <div class="sitemap_block box">
-            <h3 class="page-subheading">{l s='Our offers'}</h3>
-            <ul>
-                <li>
-                    <a 
-                    href="{$link->getPageLink('new-products')|escape:'html':'UTF-8'}" 
-                    title="{l s='View a new product'}">
-                        {l s='New products'}
-                    </a>
-                </li>
-                {if !$PS_CATALOG_MODE}
-                {if $PS_DISPLAY_BEST_SELLERS}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('best-sales')|escape:'html':'UTF-8'}" 
-                        title="{l s='View top-selling products'}">
-                            {l s='Best sellers'}
-                        </a>
-                    </li>
-                {/if}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}" 
-                        title="{l s='View products with a price drop'}">
-                            {l s='Price drop'}
-                        </a>
-                    </li>
-                {/if}
-                {if $display_manufacturer_link OR $PS_DISPLAY_SUPPLIERS}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('manufacturer')|escape:'html':'UTF-8'}" 
-                        title="{l s='View a list of manufacturers'}">
-                            {l s='Manufacturers'}
-                        </a>
-                    </li>
-                {/if}
-                {if $display_supplier_link OR $PS_DISPLAY_SUPPLIERS}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('supplier')|escape:'html':'UTF-8'}" 
-                        title="{l s='View a list of suppliers'}">
-                            {l s='Suppliers'}
-                        </a>
-                    </li>
-                {/if}
-            </ul>
-       </div>
+  <div class="col-xs-12 col-sm-6">
+    <div class="sitemap_block box">
+      <h3 class="page-subheading">{l s='Our offers'}</h3>
+      <ul>
+        <li>
+          <a
+            href="{$link->getPageLink('new-products')|escape:'html':'UTF-8'}"
+            title="{l s='View a new product'}">
+            {l s='New products'}
+          </a>
+        </li>
+        {if !$PS_CATALOG_MODE}
+          {if $PS_DISPLAY_BEST_SELLERS}
+            <li>
+              <a
+                href="{$link->getPageLink('best-sales')|escape:'html':'UTF-8'}"
+                title="{l s='View top-selling products'}">
+                {l s='Best sellers'}
+              </a>
+            </li>
+          {/if}
+          <li>
+            <a
+              href="{$link->getPageLink('prices-drop')|escape:'html':'UTF-8'}"
+              title="{l s='View products with a price drop'}">
+              {l s='Price drop'}
+            </a>
+          </li>
+        {/if}
+        {if $display_manufacturer_link OR $PS_DISPLAY_SUPPLIERS}
+          <li>
+            <a
+              href="{$link->getPageLink('manufacturer')|escape:'html':'UTF-8'}"
+              title="{l s='View a list of manufacturers'}">
+              {l s='Manufacturers'}
+            </a>
+          </li>
+        {/if}
+        {if $display_supplier_link OR $PS_DISPLAY_SUPPLIERS}
+          <li>
+            <a
+              href="{$link->getPageLink('supplier')|escape:'html':'UTF-8'}"
+              title="{l s='View a list of suppliers'}">
+              {l s='Suppliers'}
+            </a>
+          </li>
+        {/if}
+      </ul>
     </div>
-    <div class="col-xs-12 col-sm-6">
-        <div class="sitemap_block box">
-            <h3 class="page-subheading">
-                {l s='Your Account'}
-            </h3>
-            <ul>
-                {if $is_logged}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}" 
-                        rel="nofollow" 
-                        title="{l s='Manage your customer account'}">
-                            {l s='Your Account'}
-                        </a>
-                    </li>
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}" 
-                        rel="nofollow" 
-                        title="{l s='Manage your personal information'}">
-                            {l s='Personal information'}
-                        </a>
-                    </li>
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}" 
-                        rel="nofollow" 
-                        title="{l s='View a list of my addresses'}">
-                            {l s='Addresses'}
-                        </a>
-                    </li>
-                    {if $voucherAllowed}
-                        <li>
-                            <a 
-                            href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}" 
-                            rel="nofollow" 
-                            title="{l s='View a list of my discounts'}">
-                                {l s='Discounts'}
-                            </a>
-                        </li>
-                        {/if}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}" 
-                        rel="nofollow"
-                        title="{l s='View a list of my orders'}" >
-                            {l s='Order history'}
-                        </a>
-                    </li>
-                {else}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}" 
-                        rel="nofollow"
-                        title="{l s='Authentication'}" >
-                            {l s='Authentication'}
-                        </a>
-                    </li>
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}"
-                        rel="nofollow" 
-                        title="{l s='Create new account'}" >
-                            {l s='Create new account'}
-                        </a>
-                    </li>
-                {/if}
-                {if $is_logged}
-                    <li>
-                        <a 
-                        href="{$link->getPageLink('index')}?mylogout" 
-                        rel="nofollow"
-                        title="{l s='Sign out'}" >
-                            {l s='Sign out'}
-                        </a>
-                    </li>
-                {/if}
-            </ul>
-        </div>
+  </div>
+  <div class="col-xs-12 col-sm-6">
+    <div class="sitemap_block box">
+      <h3 class="page-subheading">
+        {l s='Your Account'}
+      </h3>
+      <ul>
+        {if $is_logged}
+          <li>
+            <a
+              href="{$link->getPageLink('my-account', true)|escape:'html':'UTF-8'}"
+              rel="nofollow"
+              title="{l s='Manage your customer account'}">
+              {l s='Your Account'}
+            </a>
+          </li>
+          <li>
+            <a
+              href="{$link->getPageLink('identity', true)|escape:'html':'UTF-8'}"
+              rel="nofollow"
+              title="{l s='Manage your personal information'}">
+              {l s='Personal information'}
+            </a>
+          </li>
+          <li>
+            <a
+              href="{$link->getPageLink('addresses', true)|escape:'html':'UTF-8'}"
+              rel="nofollow"
+              title="{l s='View a list of my addresses'}">
+              {l s='Addresses'}
+            </a>
+          </li>
+          {if $voucherAllowed}
+            <li>
+              <a
+                href="{$link->getPageLink('discount', true)|escape:'html':'UTF-8'}"
+                rel="nofollow"
+                title="{l s='View a list of my discounts'}">
+                {l s='Discounts'}
+              </a>
+            </li>
+          {/if}
+          <li>
+            <a
+              href="{$link->getPageLink('history', true)|escape:'html':'UTF-8'}"
+              rel="nofollow"
+              title="{l s='View a list of my orders'}" >
+              {l s='Order history'}
+            </a>
+          </li>
+        {else}
+          <li>
+            <a
+              href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}"
+              rel="nofollow"
+              title="{l s='Authentication'}" >
+              {l s='Authentication'}
+            </a>
+          </li>
+          <li>
+            <a
+              href="{$link->getPageLink('authentication', true)|escape:'html':'UTF-8'}"
+              rel="nofollow"
+              title="{l s='Create new account'}" >
+              {l s='Create new account'}
+            </a>
+          </li>
+        {/if}
+        {if $is_logged}
+          <li>
+            <a
+              href="{$link->getPageLink('index')}?mylogout"
+              rel="nofollow"
+              title="{l s='Sign out'}" >
+              {l s='Sign out'}
+            </a>
+          </li>
+        {/if}
+      </ul>
     </div>
+  </div>
 </div>
 <div id="listpage_content" class="row">
-    <div class="col-xs-12 col-sm-6">
-        <div class="categTree box">
-            <h3 class="page-subheading">{l s='Categories'}</h3>
-            <div class="tree_top">
-                <a href="{$base_dir_ssl}" title="{$categoriesTree.name|escape:'html':'UTF-8'}"></a>
-            </div>
-            <ul class="tree">
-            {if isset($categoriesTree.children)}
-                {foreach $categoriesTree.children as $child}
-                    {if $child@last}
-                        {include file="$tpl_dir./category-tree-branch.tpl" node=$child last='true'}
-                    {else}
-                        {include file="$tpl_dir./category-tree-branch.tpl" node=$child}
-                    {/if}
-                {/foreach}
+  <div class="col-xs-12 col-sm-6">
+    <div class="categTree box">
+      <h3 class="page-subheading">{l s='Categories'}</h3>
+      <div class="tree_top">
+        <a href="{$base_dir_ssl}" title="{$categoriesTree.name|escape:'html':'UTF-8'}"></a>
+      </div>
+      <ul class="tree">
+        {if isset($categoriesTree.children)}
+          {foreach $categoriesTree.children as $child}
+            {if $child@last}
+              {include file="$tpl_dir./category-tree-branch.tpl" node=$child last='true'}
+            {else}
+              {include file="$tpl_dir./category-tree-branch.tpl" node=$child}
             {/if}
-            </ul>
-        </div>
+          {/foreach}
+        {/if}
+      </ul>
     </div>
-    <div class="col-xs-12 col-sm-6">
-        <div class="sitemap_block box">
-            <h3 class="page-subheading">{l s='Pages'}</h3>
-            <ul>
-                <li>
-                    <a href="{$categoriescmsTree.link|escape:'html':'UTF-8'}" title="{$categoriescmsTree.name|escape:'html':'UTF-8'}">
-                        {$categoriescmsTree.name|escape:'html':'UTF-8'}
-                    </a>
-                </li>
-                {if isset($categoriescmsTree.children)}
-                    {foreach $categoriescmsTree.children as $child}
-                        {if (isset($child.children) && $child.children|@count > 0) || $child.cms|@count > 0}
-                            {include file="$tpl_dir./category-cms-tree-branch.tpl" node=$child}
-                        {/if}
-                    {/foreach}
-                {/if}
-                {foreach from=$categoriescmsTree.cms item=cms name=cmsTree}
-                    <li>
-                        <a href="{$cms.link|escape:'html':'UTF-8'}" title="{$cms.meta_title|escape:'html':'UTF-8'}">
-                            {$cms.meta_title|escape:'html':'UTF-8'}
-                        </a>
-                    </li>
-                {/foreach}
-                <li>
-                    <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}" title="{l s='Contact'}">
-                        {l s='Contact'}
-                    </a>
-                </li>
-                {if $display_store}
-                    <li class="last">
-                        <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='List of our stores'}">
-                            {l s='Our stores'}
-                        </a>
-                    </li>
-                {/if}
-            </ul>
-        </div>
+  </div>
+  <div class="col-xs-12 col-sm-6">
+    <div class="sitemap_block box">
+      <h3 class="page-subheading">{l s='Pages'}</h3>
+      <ul>
+        <li>
+          <a href="{$categoriescmsTree.link|escape:'html':'UTF-8'}" title="{$categoriescmsTree.name|escape:'html':'UTF-8'}">
+            {$categoriescmsTree.name|escape:'html':'UTF-8'}
+          </a>
+        </li>
+        {if isset($categoriescmsTree.children)}
+          {foreach $categoriescmsTree.children as $child}
+            {if (isset($child.children) && $child.children|@count > 0) || $child.cms|@count > 0}
+              {include file="$tpl_dir./category-cms-tree-branch.tpl" node=$child}
+            {/if}
+          {/foreach}
+        {/if}
+        {foreach from=$categoriescmsTree.cms item=cms name=cmsTree}
+          <li>
+            <a href="{$cms.link|escape:'html':'UTF-8'}" title="{$cms.meta_title|escape:'html':'UTF-8'}">
+              {$cms.meta_title|escape:'html':'UTF-8'}
+            </a>
+          </li>
+        {/foreach}
+        <li>
+          <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}" title="{l s='Contact'}">
+            {l s='Contact'}
+          </a>
+        </li>
+        {if $display_store}
+          <li class="last">
+            <a href="{$link->getPageLink('stores')|escape:'html':'UTF-8'}" title="{l s='List of our stores'}">
+              {l s='Our stores'}
+            </a>
+          </li>
+        {/if}
+      </ul>
     </div>
+  </div>
 </div>

--- a/themes/community-theme-16/store_infos.tpl
+++ b/themes/community-theme-16/store_infos.tpl
@@ -33,9 +33,9 @@
     {l s='Sunday'}
 *}
 
-    {foreach from=$days_datas  item=one_day}
-    <p>
-        <strong class="dark">{l s=$one_day.day}: </strong> &nbsp;<span>{$one_day.hours}</span>
-    </p>
-    {/foreach}
+{foreach from=$days_datas  item=one_day}
+  <p>
+    <strong class="dark">{l s=$one_day.day}: </strong> &nbsp;<span>{$one_day.hours}</span>
+  </p>
+{/foreach}
 

--- a/themes/community-theme-16/stores.tpl
+++ b/themes/community-theme-16/stores.tpl
@@ -26,126 +26,126 @@
 {capture name=path}{l s='Our stores'}{/capture}
 
 <h1 class="page-heading">
-    {l s='Our stores'}
+  {l s='Our stores'}
 </h1>
 
 {if $simplifiedStoresDiplay}
-    {if $stores|@count}
-        <p class="store-title">
-            <strong class="dark">
-                {l s='Here you can find our store locations. Please feel free to contact us:'}
-            </strong>
-        </p>
-        <table class="table table-bordered">
-            <thead>
-                <tr>
-                    <th class="logo">{l s='Logo'}</th>
-                    <th class="name">{l s='Store name'}</th>
-                    <th class="address">{l s='Store address'}</th>
-                    <th class="store-hours">{l s='Working hours'}</th>
-                </tr>
-            </thead>
-            {foreach $stores as $store}
-                <tr class="store-small">
-                    <td class="logo">
-                        {if $store.has_picture}
-                            <div class="store-image">
-                                <img src="{$img_store_dir}{$store.id_store}-medium_default.jpg" alt="{$store.name|escape:'html':'UTF-8'}" width="{$mediumSize.width}" height="{$mediumSize.height}"/>
-                            </div>
-                        {/if}
-                    </td>
-                    <td class="name">
-                        {$store.name|escape:'html':'UTF-8'}
-                    </td>
-                    <td class="address">
-                    {assign value=$store.id_store var="id_store"}
-                    {foreach from=$addresses_formated.$id_store.ordered name=adr_loop item=pattern}
-                        {assign var=addressKey value=" "|explode:$pattern}
-                        {foreach from=$addressKey item=key name="word_loop"}
-                            <span {if isset($addresses_style[$key])} class="{$addresses_style[$key]}"{/if}>
-                                {$addresses_formated.$id_store.formated[$key|replace:',':'']|escape:'html':'UTF-8'}
-                            </span>
-                        {/foreach}
-                    {/foreach}
-                        <br/>
-                        {if $store.phone}<br/>{l s='Phone:'} {$store.phone|escape:'html':'UTF-8'}{/if}
-                        {if $store.fax}<br/>{l s='Fax:'} {$store.fax|escape:'html':'UTF-8'}{/if}
-                        {if $store.email}<br/>{l s='Email:'} {$store.email|escape:'html':'UTF-8'}{/if}
-                        {if $store.note}<br/><br/>{$store.note|escape:'html':'UTF-8'|nl2br}{/if}
-                    </td>
-                    <td class="store-hours">
-                        {if isset($store.working_hours)}{$store.working_hours}{/if}
-                    </td>
-                </tr>
-            {/foreach}
-        </table>
-    {/if}
-{else}
-    <div id="map"></div>
+  {if $stores|@count}
     <p class="store-title">
-        <strong class="dark">
-            {l s='Enter a location (e.g. zip/postal code, address, city or country) in order to find the nearest stores.'}
-        </strong>
+      <strong class="dark">
+        {l s='Here you can find our store locations. Please feel free to contact us:'}
+      </strong>
     </p>
-    <div class="store-content">
-        <div class="address-input">
-            <label for="addressInput">{l s='Your location:'}</label>
-            <input class="form-control grey" type="text" name="location" id="addressInput" value="{l s='Address, zip / postal code, city, state or country'}" />
-        </div>
-        <div class="radius-input">
-            <label for="radiusSelect">{l s='Radius:'}</label>
-            <select name="radius" id="radiusSelect" class="form-control">
-                <option value="15">15</option>
-                <option value="25">25</option>
-                <option value="50">50</option>
-                <option value="100">100</option>
-            </select>
-            <img src="{$img_ps_dir}loader.gif" class="middle" alt="" id="stores_loader" />
-        </div>
-        <div>
-            <button name="search_locations" class="button btn btn-default button-small">
-                <span>
-                    {l s='Search'}<i class="icon-chevron-right right"></i>
+    <table class="table table-bordered">
+      <thead>
+      <tr>
+        <th class="logo">{l s='Logo'}</th>
+        <th class="name">{l s='Store name'}</th>
+        <th class="address">{l s='Store address'}</th>
+        <th class="store-hours">{l s='Working hours'}</th>
+      </tr>
+      </thead>
+      {foreach $stores as $store}
+        <tr class="store-small">
+          <td class="logo">
+            {if $store.has_picture}
+              <div class="store-image">
+                <img src="{$img_store_dir}{$store.id_store}-medium_default.jpg" alt="{$store.name|escape:'html':'UTF-8'}" width="{$mediumSize.width}" height="{$mediumSize.height}"/>
+              </div>
+            {/if}
+          </td>
+          <td class="name">
+            {$store.name|escape:'html':'UTF-8'}
+          </td>
+          <td class="address">
+            {assign value=$store.id_store var="id_store"}
+            {foreach from=$addresses_formated.$id_store.ordered name=adr_loop item=pattern}
+              {assign var=addressKey value=" "|explode:$pattern}
+              {foreach from=$addressKey item=key name="word_loop"}
+                <span {if isset($addresses_style[$key])} class="{$addresses_style[$key]}"{/if}>
+                  {$addresses_formated.$id_store.formated[$key|replace:',':'']|escape:'html':'UTF-8'}
                 </span>
-            </button>
-        </div>
-    </div>
-    <div class="store-content-select selector3">
-        <select id="locationSelect" class="form-control">
-            <option>-</option>
-        </select>
-    </div>
-
-    <table id="stores-table" class="table table-bordered">
-        <thead>
-            <tr>
-                <th class="num">#</th>
-                <th>{l s='Store'}</th>
-                <th>{l s='Address'}</th>
-                <th>{l s='Distance'}</th>
-            </tr>
-        </thead>
-        <tbody>
-        </tbody>
+              {/foreach}
+            {/foreach}
+            <br/>
+            {if $store.phone}<br/>{l s='Phone:'} {$store.phone|escape:'html':'UTF-8'}{/if}
+            {if $store.fax}<br/>{l s='Fax:'} {$store.fax|escape:'html':'UTF-8'}{/if}
+            {if $store.email}<br/>{l s='Email:'} {$store.email|escape:'html':'UTF-8'}{/if}
+            {if $store.note}<br/><br/>{$store.note|escape:'html':'UTF-8'|nl2br}{/if}
+          </td>
+          <td class="store-hours">
+            {if isset($store.working_hours)}{$store.working_hours}{/if}
+          </td>
+        </tr>
+      {/foreach}
     </table>
-{strip}
-{addJsDef map=''}
-{addJsDef markers=array()}
-{addJsDef infoWindow=''}
-{addJsDef locationSelect=''}
-{addJsDef defaultLat=$defaultLat}
-{addJsDef defaultLong=$defaultLong}
-{addJsDef hasStoreIcon=$hasStoreIcon}
-{addJsDef distance_unit=$distance_unit}
-{addJsDef img_store_dir=$img_store_dir}
-{addJsDef img_ps_dir=$img_ps_dir}
-{addJsDef searchUrl=$searchUrl}
-{addJsDef logo_store=$logo_store}
-{addJsDefL name=translation_1}{l s='No stores were found. Please try selecting a wider radius.' js=1}{/addJsDefL}
-{addJsDefL name=translation_2}{l s='store found -- see details:' js=1}{/addJsDefL}
-{addJsDefL name=translation_3}{l s='stores found -- view all results:' js=1}{/addJsDefL}
-{addJsDefL name=translation_4}{l s='Phone:' js=1}{/addJsDefL}
-{addJsDefL name=translation_5}{l s='Get directions' js=1}{/addJsDefL}
-{addJsDefL name=translation_6}{l s='Not found' js=1}{/addJsDefL}
-{/strip}
+  {/if}
+{else}
+  <div id="map"></div>
+  <p class="store-title">
+    <strong class="dark">
+      {l s='Enter a location (e.g. zip/postal code, address, city or country) in order to find the nearest stores.'}
+    </strong>
+  </p>
+  <div class="store-content">
+    <div class="address-input">
+      <label for="addressInput">{l s='Your location:'}</label>
+      <input class="form-control grey" type="text" name="location" id="addressInput" value="{l s='Address, zip / postal code, city, state or country'}" />
+    </div>
+    <div class="radius-input">
+      <label for="radiusSelect">{l s='Radius:'}</label>
+      <select name="radius" id="radiusSelect" class="form-control">
+        <option value="15">15</option>
+        <option value="25">25</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+      </select>
+      <img src="{$img_ps_dir}loader.gif" class="middle" alt="" id="stores_loader" />
+    </div>
+    <div>
+      <button name="search_locations" class="button btn btn-default button-small">
+        <span>
+          {l s='Search'}<i class="icon-chevron-right right"></i>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div class="store-content-select selector3">
+    <select id="locationSelect" class="form-control">
+      <option>-</option>
+    </select>
+  </div>
+
+  <table id="stores-table" class="table table-bordered">
+    <thead>
+    <tr>
+      <th class="num">#</th>
+      <th>{l s='Store'}</th>
+      <th>{l s='Address'}</th>
+      <th>{l s='Distance'}</th>
+    </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+  {strip}
+    {addJsDef map=''}
+    {addJsDef markers=array()}
+    {addJsDef infoWindow=''}
+    {addJsDef locationSelect=''}
+    {addJsDef defaultLat=$defaultLat}
+    {addJsDef defaultLong=$defaultLong}
+    {addJsDef hasStoreIcon=$hasStoreIcon}
+    {addJsDef distance_unit=$distance_unit}
+    {addJsDef img_store_dir=$img_store_dir}
+    {addJsDef img_ps_dir=$img_ps_dir}
+    {addJsDef searchUrl=$searchUrl}
+    {addJsDef logo_store=$logo_store}
+    {addJsDefL name=translation_1}{l s='No stores were found. Please try selecting a wider radius.' js=1}{/addJsDefL}
+    {addJsDefL name=translation_2}{l s='store found -- see details:' js=1}{/addJsDefL}
+    {addJsDefL name=translation_3}{l s='stores found -- view all results:' js=1}{/addJsDefL}
+    {addJsDefL name=translation_4}{l s='Phone:' js=1}{/addJsDefL}
+    {addJsDefL name=translation_5}{l s='Get directions' js=1}{/addJsDefL}
+    {addJsDefL name=translation_6}{l s='Not found' js=1}{/addJsDefL}
+  {/strip}
 {/if}

--- a/themes/community-theme-16/supplier-list.tpl
+++ b/themes/community-theme-16/supplier-list.tpl
@@ -26,49 +26,49 @@
 {capture name=path}{l s='Suppliers:'}{/capture}
 
 <h1 class="page-heading product-listing">{l s='Suppliers:'}
-    {strip}
-        <span class="heading-counter">
-            {if $nbSuppliers == 0}{l s='There are no suppliers.'}
-            {else}
-                {if $nbSuppliers == 1}
-                    {l s='There is %d supplier.' sprintf=$nbSuppliers}
-                {else}
-                    {l s='There are %d suppliers.' sprintf=$nbSuppliers}
-                {/if}
-            {/if}
-        </span>
-    {/strip}
+  {strip}
+    <span class="heading-counter">
+      {if $nbSuppliers == 0}{l s='There are no suppliers.'}
+      {else}
+        {if $nbSuppliers == 1}
+          {l s='There is %d supplier.' sprintf=$nbSuppliers}
+        {else}
+          {l s='There are %d suppliers.' sprintf=$nbSuppliers}
+        {/if}
+      {/if}
+    </span>
+  {/strip}
 </h1>
 
 {if isset($errors) AND $errors}
-    {include file="$tpl_dir./errors.tpl"}
+  {include file="$tpl_dir./errors.tpl"}
 {else}
 
-{if $nbSuppliers > 0}
+  {if $nbSuppliers > 0}
     <div class="content_sortPagiBar">
-        <div class="sortPagiBar clearfix">
-            {if isset($supplier) && isset($supplier.nb_products) && $supplier.nb_products > 0}
-                <ul class="display hidden-xs">
-                    <li class="display-title">
-                        {l s='View:'}
-                    </li>
-                    <li id="grid">
-                        <a rel="nofollow" href="#" title="{l s='Grid'}">
-                            <i class="icon-th-large"></i>{l s='Grid'}
-                        </a>
-                    </li>
-                    <li id="list">
-                        <a rel="nofollow" href="#" title="{l s='List'}">
-                            <i class="icon-th-list"></i>{l s='List'}
-                        </a>
-                    </li>
-                </ul>
-            {/if}
-            {include file="./nbr-product-page.tpl"}
-        </div>
-        <div class="top-pagination-content clearfix bottom-line">
-            {include file="$tpl_dir./pagination.tpl" no_follow=1}
-        </div>
+      <div class="sortPagiBar clearfix">
+        {if isset($supplier) && isset($supplier.nb_products) && $supplier.nb_products > 0}
+          <ul class="display hidden-xs">
+            <li class="display-title">
+              {l s='View:'}
+            </li>
+            <li id="grid">
+              <a rel="nofollow" href="#" title="{l s='Grid'}">
+                <i class="icon-th-large"></i>{l s='Grid'}
+              </a>
+            </li>
+            <li id="list">
+              <a rel="nofollow" href="#" title="{l s='List'}">
+                <i class="icon-th-list"></i>{l s='List'}
+              </a>
+            </li>
+          </ul>
+        {/if}
+        {include file="./nbr-product-page.tpl"}
+      </div>
+      <div class="top-pagination-content clearfix bottom-line">
+        {include file="$tpl_dir./pagination.tpl" no_follow=1}
+      </div>
     </div> <!-- .content_sortPagiBar -->
 
     {assign var='nbItemsPerLine' value=3}
@@ -78,67 +78,67 @@
     {math equation="nbLi/nbItemsPerLineTablet" nbLi=$nbLi nbItemsPerLineTablet=$nbItemsPerLineTablet assign=nbLinesTablet}
 
     <ul id="suppliers_list" class="list row">
-        {foreach from=$suppliers_list item=supplier name=supplier}
-            {math equation="(total%perLine)" total=$smarty.foreach.supplier.total perLine=$nbItemsPerLine assign=totModulo}
-            {math equation="(total%perLineT)" total=$smarty.foreach.supplier.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
-            {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
-            {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
-            <li class="{if $smarty.foreach.supplier.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.supplier.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.supplier.iteration > ($smarty.foreach.supplier.total - $totModulo)}last-line{/if} {if $smarty.foreach.supplier.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.supplier.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.supplier.iteration > ($smarty.foreach.supplier.total - $totModuloTablet)}last-tablet-line{/if}col-xs-12">
-                <div class="mansup-container">
-                    <div class="row">
-                        <div class="left-side col-xs-12 col-sm-3">
-                            <!-- logo -->
-                            <div class="logo">
-                                {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                    <a href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}" title="{$supplier.name|escape:'html':'UTF-8'}">
-                                {/if}
-                                <img src="{$img_sup_dir}{$supplier.image|escape:'html':'UTF-8'}-medium_default.jpg" alt="" width="{$mediumSize.width}" height="{$mediumSize.height}" />
-                                {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                    </a>
-                                {/if}
-                            </div> <!-- .logo -->
-                        </div> <!-- .left-side -->
+      {foreach from=$suppliers_list item=supplier name=supplier}
+        {math equation="(total%perLine)" total=$smarty.foreach.supplier.total perLine=$nbItemsPerLine assign=totModulo}
+        {math equation="(total%perLineT)" total=$smarty.foreach.supplier.total perLineT=$nbItemsPerLineTablet assign=totModuloTablet}
+        {if $totModulo == 0}{assign var='totModulo' value=$nbItemsPerLine}{/if}
+        {if $totModuloTablet == 0}{assign var='totModuloTablet' value=$nbItemsPerLineTablet}{/if}
+        <li class="{if $smarty.foreach.supplier.iteration%$nbItemsPerLine == 0} last-in-line{elseif $smarty.foreach.supplier.iteration%$nbItemsPerLine == 1} first-in-line{/if} {if $smarty.foreach.supplier.iteration > ($smarty.foreach.supplier.total - $totModulo)}last-line{/if} {if $smarty.foreach.supplier.iteration%$nbItemsPerLineTablet == 0}last-item-of-tablet-line{elseif $smarty.foreach.supplier.iteration%$nbItemsPerLineTablet == 1}first-item-of-tablet-line{/if} {if $smarty.foreach.supplier.iteration > ($smarty.foreach.supplier.total - $totModuloTablet)}last-tablet-line{/if}col-xs-12">
+          <div class="mansup-container">
+            <div class="row">
+              <div class="left-side col-xs-12 col-sm-3">
+                <!-- logo -->
+                <div class="logo">
+                  {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                  <a href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}" title="{$supplier.name|escape:'html':'UTF-8'}">
+                    {/if}
+                    <img src="{$img_sup_dir}{$supplier.image|escape:'html':'UTF-8'}-medium_default.jpg" alt="" width="{$mediumSize.width}" height="{$mediumSize.height}" />
+                    {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                  </a>
+                  {/if}
+                </div> <!-- .logo -->
+              </div> <!-- .left-side -->
 
-                        <div class="middle-side col-xs-12 col-sm-5">
-                            <h3>
-                                {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                    <a class="product-name" href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">
-                                {/if}
-                                {$supplier.name|truncate:60:'...'|escape:'html':'UTF-8'}
-                                {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                    </a>
-                                {/if}
-                            </h3>
-                            <div class="description">
-                                {$supplier.description|truncate:180:'...'}
-                            </div>
-                        </div><!-- .middle-side -->
-
-                        <div class="right-side col-xs-12 col-sm-4">
-                            <div class="right-side-content">
-                                <p class="product-counter">
-                                    {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                        <a href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">
-                                    {/if}
-                                    {if isset($supplier.nb_products) && $supplier.nb_products == 1}{l s='%d product' sprintf=$supplier.nb_products|intval}{else}{l s='%d products' sprintf=$supplier.nb_products|intval}{/if}
-                                    {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                        </a>
-                                    {/if}
-                                </p>
-                                {if isset($supplier.nb_products) && $supplier.nb_products > 0}
-                                    <a class="btn btn-default button exclusive-medium" href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}"><span>{l s='View products'} <i class="icon-chevron-right right"></i></span></a>
-                                {/if}
-                            </div>
-                        </div><!-- .right-side -->
-                    </div>
+              <div class="middle-side col-xs-12 col-sm-5">
+                <h3>
+                  {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                  <a class="product-name" href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">
+                    {/if}
+                    {$supplier.name|truncate:60:'...'|escape:'html':'UTF-8'}
+                    {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                  </a>
+                  {/if}
+                </h3>
+                <div class="description">
+                  {$supplier.description|truncate:180:'...'}
                 </div>
-            </li>
-        {/foreach}
+              </div><!-- .middle-side -->
+
+              <div class="right-side col-xs-12 col-sm-4">
+                <div class="right-side-content">
+                  <p class="product-counter">
+                    {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                    <a href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}">
+                      {/if}
+                      {if isset($supplier.nb_products) && $supplier.nb_products == 1}{l s='%d product' sprintf=$supplier.nb_products|intval}{else}{l s='%d products' sprintf=$supplier.nb_products|intval}{/if}
+                      {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                    </a>
+                    {/if}
+                  </p>
+                  {if isset($supplier.nb_products) && $supplier.nb_products > 0}
+                    <a class="btn btn-default button exclusive-medium" href="{$link->getsupplierLink($supplier.id_supplier, $supplier.link_rewrite)|escape:'html':'UTF-8'}"><span>{l s='View products'} <i class="icon-chevron-right right"></i></span></a>
+                  {/if}
+                </div>
+              </div><!-- .right-side -->
+            </div>
+          </div>
+        </li>
+      {/foreach}
     </ul>
     <div class="content_sortPagiBar">
-        <div class="bottom-pagination-content clearfix">
-            {include file="$tpl_dir./pagination.tpl" no_follow=1 paginationId='bottom'}
-        </div>
+      <div class="bottom-pagination-content clearfix">
+        {include file="$tpl_dir./pagination.tpl" no_follow=1 paginationId='bottom'}
+      </div>
     </div>
-{/if}
+  {/if}
 {/if}

--- a/themes/community-theme-16/supplier.tpl
+++ b/themes/community-theme-16/supplier.tpl
@@ -26,36 +26,36 @@
 {include file="$tpl_dir./errors.tpl"}
 
 {if !isset($errors) OR !sizeof($errors)}
-    <h1 class="page-heading product-listing">
-        {l s='List of products by supplier:'}&nbsp;{$supplier->name|escape:'html':'UTF-8'}
-    </h1>
-    {if !empty($supplier->description)}
-        <div class="description_box rte">
-            <p>{$supplier->description}</p>
-        </div>
-    {/if}
+  <h1 class="page-heading product-listing">
+    {l s='List of products by supplier:'}&nbsp;{$supplier->name|escape:'html':'UTF-8'}
+  </h1>
+  {if !empty($supplier->description)}
+    <div class="description_box rte">
+      <p>{$supplier->description}</p>
+    </div>
+  {/if}
 
-    {if $products}
-        <div class="content_sortPagiBar">
-            <div class="sortPagiBar clearfix">
-                {include file="./product-sort.tpl"}
-                {include file="./nbr-product-page.tpl"}
-            </div>
-            <div class="top-pagination-content clearfix">
-                {include file="./product-compare.tpl"}
-                {include file="$tpl_dir./pagination.tpl" no_follow=1}
-            </div>
-        </div>
+  {if $products}
+    <div class="content_sortPagiBar">
+      <div class="sortPagiBar clearfix">
+        {include file="./product-sort.tpl"}
+        {include file="./nbr-product-page.tpl"}
+      </div>
+      <div class="top-pagination-content clearfix">
+        {include file="./product-compare.tpl"}
+        {include file="$tpl_dir./pagination.tpl" no_follow=1}
+      </div>
+    </div>
 
-        {include file="./product-list.tpl" products=$products}
+    {include file="./product-list.tpl" products=$products}
 
-        <div class="content_sortPagiBar">
-            <div class="bottom-pagination-content clearfix">
-                {include file="./product-compare.tpl"}
-                {include file="./pagination.tpl" paginationId='bottom' no_follow=1}
-            </div>
-        </div>
-    {else}
-        <p class="alert alert-warning">{l s='No products for this supplier.'}</p>
-    {/if}
+    <div class="content_sortPagiBar">
+      <div class="bottom-pagination-content clearfix">
+        {include file="./product-compare.tpl"}
+        {include file="./pagination.tpl" paginationId='bottom' no_follow=1}
+      </div>
+    </div>
+  {else}
+    <p class="alert alert-warning">{l s='No products for this supplier.'}</p>
+  {/if}
 {/if}


### PR DESCRIPTION
Ok, so 2 spaces was chosen because:
- smaller size
- better view of nested elements (in some file the nested trees are very deep)
- works with inline `script` block, which should be indentation the same way the are in `.js` files (2 spaces)
- Google and other people recommend it https://google.github.io/styleguide/htmlcssguide.xml#HTML_Style_Rules
