### PR TITLE
[*] JS: Refactor fancybox errors to PrestaShop.showError module

### DIFF
--- a/themes/community-theme-16/js/authentication.js
+++ b/themes/community-theme-16/js/authentication.js
@@ -53,19 +53,10 @@ function submitFunction() {
       }
     },
     error: function(XMLHttpRequest, textStatus, errorThrown) {
-      var error = 'TECHNICAL ERROR: unable to load form.\n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-      if (!!$.prototype.fancybox) {
-        $.fancybox.open([{
-          type: 'inline',
-          autoScale: true,
-          minHeight: 30,
-          content: '<p class=\'fancybox-error\'>' + error + '</p>'
-        }], {
-          padding: 0
-        });
-      } else {
-        alert(error);
-      }
+      PrestaShop.showError(
+        'TECHNICAL ERROR: unable to load form.\n\nDetails:\nError thrown: '
+        + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+      );
     }
   });
 }

--- a/themes/community-theme-16/js/cart-summary.js
+++ b/themes/community-theme-16/js/cart-summary.js
@@ -51,24 +51,7 @@ $(document).ready(function() {
       '&allow_refresh=1',
       success: function(jsonData) {
         if (jsonData.hasError) {
-          var errors = '';
-          for (var error in jsonData.errors)
-            //IE6 bug fix
-            if (error !== 'indexOf')
-              errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-                {
-                  type: 'inline',
-                  autoScale: true,
-                  minHeight: 30,
-                  content: '<p class="fancybox-error">' + errors + '</p>'
-                }],
-              {
-                padding: 0
-              });
-          else
-            alert(errors);
+          PrestaShop.showError(jsonData.errors);
           $('input[name=quantity_' + id + ']').val($('input[name=quantity_' + id + '_hidden]').val());
         } else {
           if (jsonData.refresh) {
@@ -163,20 +146,7 @@ function changeAddressDelivery(obj) {
       '&allow_refresh=1',
       success: function(jsonData) {
         if (typeof(jsonData.hasErrors) != 'undefined' && jsonData.hasErrors) {
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-                {
-                  type: 'inline',
-                  autoScale: true,
-                  minHeight: 30,
-                  content: '<p class="fancybox-error">' + jsonData.error + '</p>'
-                }],
-              {
-                padding: 0
-              });
-          else
-            alert(jsonData.error);
-
+          PrestaShop.showError(jsonData.error);
           // Reset the old address
           $('#select_address_delivery_' + id_product + '_' + id_product_attribute + '_' + old_id_address_delivery).val(old_id_address_delivery);
         } else {
@@ -211,19 +181,7 @@ function changeAddressDelivery(obj) {
   {
     // This test is will not usefull in the future
     if (old_id_address_delivery == 0) {
-      if (!!$.prototype.fancybox)
-        $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + txtSelectAnAddressFirst + '</p>'
-            }],
-          {
-            padding: 0
-          });
-      else
-        alert(txtSelectAnAddressFirst);
+      PrestaShop.showError(txtSelectAnAddressFirst);
       return false;
     }
 
@@ -255,20 +213,9 @@ function changeAddressDelivery(obj) {
       '&token=' + static_token +
       '&allow_refresh=1',
       success: function(jsonData) {
-        if (jsonData.error && !!$.prototype.fancybox)
-          $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + jsonData.error + '</p>'
-              }],
-            {
-              padding: 0
-            });
-        else
-          alert(jsonData.error);
-
+        if (jsonData.error) {
+          PrestaShop.showError(jsonData.error);
+        }
         var line = $('#product_' + id_product + '_' + id_product_attribute + '_0_' + old_id_address_delivery);
         var new_line = line.clone();
         updateAddressId(id_product, id_product_attribute, old_id_address_delivery, id_address_delivery, new_line);
@@ -386,24 +333,7 @@ function deleteProductFromSummary(id) {
     '&allow_refresh=1',
     success: function(jsonData) {
       if (jsonData.hasError) {
-        var errors = '';
-        for (var error in jsonData.errors)
-          //IE6 bug fix
-          if (error !== 'indexOf')
-            errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + errors + '</p>'
-              }],
-            {
-              padding: 0
-            });
-        else
-          alert(errors);
+        PrestaShop.showError(jsonData.errors);
       } else {
         if (jsonData.refresh) {
           window.location.reload();
@@ -472,20 +402,10 @@ function deleteProductFromSummary(id) {
     },
     error: function(XMLHttpRequest, textStatus, errorThrown) {
       if (textStatus !== 'abort') {
-        var error = 'TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + error + '</p>'
-              }],
-            {
-              padding: 0
-            });
-        else
-          alert(error);
+        PrestaShop.showError(
+          'TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: '
+          + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+        );
       }
     }
   });
