### PR TITLE
Added "nofollow" attribute to telephone link

### DIFF
--- a/themes/community-theme-16/modules/blockcontact/nav.tpl
+++ b/themes/community-theme-16/modules/blockcontact/nav.tpl
@@ -9,7 +9,7 @@
     <p class="navbar-text">
       <i class="icon icon-phone"></i>
       {l s='Call us now:' mod='blockcontact'}
-      <a class="phone-link" href="tel:{$telnumber|escape:'html':'UTF-8'}">{$telnumber|escape:'html':'UTF-8'}</a>
+      <a class="phone-link" rel="nofollow" href="tel:{$telnumber|escape:'html':'UTF-8'}">{$telnumber|escape:'html':'UTF-8'}</a>
     </p>
   </li>
 {/if}


### PR DESCRIPTION
I had lots of crawling errors in google webmaster-tools with urls containing the telephone-no. Not sure if it was caused by the missing "tel:" attribute in footer telephone link or from missing "nofollow". I think googlebot shouldn´t follow the telephonenumber.
