### PR TITLE
[+] POC: No more compass!

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
     "fs-extra": "^0.27.0",
     "glob-all": "^3.0.1",
     "gulp": "^3.9.0",
+    "gulp-sass": "^2.3.1",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-jscs": "^3.0.2",
     "gulp-zip": "^3.0.2",
+    "node-bourbon": "^4.2.8",
     "mkdirp": "^0.5.1",
     "run-sequence": "^1.1.5",
-    "yargs": "^4.2.0"
+    "yargs": "^4.2.0",
+    "gulp-notify": "^2.2.0"
   }
 }

--- a/themes/community-theme-16/sass/_theme_variables.scss
+++ b/themes/community-theme-16/sass/_theme_variables.scss
@@ -55,3 +55,7 @@ $input-border-focus: $brand-primary;
 // Font Awesome
 $font-icon     : 'FontAwesome';
 $fa-css-prefix : icon;
+
+// Custom mixins + bourbon
+@import "bourbon";
+@import "vendor_mixins";

--- a/themes/community-theme-16/sass/_vendor_mixins.scss
+++ b/themes/community-theme-16/sass/_vendor_mixins.scss
@@ -1,2 +1,6 @@
 @import "vendor/bootstrap/bootstrap/mixins";
 @import "vendor/font-awesome/font-awesome/mixins";
+
+@mixin border-radius($radius) {
+    border-radius: $radius;
+}

--- a/themes/community-theme-16/sass/addresses.scss
+++ b/themes/community-theme-16/sass/addresses.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/authentication.scss
+++ b/themes/community-theme-16/sass/authentication.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/category.scss
+++ b/themes/community-theme-16/sass/category.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/cms.scss
+++ b/themes/community-theme-16/sass/cms.scss
@@ -1,4 +1,4 @@
-// @import "compass";
+// 
 // @import "theme_variables";
 // @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/comparator.scss
+++ b/themes/community-theme-16/sass/comparator.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/contact-form.scss
+++ b/themes/community-theme-16/sass/contact-form.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/global.scss
+++ b/themes/community-theme-16/sass/global.scss
@@ -2,7 +2,7 @@
 // Make sure the charset is set appropriately
 
 // Resets and mixins
-@import "compass";
+
 
 // Vendor variable overrides
 @import "theme_variables";

--- a/themes/community-theme-16/sass/history.scss
+++ b/themes/community-theme-16/sass/history.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/maintenance.scss
+++ b/themes/community-theme-16/sass/maintenance.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blockcart/blockcart.scss
+++ b/themes/community-theme-16/sass/modules/blockcart/blockcart.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blockcategories/blockcategories.scss
+++ b/themes/community-theme-16/sass/modules/blockcategories/blockcategories.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "../../theme_variables";
 @import "../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blockcmsinfo/style.scss
+++ b/themes/community-theme-16/sass/modules/blockcmsinfo/style.scss
@@ -1,3 +1,3 @@
-@import "compass";
+
 @import "../../theme_variables";
 @import "../../vendor_variables";

--- a/themes/community-theme-16/sass/modules/blockcontact/blockcontact.scss
+++ b/themes/community-theme-16/sass/modules/blockcontact/blockcontact.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blockfacebook/blockfacebook.scss
+++ b/themes/community-theme-16/sass/modules/blockfacebook/blockfacebook.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blocklayered/blocklayered.scss
+++ b/themes/community-theme-16/sass/modules/blocklayered/blocklayered.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blocknewsletter/blocknewsletter.scss
+++ b/themes/community-theme-16/sass/modules/blocknewsletter/blocknewsletter.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blocksearch/blocksearch.scss
+++ b/themes/community-theme-16/sass/modules/blocksearch/blocksearch.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blocktopmenu/css/blocktopmenu.scss
+++ b/themes/community-theme-16/sass/modules/blocktopmenu/css/blocktopmenu.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../../theme_variables";
 @import "./../../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blocktopmenu/css/superfish-modified.scss
+++ b/themes/community-theme-16/sass/modules/blocktopmenu/css/superfish-modified.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../../theme_variables";
 @import "./../../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/blockwishlist/blockwishlist.scss
+++ b/themes/community-theme-16/sass/modules/blockwishlist/blockwishlist.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/crossselling/crossselling.scss
+++ b/themes/community-theme-16/sass/modules/crossselling/crossselling.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/favoriteproducts/favoriteproducts.scss
+++ b/themes/community-theme-16/sass/modules/favoriteproducts/favoriteproducts.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/homeslider/homeslider.scss
+++ b/themes/community-theme-16/sass/modules/homeslider/homeslider.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/productcomments/productcomments.scss
+++ b/themes/community-theme-16/sass/modules/productcomments/productcomments.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/productscategory/css/productscategory.scss
+++ b/themes/community-theme-16/sass/modules/productscategory/css/productscategory.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../../theme_variables";
 @import "./../../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/sendtoafriend/sendtoafriend.scss
+++ b/themes/community-theme-16/sass/modules/sendtoafriend/sendtoafriend.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/socialsharing/socialsharing.scss
+++ b/themes/community-theme-16/sass/modules/socialsharing/socialsharing.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/modules/themeconfigurator/hooks.scss
+++ b/themes/community-theme-16/sass/modules/themeconfigurator/hooks.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "./../../theme_variables";
 @import "./../../vendor_variables";
 

--- a/themes/community-theme-16/sass/my-account.scss
+++ b/themes/community-theme-16/sass/my-account.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/order-opc.scss
+++ b/themes/community-theme-16/sass/order-opc.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 @import "vendor_mixins";

--- a/themes/community-theme-16/sass/print.scss
+++ b/themes/community-theme-16/sass/print.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/product.scss
+++ b/themes/community-theme-16/sass/product.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/product_list.scss
+++ b/themes/community-theme-16/sass/product_list.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/rtl.scss
+++ b/themes/community-theme-16/sass/rtl.scss
@@ -1,4 +1,4 @@
-// @import "compass";
+// 
 // @import "theme_variables";
 // @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/sitemap.scss
+++ b/themes/community-theme-16/sass/sitemap.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 

--- a/themes/community-theme-16/sass/stores.scss
+++ b/themes/community-theme-16/sass/stores.scss
@@ -1,4 +1,4 @@
-@import "compass";
+
 @import "theme_variables";
 @import "vendor_variables";
 


### PR DESCRIPTION
I was really tired of slow compass so I decided to remove it entirely from the project and use Bourbon.io instead. Results? Before compilation it took something about 10-14s, now it's 2-3.5s :)

Oh, and I added notification after everything is compiled, now we don't have to use any external application, we have fast compilation and we have nice popup after task is done.

Few additional things:
- on my machine with Compass process takes  4.5s for global.scss with `--sourcemaps`, all files on Bourbon without compass takes 2.5s
- I'm waiting for a feedback from co-worker

How to test?
Setup community theme, add `--sourcemaps` flag to `compass` command in `gulp.js`, edit _theme_variables.scss (to compile entire project), run `gulp compile-css`, for me it's 34s on compass

After my fix it's 2.2s for **entire** project
