### PR TITLE
FO: Couldn't delete compared products on Firefox

### DIFF
--- a/themes/community-theme-16/js/products-comparison.js
+++ b/themes/community-theme-16/js/products-comparison.js
@@ -66,7 +66,11 @@ function reloadProductComparison() {
       cache: false,
     });
 
-    window.location.search = '?' + $.param(params);
+    if (params['compare_product_list'] > 0) {
+      window.location.search = '?' + $.param(params);
+    } else {
+      window.location.search = '';
+    }
   });
 }
 


### PR DESCRIPTION
I couldn't delete all products from comparison on Firefox, try:
1. Add two or more products
2. Delete one by one in Chrome, everything ok.
3. Delete one by one in Firefox, they'll "restore" after you will delete the last one