@@ -549,24 +469,7 @@ function upQuantity(id, qty) {
     '&allow_refresh=1',
     success: function(jsonData) {
       if (jsonData.hasError) {
-        var errors = '';
-        for (var error in jsonData.errors)
-          //IE6 bug fix
-          if (error !== 'indexOf')
-            errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + errors + '</p>'
-              }],
-            {
-              padding: 0
-            });
-        else
-          alert(errors);
+        PrestaShop.showError(jsonData.errors);
         $('input[name=quantity_' + id + ']').val($('input[name=quantity_' + id + '_hidden]').val());
       } else {
         if (jsonData.refresh) {
@@ -587,20 +490,10 @@ function upQuantity(id, qty) {
     },
     error: function(XMLHttpRequest, textStatus, errorThrown) {
       if (textStatus !== 'abort') {
-        error = 'TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + error + '</p>'
-              }],
-            {
-              padding: 0
-            });
-        else
-          alert(error);
+        PrestaShop.showError(
+          'TECHNICAL ERROR: unable to save update quantity \n\nDetails:\nError thrown: '
+          + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+        );
       }
     }
   });
@@ -653,24 +546,7 @@ function downQuantity(id, qty) {
       '&allow_refresh=1',
       success: function(jsonData) {
         if (jsonData.hasError) {
-          var errors = '';
-          for (var error in jsonData.errors)
-            //IE6 bug fix
-            if (error !== 'indexOf')
-              errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-                {
-                  type: 'inline',
-                  autoScale: true,
-                  minHeight: 30,
-                  content: '<p class="fancybox-error">' + errors + '</p>'
-                }],
-              {
-                padding: 0
-              });
-          else
-            alert(errors);
+          PrestaShop.showError(jsonData.errors);
           $('input[name=quantity_' + id + ']').val($('input[name=quantity_' + id + '_hidden]').val());
         } else {
           if (jsonData.refresh) {

--- a/themes/community-theme-16/js/global.js
+++ b/themes/community-theme-16/js/global.js
@@ -2,35 +2,40 @@
 
 var PrestaShop = (function() {
 
+  function showWindowAlert(msg, title) {
+    var content = title ? title + "\n\n" : '';
+    content +=  $.isArray(msg) ? msg.join("\n") : msg;
+    alert(content);
+  }
+
+  function showFancyboxAlert(msg, title, wrapperClass) {
+    if ($.isArray(msg)) {
+      msg = '<ul><li>' + msg.join('</li><li>') + '</li><ul>';
+    }
+    $.fancybox.open([{
+      type: 'inline',
+      autoScale: true,
+      minHeight: 30,
+      content: '<div class="fancybox-error' + (wrapperClass ? ' ' + wrapperClass : '') + '">'
+                + (title ? '<p><b>' + title + '</b></p>' : '') + msg + '</div>'
+    }], {
+      padding: 0
+    });
+  }
+
   return {
     showError : function (msg, title) {
-      // @TODO msg array
       if (!!$.prototype.fancybox) {
-        $.fancybox.open([{
-          type: 'inline',
-          autoScale: true,
-          minHeight: 30,
-          content: '<p class="fancybox-error">' + msg + '</p>'
-        }], {
-          padding: 0
-        });
+        showFancyboxAlert(msg, title);
       } else {
-        alert(msg);
+        showWindowAlert(msg, title);
       }
     },
     showSuccess : function (msg, title) {
-      // @TODO msg array
       if (!!$.prototype.fancybox) {
-        $.fancybox.open([{
-          type: 'inline',
-          autoScale: true,
-          minHeight: 30,
-          content: '<p class="fancybox-error">' + msg + '</p>'
-        }], {
-          padding: 0
-        });
+        showFancyboxAlert(msg, title, 'fancybox-success');
       } else {
-        alert(msg);
+        showWindowAlert(msg, title);
       }
     }
   };

--- a/themes/community-theme-16/js/global.js
+++ b/themes/community-theme-16/js/global.js
@@ -2,6 +2,22 @@
 
 var PrestaShop = {
   showError : function (msg, title) {
+    // @TODO msg array
+    if (!!$.prototype.fancybox) {
+      $.fancybox.open([{
+        type: 'inline',
+        autoScale: true,
+        minHeight: 30,
+        content: '<p class="fancybox-error">' + msg + '</p>'
+      }], {
+        padding: 0
+      });
+    } else {
+      alert(msg);
+    }
+  },
+  showSuccess : function (msg, title) {
+    // @TODO msg array
     if (!!$.prototype.fancybox) {
       $.fancybox.open([{
         type: 'inline',

--- a/themes/community-theme-16/js/global.js
+++ b/themes/community-theme-16/js/global.js
@@ -1,4 +1,22 @@
 /* global quickView, page_name, FancyboxI18nClose, FancyboxI18nNext, FancyboxI18nPrev, highDPI, request, url */
+
+var PrestaShop = {
+  showError : function (msg, title) {
+    if (!!$.prototype.fancybox) {
+      $.fancybox.open([{
+        type: 'inline',
+        autoScale: true,
+        minHeight: 30,
+        content: '<p class="fancybox-error">' + msg + '</p>'
+      }], {
+        padding: 0
+      });
+    } else {
+      alert(msg);
+    }
+  }
+};
+
 $(function() {
 
   var touch = !!isTouchDevice();

--- a/themes/community-theme-16/js/global.js
+++ b/themes/community-theme-16/js/global.js
@@ -1,37 +1,41 @@
 /* global quickView, page_name, FancyboxI18nClose, FancyboxI18nNext, FancyboxI18nPrev, highDPI, request, url */
 
-var PrestaShop = {
-  showError : function (msg, title) {
-    // @TODO msg array
-    if (!!$.prototype.fancybox) {
-      $.fancybox.open([{
-        type: 'inline',
-        autoScale: true,
-        minHeight: 30,
-        content: '<p class="fancybox-error">' + msg + '</p>'
-      }], {
-        padding: 0
-      });
-    } else {
-      alert(msg);
+var PrestaShop = (function() {
+
+  return {
+    showError : function (msg, title) {
+      // @TODO msg array
+      if (!!$.prototype.fancybox) {
+        $.fancybox.open([{
+          type: 'inline',
+          autoScale: true,
+          minHeight: 30,
+          content: '<p class="fancybox-error">' + msg + '</p>'
+        }], {
+          padding: 0
+        });
+      } else {
+        alert(msg);
+      }
+    },
+    showSuccess : function (msg, title) {
+      // @TODO msg array
+      if (!!$.prototype.fancybox) {
+        $.fancybox.open([{
+          type: 'inline',
+          autoScale: true,
+          minHeight: 30,
+          content: '<p class="fancybox-error">' + msg + '</p>'
+        }], {
+          padding: 0
+        });
+      } else {
+        alert(msg);
+      }
     }
-  },
-  showSuccess : function (msg, title) {
-    // @TODO msg array
-    if (!!$.prototype.fancybox) {
-      $.fancybox.open([{
-        type: 'inline',
-        autoScale: true,
-        minHeight: 30,
-        content: '<p class="fancybox-error">' + msg + '</p>'
-      }], {
-        padding: 0
-      });
-    } else {
-      alert(msg);
-    }
-  }
-};
+  };
+
+})();
 
 $(function() {
 

--- a/themes/community-theme-16/js/modules/blockcart/ajax-cart.js
+++ b/themes/community-theme-16/js/modules/blockcart/ajax-cart.js
@@ -204,19 +204,7 @@ var ajaxCart = {
         window.parent.location.href = window.location.href.replace('content_only=1', '');
         return;
       }
-      if (!!$.prototype.fancybox)
-        $.fancybox.open([
-          {
-            type: 'inline',
-            autoScale: true,
-            minHeight: 30,
-            content: '<p class="fancybox-error">' + fieldRequired + '</p>'
-          }
-        ], {
-          padding: 0
-        });
-      else
-        alert(fieldRequired);
+      PrestaShop.showError(fieldRequired);
       return;
     }
 
@@ -306,22 +294,11 @@ var ajaxCart = {
 
       },
       error: function(XMLHttpRequest, textStatus, errorThrown) {
-        var error = 'Impossible to add the product to the cart.<br/>textStatus: \'' + textStatus + '\'<br/>errorThrown: \'' +
-          errorThrown + '\'<br/>responseText:<br/>' + XMLHttpRequest.responseText;
-        if (!!$.prototype.fancybox) {
-          $.fancybox.open([{
-            type: 'inline',
-            autoScale: true,
-            minHeight: 30,
-            content: '<p class="fancybox-error">' + error + '</p>'
-          }], {
-            padding: 0
-          });
-        } else {
-          alert(error);
-        }
-
-        //reactive the button when adding has finished
+        PrestaShop.showError(
+          'Impossible to add the product to the cart.<br/>textStatus: \'' + textStatus + '\'<br/>errorThrown: \'' +
+          errorThrown + '\'<br/>responseText:<br/>' + XMLHttpRequest.responseText
+        );
+        // Reactivate the button when adding has finished
         if (addedFromProductPage) {
           $productPageBtn.removeProp('disabled').removeClass('disabled');
         } else {
@@ -352,19 +329,7 @@ var ajaxCart = {
         }
       },
       error: function() {
-        var error = 'ERROR: unable to delete the product';
-        if (!!$.prototype.fancybox) {
-          $.fancybox.open([{
-            type: 'inline',
-            autoScale: true,
-            minHeight: 30,
-            content: error
-          }], {
-            padding: 0
-          });
-        } else {
-          alert(error);
-        }
+        PrestaShop.showError('ERROR: unable to delete the product');
       }
     });
   },
@@ -744,30 +709,7 @@ var ajaxCart = {
   updateCart: function(jsonData) {
     //user errors display
     if (jsonData.hasError) {
-      var errors = '';
-
-      for (var error in jsonData.errors) {
-        if (jsonData.errors.hasOwnProperty(error)) {
-          //IE6 bug fix
-          if (error != 'indexOf') {
-            errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-          }
-        }
-      }
-
-      if (!!$.prototype.fancybox) {
-        $.fancybox.open([{
-          type: 'inline',
-          autoScale: true,
-          minHeight: 30,
-          content: '<p class="fancybox-error">' + errors + '</p>'
-        }], {
-          padding: 0
-        });
-      } else {
-        alert(errors);
-      }
-
+      PrestaShop.showError(jsonData.errors);
     } else {
       ajaxCart.updateCartEverywhere(jsonData);
       ajaxCart.hideOldProducts(jsonData);

--- a/themes/community-theme-16/js/modules/blockwishlist/js/ajax-wishlist.js
+++ b/themes/community-theme-16/js/modules/blockwishlist/js/ajax-wishlist.js
@@ -43,34 +43,9 @@ function WishlistCart(id, action, id_product, id_product_attribute, quantity, id
         if (isLogged == true) {
           wishlistProductsIdsAdd(id_product);
           wishlistRefreshStatus();
-
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + added_to_wishlist + '</p>'
-              }
-            ], {
-              padding: 0
-            });
-          else
-            alert(added_to_wishlist);
+          PrestaShop.showSuccess(added_to_wishlist);
         } else {
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + loggin_required + '</p>'
-              }
-            ], {
-              padding: 0
-            });
-          else
-            alert(loggin_required);
+          PrestaShop.showError(loggin_required);
         }
       }
       if (action == 'delete') {
@@ -139,19 +114,7 @@ function WishlistAddProductCart(token, id_product, id_product_attribute, id_quan
     cache: false,
     success: function(data) {
       if (data) {
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + data + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(data);
+        PrestaShop.showSuccess(data);
       } else
         $('#' + id_quantity).val($('#' + id_quantity).val() - 1);
     }
@@ -333,19 +296,7 @@ function WishlistSend(id, id_wishlist, id_email) {
     },
     function(data) {
       if (data) {
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + data + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(data);
+        PrestaShop.showSuccess(data);
       } else
         WishlistVisibility(id, 'hideSendWishlist');
     }
@@ -399,17 +350,7 @@ function wishlistProductChange(id_product, id_product_attribute, id_old_wishlist
         $('#wishlist_' + id_old_wishlist + ' td:nth-child(2)').text($('#wishlist_' + id_old_wishlist + ' td:nth-child(2)').text() - quantity);
         $('#wishlist_' + id_new_wishlist + ' td:nth-child(2)').text(+$('#wishlist_' + id_new_wishlist + ' td:nth-child(2)').text() + +quantity);
       } else {
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + data.error + '</p>'
-            }
-          ], {
-            padding: 0
-          });
+        PrestaShop.showError(data.error);
       }
     }
   });

--- a/themes/community-theme-16/js/order-address.js
+++ b/themes/community-theme-16/js/order-address.js
@@ -90,24 +90,7 @@ function updateAddresses() {
       },
       success: function(jsonData) {
         if (jsonData.hasError) {
-          var errors = '';
-          for (var error in jsonData.errors)
-            //IE6 bug fix
-            if (error !== 'indexOf')
-              errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + errors + '</p>'
-              }
-            ], {
-              padding: 0
-            });
-          else
-            alert(errors);
+          PrestaShop.showError(jsonData.errors);
         }
         $('.addresses .waitimage').hide();
         $('[name="processAddress"]').prop('disabled', '');
@@ -116,20 +99,10 @@ function updateAddresses() {
         $('.addresses .waitimage').hide();
         $('[name="processAddress"]').prop('disabled', '');
         if (textStatus !== 'abort') {
-          error = 'TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + error + '</p>'
-              }
-            ], {
-              padding: 0
-            });
-          else
-            alert(error);
+          PrestaShop.showError(
+            'TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: '
+            + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+          );
         }
       }
     });

