### PR TITLE
fixed wrong floating in cart popup

### DIFF
--- a/themes/community-theme-16/modules/blockcart/includes/popup.tpl
+++ b/themes/community-theme-16/modules/blockcart/includes/popup.tpl
@@ -53,7 +53,7 @@
             {/if}
           {/if}
         </strong>
-        <span class="ajax_block_products_total">
+        <span class="cart_block_total">
           {if $cart_qties > 0}
             {convertPrice price=$cart->getOrderTotal(false, Cart::ONLY_PRODUCTS)}
           {/if}
@@ -72,7 +72,7 @@
               {/if}
             {/if}
           </strong>
-          <span class="price cart_block_wrapping_cost">
+          <span class="cart_block_wrapping_cost">
             {if $priceDisplay == 1}
               {convertPrice price=$cart->getOrderTotal(false, Cart::ONLY_WRAPPING)}
             {else}
@@ -86,7 +86,7 @@
         <strong class="{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
           {l s='Total shipping:' mod='blockcart'}&nbsp;{if $use_taxes && $display_tax_label && $show_tax}{if $priceDisplay == 1}{l s='(tax excl.)' mod='blockcart'}{else}{l s='(tax incl.)' mod='blockcart'}{/if}{/if}
         </strong>
-        <span class="ajax_cart_shipping_cost{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
+        <span class="cart_block_shipping_cost{if $shipping_cost_float == 0 && (!$cart_qties || $cart->isVirtualCart() || !isset($cart->id_address_delivery) || !$cart->id_address_delivery)} unvisible{/if}">
           {if $shipping_cost_float == 0}
             {if (!isset($cart->id_address_delivery) || !$cart->id_address_delivery)}{l s='To be determined' mod='blockcart'}{else}{l s='Free shipping!' mod='blockcart'}{/if}
           {else}
@@ -98,7 +98,7 @@
       {if $show_tax && isset($tax_cost)}
         <p class="layer_cart_row">
           <strong>{l s='Tax:' mod='blockcart'}</strong>
-          <span class="price cart_block_tax_cost ajax_cart_tax_cost">{$tax_cost}</span>
+          <span class="cart_block_tax_cost">{$tax_cost}</span>
         </p>
       {/if}
 
@@ -113,7 +113,7 @@
             {/if}
           {/if}
         </strong>
-        <span class="ajax_block_cart_total">
+        <span class="price cart_block_total">
           {if $cart_qties > 0}
             {if $priceDisplay == 1}
               {convertPrice price=$cart->getOrderTotal(false)}


### PR DESCRIPTION
due to removed "ajax_block_cart...." styles the prices in cart popup where not floated correctly to the right (except total tax). There where also wrong bold styles in popup. Now only total price is with (bold)-style "price".
