### PR TITLE
Correct markup for telephone link

### DIFF
--- a/themes/community-theme-16/modules/blockcontactinfos/blockcontactinfos.tpl
+++ b/themes/community-theme-16/modules/blockcontactinfos/blockcontactinfos.tpl
@@ -15,7 +15,7 @@
       {if !empty($blockcontactinfos_phone)}
         <li>
           <i class="icon icon-phone"></i>
-          <a href="{$blockcontactinfos_phone|escape:'html':'UTF-8'}">{$blockcontactinfos_phone|escape:'html':'UTF-8'}</a>
+          <a href="tel:{$blockcontactinfos_phone|escape:'html':'UTF-8'}" class="phone-link" rel="nofollow">{$blockcontactinfos_phone|escape:'html':'UTF-8'}</a>
         </li>
       {/if}
       {if !empty($blockcontactinfos_email)}


### PR DESCRIPTION
There was a missing "tel:" in the telefone link. So googlebot tried to search for sites with telephone-no. as user-friendly url. Added a rel="nofollow", too.