--- a/themes/community-theme-16/js/order-carrier.js
+++ b/themes/community-theme-16/js/order-carrier.js
@@ -27,20 +27,9 @@ $(document).ready(function() {
 
 function acceptCGV() {
   if (typeof msg_order_carrier != 'undefined' && $('#cgv').length && !$('input#cgv:checked').length) {
-    if (!!$.prototype.fancybox)
-      $.fancybox.open([
-          {
-            type: 'inline',
-            autoScale: true,
-            minHeight: 30,
-            content: '<p class="fancybox-error">' + msg_order_carrier + '</p>'
-          }],
-        {
-          padding: 0
-        });
-    else
-      alert(msg_order_carrier);
-  } else
-    return true;
-  return false;
+    PrestaShop.showError(msg_order_carrier);
+    return false;
+  }
+
+  return true;
 }

--- a/themes/community-theme-16/js/order-opc.js
+++ b/themes/community-theme-16/js/order-opc.js
@@ -71,20 +71,10 @@ $(document).ready(function() {
         },
         error: function(XMLHttpRequest, textStatus, errorThrown) {
           if (textStatus !== 'abort') {
-            error = 'TECHNICAL ERROR: unable to send login informations \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-            if (!!$.prototype.fancybox)
-              $.fancybox.open([
-                {
-                  type: 'inline',
-                  autoScale: true,
-                  minHeight: 30,
-                  content: '<p class="fancybox-error">' + error + '</p>'
-                }
-              ], {
-                padding: 0
-              });
-            else
-              alert(error);
+            PrestaShop.showError(
+              'TECHNICAL ERROR: unable to send login informations \n\nDetails:\nError thrown: '
+              + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+            );
           }
         }
       });
