### PR TITLE
[-] CSS: Temporary fix for floating point error in product lists

### DIFF
--- a/themes/community-theme-16/sass/product_list.scss
+++ b/themes/community-theme-16/sass/product_list.scss
@@ -322,7 +322,7 @@ ul.product_list.grid {
     }
   }
   li.hovered{
-    h5{
+    h4 {
       min-height: 30px;
     }
   }
@@ -363,7 +363,7 @@ ul.product_list.list {
         color: #f13340;
       }
     }
-    h5 {
+    h4 {
       padding-bottom: 8px;
     }
     .product-desc {

--- a/themes/community-theme-16/sass/product_list.scss
+++ b/themes/community-theme-16/sass/product_list.scss
@@ -348,7 +348,8 @@ ul.product_list.list {
     .product-image-container {
       position: relative;
       border: 1px solid $base-listing-border-color;
-      padding: 9px;
+      // @Warning! Floating point size of scaled image might break <li> lines
+      padding: 5px;
       @media (max-width: $screen-xs - 1) { // max 479px
         max-width: 290px;
         margin: 0 auto;


### PR DESCRIPTION
Responsive image size can be a floating point. The hover effect used jQuery to get product card footer height which is rounded = list collapses.
