### PR TITLE
check msg_newsl is defined

### DIFF
--- a/themes/community-theme-16/js/modules/blocknewsletter/blocknewsletter.js
+++ b/themes/community-theme-16/js/modules/blocknewsletter/blocknewsletter.js
@@ -6,7 +6,7 @@ $(function() {
 
   $('#newsletter-input').on({
     focus: function() {
-      if ($(this).val() == placeholder_blocknewsletter || $(this).val() == msg_newsl) {
+      if ($(this).val() == placeholder_blocknewsletter || (typeof msg_newsl != 'undefined' && $(this).val() == msg_newsl)) {
         $(this).val('');
       }
     },


### PR DESCRIPTION
When mail is not valid and required attribute is present, it causes focus and trigger this event. When msg_newsl is not defined, it causes error in console for nothing.