### PR TITLE
Install gulp-cli utility to run gulp in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ To verify that tools are installed and have the correct versions, type the follo
 node -v
 npm -v  // Should output 3.5.2 or higher
 ```
+If you can't access gulp command from your terminal try to install globally gulp-cli utility:
+
+``` bash
+sudo npm install gulp-cli -g
 
 Once these tools are available, navigate to your cloned repository and run `npm install` command:
 


### PR DESCRIPTION
Explain how to install gulp-cli utility if the gulp shell command is not available in your shell