@@ -204,20 +194,10 @@ $(document).ready(function() {
         },
         error: function(XMLHttpRequest, textStatus, errorThrown) {
           if (textStatus !== 'abort') {
-            error = 'TECHNICAL ERROR: unable to save account \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-            if (!!$.prototype.fancybox)
-              $.fancybox.open([
-                {
-                  type: 'inline',
-                  autoScale: true,
-                  minHeight: 30,
-                  content: '<p class="fancybox-error">' + error + '</p>'
-                }
-              ], {
-                padding: 0
-              });
-            else
-              alert(error);
+            PrestaShop.showError(
+              'TECHNICAL ERROR: unable to save account \n\nDetails:\nError thrown: '
+              + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+            );
           }
           $('#opc_new_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeIn('slow');
         }
@@ -301,24 +281,7 @@ function updateAddressSelection(is_adv_api) {
     (is_adv_api ? '&isAdvApi=1' : ''),
     success: function(jsonData) {
       if (jsonData.hasError) {
-        var errors = '';
-        for (var error in jsonData.errors)
-          //IE6 bug fix
-          if (error !== 'indexOf')
-            errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + errors + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(errors);
+        PrestaShop.showError(jsonData.errors);
       } else {
         if (jsonData.refresh) {
           window.location.reload();
@@ -383,20 +346,10 @@ function updateAddressSelection(is_adv_api) {
     },
     error: function(XMLHttpRequest, textStatus, errorThrown) {
       if (textStatus !== 'abort') {
-        error = 'TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + error + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(error);
+        PrestaShop.showError(
+          'TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: '
+          + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+        );
       }
       $('#opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
     }
@@ -415,37 +368,7 @@ function getCarrierListAndUpdate() {
     data: 'ajax=true&method=getCarrierList&token=' + static_token,
     success: function(jsonData) {
       if (jsonData.hasError) {
-        var errors = '';
-        for (var error in jsonData.errors)
-          //IE6 bug fix
-          if (error !== 'indexOf')
-            errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-        if (!!$.prototype.fancybox) {
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + errors + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        } else {
-          if (!!$.prototype.fancybox)
-            $.fancybox.open([
-              {
-                type: 'inline',
-                autoScale: true,
-                minHeight: 30,
-                content: '<p class="fancybox-error">' + errors + '</p>'
-              }
-            ], {
-              padding: 0
-            });
-          else
-            alert(errors);
-        }
+        PrestaShop.showError(jsonData.errors);
       } else
         updateCarrierList(jsonData);
       $('#opc_delivery_methods-overlay').fadeOut('slow');
@@ -485,24 +408,7 @@ function updateCarrierSelectionAndGift() {
     data: 'ajax=true&method=updateCarrierAndGetPayments' + delivery_option_params + 'recyclable=' + recyclablePackage + '&gift=' + gift + '&gift_message=' + giftMessage + '&token=' + static_token ,
     success: function(jsonData) {
       if (jsonData.hasError) {
-        var errors = '';
-        for (var error in jsonData.errors)
-          //IE6 bug fix
-          if (error !== 'indexOf')
-            errors += $('<div />').html(jsonData.errors[error]).text() + '\n';
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + errors + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(errors);
+        PrestaShop.showError(jsonData.errors);
       } else {
         updateCartSummary(jsonData.summary);
         updatePaymentMethods(jsonData);
@@ -549,20 +455,10 @@ function confirmFreeOrder() {
     },
     error: function(XMLHttpRequest, textStatus, errorThrown) {
       if (textStatus !== 'abort') {
-        error = 'TECHNICAL ERROR: unable to confirm the order \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + error + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(error);
+        PrestaShop.showError(
+          'TECHNICAL ERROR: unable to confirm the order \n\nDetails:\nError thrown: '
+          + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+        );
       }
     }
   });
@@ -644,20 +540,10 @@ function saveAddress(type) {
     },
     error: function(XMLHttpRequest, textStatus, errorThrown) {
       if (textStatus !== 'abort') {
-        error = 'TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: ' + XMLHttpRequest + '\n' + 'Text status: ' + textStatus;
-        if (!!$.prototype.fancybox)
-          $.fancybox.open([
-            {
-              type: 'inline',
-              autoScale: true,
-              minHeight: 30,
-              content: '<p class="fancybox-error">' + error + '</p>'
-            }
-          ], {
-            padding: 0
-          });
-        else
-          alert(error);
+        PrestaShop.showError(
+          'TECHNICAL ERROR: unable to save adresses \n\nDetails:\nError thrown: '
+          + XMLHttpRequest + '\n' + 'Text status: ' + textStatus
+        );
       }
       $('#opc_account-overlay, #opc_delivery_methods-overlay, #opc_payment_methods-overlay').fadeOut('slow');
     }

--- a/themes/community-theme-16/js/products-comparison.js
+++ b/themes/community-theme-16/js/products-comparison.js
@@ -38,18 +38,7 @@ function addToCompare(productId) {
         $('.bt_compare').next('.compare_product_count').val(totalVal);
         totalValue(totalVal);
       } else {
-        if (!!$.prototype.fancybox) {
-          $.fancybox.open([{
-            type: 'inline',
-            autoScale: true,
-            minHeight: 30,
-            content: '<p class="fancybox-error">' + max_item + '</p>'
-          }], {
-            padding: 0
-          });
-        } else {
-          alert(max_item);
-        }
+        PrestaShop.showError(max_item);
       }
       totalCompareButtons();
     },

--- a/themes/community-theme-16/js/stores.js
+++ b/themes/community-theme-16/js/stores.js
@@ -69,19 +69,11 @@ function searchLocations() {
     if (status === google.maps.GeocoderStatus.OK)
       searchLocationsNear(results[0].geometry.location);
     else {
-      if (!!$.prototype.fancybox && isCleanHtml(address))
-        $.fancybox.open([
-          {
-            type: 'inline',
-            autoScale: true,
-            minHeight: 30,
-            content: '<p class="fancybox-error">' + address + ' ' + translation_6 + '</p>'
-          }
-        ], {
-          padding: 0
-        });
-      else
+      if (isCleanHtml(address)) {
+        PrestaShop.showError(address + ' ' + translation_6);
+      } else {
         alert(address + ' ' + translation_6);
+      }
     }
     $('#stores_loader').hide();
   });


### PR DESCRIPTION
`PrestaShop` module is defined in global.js and has these methods:
- `showSuccess(msg, title)`
- `showError(msg, title)`

You can now replace fancybox error popup with something like http://t4t5.github.io/sweetalert/ just by customizing these methods
